### PR TITLE
update create-reactor-app to support private repos

### DIFF
--- a/packages/create-app/.prettierrc
+++ b/packages/create-app/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "lf"
+}

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -34,18 +34,37 @@ You'll be asked to:
 You can also provide arguments directly:
 
 ```bash
-npx create-reactor-app [project-name] [template]
+npx create-reactor-app [project-name] [template] [options]
 ```
+
+**Options:**
+
+| Option          | Description                                |
+| --------------- | ------------------------------------------ |
+| `--token`, `-t` | GitHub token for private repository access |
+| `--help`, `-h`  | Show help message                          |
 
 **Examples:**
 
-````bash
+```bash
 # Create a project with longlive template
 npx create-reactor-app my-game longlive
 
 # Create a project with matrix template
 npx create-reactor-app my-matrix-app matrix-2
 
+# Create a project with a GitHub token (for private repos)
+npx create-reactor-app my-app longlive --token ghp_xxxxxxxxxxxx
+```
+
+### Private Repository Access
+
+If the repository is private, you'll be prompted to enter a GitHub token when:
+
+- Fetching available templates fails
+- Cloning the repository fails
+
+You can also pass the token directly via the `--token` (or `-t`) argument to skip the prompt.
 
 ### Available Templates
 
@@ -58,7 +77,7 @@ After creating your project:
 ```bash
 cd your-project-name
 pnpm dev
-````
+```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser to see your application running. Make sure to setup your API keys first!
 
@@ -76,6 +95,36 @@ For comprehensive guides, API references, and tutorials, visit the official Reac
 
 - Node.js 16 or later
 - pnpm (recommended) or npm
