### PR TITLE
LocalCoordinatorClient: Don't terminate session upon ConflictError

### DIFF
--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -3,6 +3,7 @@
  * It extends CoordinatorClient and overrides methods for local development.
  */
 
+import { ConflictError } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
@@ -60,6 +61,9 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     });
 
     if (!response.ok) {
+      if (response.status === 409) {
+        throw new ConflictError("Connection superseded by newer request");
+      }
       throw new Error("Failed to get SDP answer from local coordinator.");
     }
 

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -1,8 +1,9 @@
-import type {
-  ReactorEvent,
-  ReactorStatus,
-  ReactorState,
-  ReactorError,
+import {
+  type ReactorEvent,
+  type ReactorStatus,
+  type ReactorState,
+  type ReactorError,
+  ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
 import { LocalCoordinatorClient } from "./LocalCoordinatorClient";
@@ -143,6 +144,11 @@ export class Reactor {
       return;
     }
 
+    if (this.status === "ready") {
+      console.warn("[Reactor] Already connected, no need to reconnect.");
+      return;
+    }
+
     this.setStatus("connecting");
 
     if (!this.machineClient) {
@@ -164,9 +170,13 @@ export class Reactor {
       await this.machineClient.connect(sdpAnswer);
       this.setStatus("ready");
     } catch (error) {
+      let recoverable = false;
+      if (error instanceof ConflictError) {
+        recoverable = true;
+      }
       console.error("[Reactor] Failed to reconnect:", error);
       // disconnect without recovery, as the session "connect" call on the coordinator failed
-      this.disconnect(false);
+      this.disconnect(recoverable);
       this.createError(
         "RECONNECTION_FAILED",
         `Failed to reconnect: ${error}`,

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -14,6 +14,12 @@ export interface ReactorError {
   retryAfter?: number; // Suggested retry delay in seconds
 }
 
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 // Enhanced state with metadata
 export interface ReactorState {
   status: ReactorStatus;


### PR DESCRIPTION
On the local setup, when we return 409 it's because the webrtc connection was superseded by a newer request.
This happens for example if you spam the re-connect button.

On the core we were not handling this case, treating it as _any_ error, which causes the stop session call to happen.
But in this case the session is still present (just superseded by another request) so it is re-connectable.

topic: handle-conflict-error-local-coord
reviewers: bryce