### PR TITLE
Remove zustand from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The official JavaScript SDK for building real-time AI video applications with [R
 ## Installation
 
 ```bash
-npm install @reactor-team/js-sdk zustand
+npm install @reactor-team/js-sdk
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Remove `zustand` from the install command in README since it's a peer dependency that gets installed automatically

## Test plan
- [x] Verify install command syntax is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)