+
+## Local Development
+
+To test or develop the CLI locally:
+
+```bash
+# Navigate to the create-app package
+cd packages/create-app
+
+# Install dependencies
+pnpm install
+
+# Build the CLI
+pnpm build
+
+# Link it globally
+pnpm link --global
+```
+
+Now you can use `create-reactor-app` anywhere on your system:
+
+```bash
+create-reactor-app my-app
+```
+
+To unlink when you're done:
+
+```bash
+pnpm unlink --global
+```
 
 ## License
 

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -24,7 +24,7 @@ async function fetchTemplates(token?: string): Promise<string[] | null> {
 
     const res = await fetch(
       `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}`,
-      { headers }
+      { headers },
     );
 
     if (!res.ok) {
@@ -104,14 +104,26 @@ function parseArgs(args: string[]): {
 function showUsage(): void {
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
-  console.log(chalk.white("  create-reactor-app [project-name] [template] [options]\n"));
+  console.log(
+    chalk.white("  create-reactor-app [project-name] [template] [options]\n"),
+  );
   console.log(chalk.white("Arguments:"));
   console.log(chalk.white("  project-name  Name of the project to create"));
-  console.log(chalk.white("  template      Template to use (longlive, matrix-2, mk64, etc.)\n"));
+  console.log(
+    chalk.white(
+      "  template      Template to use (longlive, matrix-2, mk64, etc.)\n",
+    ),
+  );
   console.log(chalk.white("Options:"));
-  console.log(chalk.white("  --token, -t   GitHub token for private repository access"));
+  console.log(
+    chalk.white("  --token, -t   GitHub token for private repository access"),
+  );
   console.log(chalk.white("  --help, -h    Show this help message\n"));
-  console.log(chalk.white("If arguments are not provided, you will be prompted interactively.\n"));
+  console.log(
+    chalk.white(
+      "If arguments are not provided, you will be prompted interactively.\n",
+    ),
+  );
 }
 
 async function main(): Promise<void> {
@@ -165,7 +177,9 @@ async function main(): Promise<void> {
 
   if (!templates && !token) {
     console.log(
-      chalk.yellow("⚠️  Could not fetch templates from GitHub. Repository may be private.")
+      chalk.yellow(
+        "⚠️  Could not fetch templates from GitHub. Repository may be private.",
+      ),
     );
 
     // Temporarily restore stdin for the prompt
@@ -191,8 +205,8 @@ async function main(): Promise<void> {
   if (!templates) {
     console.error(
       chalk.red(
-        "\n❌ Failed to fetch templates from GitHub. Please check your token and try again."
-      )
+        "\n❌ Failed to fetch templates from GitHub. Please check your token and try again.",
+      ),
     );
     process.exit(1);
   }
@@ -212,7 +226,8 @@ async function main(): Promise<void> {
       type: "input",
       name: "projectName",
       message: "Enter your project name (ESC to cancel):",
-      validate: (input: string) => (input ? true : "Project name cannot be empty."),
+      validate: (input: string) =>
+        input ? true : "Project name cannot be empty.",
     });
   }
 
@@ -275,7 +290,9 @@ async function main(): Promise<void> {
 
   if (!cloneSuccess && !token) {
     console.log(
-      chalk.yellow("\n⚠️  Repository not accessible. It may be private or require authentication.")
+      chalk.yellow(
+        "\n⚠️  Repository not accessible. It may be private or require authentication.",
+      ),
     );
 
     // Temporarily restore stdin for the prompt
@@ -294,7 +311,9 @@ async function main(): Promise<void> {
 
   if (!cloneSuccess) {
     console.error(
-      chalk.red("\n❌ Failed to clone repository. Please check your token and try again.")
+      chalk.red(
+        "\n❌ Failed to clone repository. Please check your token and try again.",
+      ),
     );
     process.exit(1);
   }
@@ -329,17 +348,23 @@ async function main(): Promise<void> {
 
   console.log(
     chalk.green(
-      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`
-    )
+      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`,
+    ),
   );
   console.log(chalk.cyan("Next steps:"));
   console.log(chalk.white(`	cd ${projectName}`));
   console.log(chalk.white(`	cp .env.example .env`));
   console.log(chalk.white(`\nFor development scenarios:`));
   console.log(chalk.cyan(`	• Using an existing model:`));
-  console.log(chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`));
+  console.log(
+    chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`),
+  );
   console.log(chalk.cyan(`\n	• Local development with custom model:`));
-  console.log(chalk.white(`	  - Set local={true} in your ReactorProvider in app/page.tsx:`));
+  console.log(
+    chalk.white(
+      `	  - Set local={true} in your ReactorProvider in app/page.tsx:`,
+    ),
+  );
   console.log(chalk.gray(`	    <ReactorProvider modelName="..." local={true}>`));
   console.log(chalk.white(`\n	pnpm dev\n`));
 }

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -24,7 +24,7 @@ async function fetchTemplates(token?: string): Promise<string[] | null> {
 
     const res = await fetch(
       `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}`,
-      { headers },
+      { headers }
     );
 
     if (!res.ok) {
@@ -105,24 +105,24 @@ function showUsage(): void {
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
   console.log(
-    chalk.white("  create-reactor-app [project-name] [template] [options]\n"),
+    chalk.white("  create-reactor-app [project-name] [template] [options]\n")
   );
   console.log(chalk.white("Arguments:"));
   console.log(chalk.white("  project-name  Name of the project to create"));
   console.log(
     chalk.white(
-      "  template      Template to use (longlive, matrix-2, mk64, etc.)\n",
-    ),
+      "  template      Template to use (longlive, matrix-2, mk64, etc.)\n"
+    )
   );
   console.log(chalk.white("Options:"));
   console.log(
-    chalk.white("  --token, -t   GitHub token for private repository access"),
+    chalk.white("  --token, -t   GitHub token for private repository access")
   );
   console.log(chalk.white("  --help, -h    Show this help message\n"));
   console.log(
     chalk.white(
-      "If arguments are not provided, you will be prompted interactively.\n",
-    ),
+      "If arguments are not provided, you will be prompted interactively.\n"
+    )
   );
 }
 
@@ -178,8 +178,8 @@ async function main(): Promise<void> {
   if (!templates && !token) {
     console.log(
       chalk.yellow(
-        "⚠️  Could not fetch templates from GitHub. Repository may be private.",
-      ),
+        "⚠️  Could not fetch templates from GitHub. Repository may be private."
+      )
     );
 
     // Temporarily restore stdin for the prompt
@@ -205,8 +205,8 @@ async function main(): Promise<void> {
   if (!templates) {
     console.error(
       chalk.red(
-        "\n❌ Failed to fetch templates from GitHub. Please check your token and try again.",
-      ),
+        "\n❌ Failed to fetch templates from GitHub. Please check your token and try again."
+      )
     );
     process.exit(1);
   }
@@ -291,8 +291,8 @@ async function main(): Promise<void> {
   if (!cloneSuccess && !token) {
     console.log(
       chalk.yellow(
-        "\n⚠️  Repository not accessible. It may be private or require authentication.",
-      ),
+        "\n⚠️  Repository not accessible. It may be private or require authentication."
+      )
     );
 
     // Temporarily restore stdin for the prompt
@@ -312,8 +312,8 @@ async function main(): Promise<void> {
   if (!cloneSuccess) {
     console.error(
       chalk.red(
-        "\n❌ Failed to clone repository. Please check your token and try again.",
-      ),
+        "\n❌ Failed to clone repository. Please check your token and try again."
+      )
     );
     process.exit(1);
   }
@@ -348,8 +348,8 @@ async function main(): Promise<void> {
 
   console.log(
     chalk.green(
-      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`,
-    ),
+      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`
+    )
   );
   console.log(chalk.cyan("Next steps:"));
   console.log(chalk.white(`	cd ${projectName}`));
@@ -357,13 +357,11 @@ async function main(): Promise<void> {
   console.log(chalk.white(`\nFor development scenarios:`));
   console.log(chalk.cyan(`	• Using an existing model:`));
   console.log(
-    chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`),
+    chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`)
   );
   console.log(chalk.cyan(`\n	• Local development with custom model:`));
   console.log(
-    chalk.white(
-      `	  - Set local={true} in your ReactorProvider in app/page.tsx:`,
-    ),
+    chalk.white(`	  - Set local={true} in your ReactorProvider in app/page.tsx:`)
   );
   console.log(chalk.gray(`	    <ReactorProvider modelName="..." local={true}>`));
   console.log(chalk.white(`\n	pnpm dev\n`));

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -5,51 +5,128 @@ import simpleGit from "simple-git";
 import fs from "fs";
 import path from "path";
 import chalk from "chalk";
-import readline from "readline";
 
-const REPO = "https://github.com/reactor-team/js-sdk.git";
+const REPO_OWNER = "reactor-team";
+const REPO_NAME = "js-sdk";
+const REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}.git`;
 const EXAMPLES_PATH = "examples";
 
-async function getTemplates(): Promise<string[]> {
+function getAuthenticatedRepoUrl(token: string): string {
+  return `https://${token}@github.com/${REPO_OWNER}/${REPO_NAME}.git`;
+}
+
+async function fetchTemplates(token?: string): Promise<string[] | null> {
   try {
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
     const res = await fetch(
-      `https://api.github.com/repos/reactor-team/js-sdk/contents/${EXAMPLES_PATH}`,
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${EXAMPLES_PATH}`,
+      { headers }
     );
+
+    if (!res.ok) {
+      return null;
+    }
+
     const data = (await res.json()) as { name: string; type: string }[];
     return data.filter((item) => item.type === "dir").map((item) => item.name);
   } catch {
-    console.log(
-      chalk.yellow(
-        "⚠️  Could not fetch from GitHub, using fallback templates.",
-      ),
-    );
-    return ["longlive", "matrix-2"];
+    return null;
   }
+}
+
+async function promptForToken(): Promise<string | undefined> {
+  try {
+    const { ghToken } = await inquirer.prompt([
+      {
+        type: "password",
+        name: "ghToken",
+        message: "Enter your GitHub token (leave empty to cancel):",
+        mask: "*",
+      },
+    ]);
+    return ghToken || undefined;
+  } catch (error: unknown) {
+    const err = error as {
+      isTtyError?: boolean;
+      name?: string;
+      message?: string;
+    };
+    if (
+      err.isTtyError ||
+      err.name === "ExitPromptError" ||
+      err.message?.includes("User force closed the prompt") ||
+      err.message?.includes("Prompt was canceled")
+    ) {
+      console.log(chalk.yellow("\n\n❌ Installation cancelled by user."));
+      process.exit(0);
+    }
+    throw error;
+  }
+}
+
+function parseArgs(args: string[]): {
+  projectName?: string;
+  template?: string;
+  token?: string;
+  help: boolean;
+} {
+  const result: {
+    projectName?: string;
+    template?: string;
+    token?: string;
+    help: boolean;
+  } = { help: false };
+  const positionalArgs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      result.help = true;
+    } else if (arg === "--token" || arg === "-t") {
+      result.token = args[++i];
+    } else if (arg.startsWith("--token=")) {
+      result.token = arg.split("=")[1];
+    } else if (!arg.startsWith("-")) {
+      positionalArgs.push(arg);
+    }
+  }
+
+  result.projectName = positionalArgs[0];
+  result.template = positionalArgs[1];
+
+  return result;
 }
 
 function showUsage(): void {
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
-  console.log(chalk.white("  create-reactor-app [project-name] [template]\n"));
+  console.log(chalk.white("  create-reactor-app [project-name] [template] [options]\n"));
   console.log(chalk.white("Arguments:"));
   console.log(chalk.white("  project-name  Name of the project to create"));
-  console.log(
-    chalk.white(
-      "  template      Template to use (longlive, matrix-2, mk64, etc.)\n",
-    ),
-  );
-  console.log(
-    chalk.white(
-      "If arguments are not provided, you will be prompted interactively.\n",
-    ),
-  );
+  console.log(chalk.white("  template      Template to use (longlive, matrix-2, mk64, etc.)\n"));
+  console.log(chalk.white("Options:"));
+  console.log(chalk.white("  --token, -t   GitHub token for private repository access"));
+  console.log(chalk.white("  --help, -h    Show this help message\n"));
+  console.log(chalk.white("If arguments are not provided, you will be prompted interactively.\n"));
 }
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
+  // Parse command line arguments
+  const {
+    projectName: argProjectName,
+    template: argTemplate,
+    token: argToken,
+    help,
+  } = parseArgs(args);
+
   // Show help if requested
-  if (args.includes("--help") || args.includes("-h")) {
+  if (help) {
     showUsage();
     process.exit(0);
   }
@@ -81,10 +158,44 @@ async function main(): Promise<void> {
 
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
 
-  const templates = await getTemplates();
+  let token = argToken;
 
-  // Parse command line arguments
-  const [argProjectName, argTemplate] = args;
+  // Try to fetch templates, prompt for token if needed
+  let templates = await fetchTemplates(token);
+
+  if (!templates && !token) {
+    console.log(
+      chalk.yellow("⚠️  Could not fetch templates from GitHub. Repository may be private.")
+    );
+
+    // Temporarily restore stdin for the prompt
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
+
+    token = await promptForToken();
+
+    // Re-enable raw mode for ESC handling
+    if (process.stdin.isTTY && token) {
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+    }
+
+    if (token) {
+      console.log(chalk.green("\nRetrying with authentication...\n"));
+      templates = await fetchTemplates(token);
+    }
+  }
+
+  if (!templates) {
+    console.error(
+      chalk.red(
+        "\n❌ Failed to fetch templates from GitHub. Please check your token and try again."
+      )
+    );
+    process.exit(1);
+  }
 
   // Validate template argument if provided
   if (argTemplate && !templates.includes(argTemplate)) {
@@ -101,8 +212,7 @@ async function main(): Promise<void> {
       type: "input",
       name: "projectName",
       message: "Enter your project name (ESC to cancel):",
-      validate: (input: string) =>
-        input ? true : "Project name cannot be empty.",
+      validate: (input: string) => (input ? true : "Project name cannot be empty."),
     });
   }
 
@@ -145,6 +255,50 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  console.log(chalk.green(`\nCloning template "${template}"...\n`));
+
+  const git = simpleGit();
+
+  // Helper function to clone with optional token
+  async function tryClone(authToken?: string): Promise<boolean> {
+    const repoUrl = authToken ? getAuthenticatedRepoUrl(authToken) : REPO_URL;
+    try {
+      await git.clone(repoUrl, projectName, ["--depth", "1"]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Try to clone, prompt for token if it fails
+  let cloneSuccess = await tryClone(token);
+
+  if (!cloneSuccess && !token) {
+    console.log(
+      chalk.yellow("\n⚠️  Repository not accessible. It may be private or require authentication.")
+    );
+
+    // Temporarily restore stdin for the prompt
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
+
+    token = await promptForToken();
+
+    if (token) {
+      console.log(chalk.green("\nRetrying with authentication...\n"));
+      cloneSuccess = await tryClone(token);
+    }
+  }
+
+  if (!cloneSuccess) {
+    console.error(
+      chalk.red("\n❌ Failed to clone repository. Please check your token and try again.")
+    );
+    process.exit(1);
+  }
+
   // End interactive phase - now we're in installation phase
   isInteractivePhase = false;
 
@@ -153,11 +307,6 @@ async function main(): Promise<void> {
     process.stdin.setRawMode(false);
     process.stdin.pause();
   }
-
-  console.log(chalk.green(`\nCloning template "${template}"...\n`));
-
-  const git = simpleGit();
-  await git.clone(REPO, projectName, ["--depth", "1"]);
 
   const examplesDir = path.join(dest, EXAMPLES_PATH);
   const templateDir = path.join(examplesDir, template);
@@ -180,23 +329,17 @@ async function main(): Promise<void> {
 
   console.log(
     chalk.green(
-      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`,
-    ),
+      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`
+    )
   );
   console.log(chalk.cyan("Next steps:"));
   console.log(chalk.white(`	cd ${projectName}`));
   console.log(chalk.white(`	cp .env.example .env`));
   console.log(chalk.white(`\nFor development scenarios:`));
   console.log(chalk.cyan(`	• Using an existing model:`));
-  console.log(
-    chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`),
-  );
+  console.log(chalk.white(`	  - Edit .env and set your NEXT_PUBLIC_REACTOR_API_KEY`));
   console.log(chalk.cyan(`\n	• Local development with custom model:`));
-  console.log(
-    chalk.white(
-      `	  - Set local={true} in your ReactorProvider in app/page.tsx:`,
-    ),
-  );
+  console.log(chalk.white(`	  - Set local={true} in your ReactorProvider in app/page.tsx:`));
   console.log(chalk.gray(`	    <ReactorProvider modelName="..." local={true}>`));
   console.log(chalk.white(`\n	pnpm dev\n`));
 }

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-reactor-app",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "bin": {
     "create-reactor-app": "dist/bin/create-reactor-app.js"
   },


### PR DESCRIPTION
Why
---
The js-sdk repo may be private, requiring authentication to fetch templates and clone.

What Changed
---
- Add `--token` / `-t` CLI argument for GitHub token
- Prompt for token when fetching templates or cloning fails
- Remove fallback templates; exit on failure instead
- Update README with token docs and local dev instructions

topic: update-create-reactor-app-to-support-private-repos
reviewers: snow, bryce