### PR TITLE
Add ICE Servers endpoint support for local flow

### DIFF
--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -43,6 +43,12 @@ export class CoordinatorClient {
     };
   }
 
+  async getIceServers(): Promise<RTCIceServer[]> {
+    // Default to Google's public STUN server
+    // TODO(REA-341) Define how the flow is in here for getting the ice servers from the coordinator.
+    return [{ urls: "stun:stun.l.google.com:19302" }];
+  }
+
   /**
    * Creates a new session with the coordinator.
    * Expects a 200 response and stores the session ID.

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -28,8 +28,8 @@ export class GPUMachineClient {
   private videoTransceiver: RTCRtpTransceiver | undefined;
   private config: webrtc.WebRTCConfig;
 
-  constructor(config?: webrtc.WebRTCConfig) {
-    this.config = config ?? {};
+  constructor(config: webrtc.WebRTCConfig) {
+    this.config = config;
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -4,6 +4,7 @@
  */
 
 import { CoordinatorClient } from "./CoordinatorClient";
+import { IceServersResponse } from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
   private localBaseUrl: string;
@@ -17,6 +18,28 @@ export class LocalCoordinatorClient extends CoordinatorClient {
       model: "local",
     });
     this.localBaseUrl = baseUrl;
+  }
+
+  /**
+   * Gets ICE servers from the local HTTP runtime.
+   * @returns The ICE server configuration
+   */
+  async getIceServers(): Promise<RTCIceServer[]> {
+    console.debug("[LocalCoordinatorClient] Fetching ICE servers...");
+    const response = await fetch(`${this.localBaseUrl}/ice_servers`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to get ICE servers from local coordinator.");
+    }
+
+    const data: IceServersResponse = await response.json();
+    console.debug(
+      "[LocalCoordinatorClient] Received ICE servers:",
+      data.ice_servers
+    );
+    return data.ice_servers;
   }
 
   /**

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -146,7 +146,10 @@ export class Reactor {
     this.setStatus("connecting");
 
     if (!this.machineClient) {
-      this.machineClient = new GPUMachineClient();
+      // Get ICE servers from coordinator
+      const iceServers = await this.coordinatorClient.getIceServers();
+
+      this.machineClient = new GPUMachineClient({ iceServers });
       this.setupMachineClientHandlers();
     }
 
@@ -207,8 +210,11 @@ export class Reactor {
             model: this.model,
           });
 
+      // Get ICE servers from coordinator
+      const iceServers = await this.coordinatorClient.getIceServers();
+
       // Create GPUMachineClient and generate SDP offer
-      this.machineClient = new GPUMachineClient();
+      this.machineClient = new GPUMachineClient({ iceServers });
       this.setupMachineClientHandlers();
 
       const sdpOffer = await this.machineClient.createOffer();

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -51,6 +51,17 @@ export const SDPParamsResponseSchema = z.object({
   extra_args: z.record(z.string(), z.any()), // Dictionary
 });
 
+// Response from GET /ice_servers endpoint (local HTTP runtime)
+export const IceServersResponseSchema = z.object({
+  ice_servers: z.array(
+    z.object({
+      urls: z.union([z.string(), z.array(z.string())]),
+      username: z.string().optional(),
+      credential: z.string().optional(),
+    })
+  ),
+});
+
 // Internal connection status for individual components
 export type InternalConnectionStatus =
   | "disconnected"
@@ -67,3 +78,5 @@ export type SDPParamsRequest = z.infer<typeof SDPParamsRequestSchema>;
 
 export type SessionInfoResponse = z.infer<typeof SessionInfoResponseSchema>;
 export type SessionStatusResponse = z.infer<typeof SessionStatusResponseSchema>;
+
+export type IceServersResponse = z.infer<typeof IceServersResponseSchema>;

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -8,16 +8,14 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface WebRTCConfig {
-  iceServers?: RTCIceServer[];
+  iceServers: RTCIceServer[];
   dataChannelLabel?: string;
 }
 
-const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
-  { urls: "stun:stun.l.google.com:19302" },
-  { urls: "stun:stun1.l.google.com:19302" },
-];
-
 const DEFAULT_DATA_CHANNEL_LABEL = "data";
+
+// Force relay mode for testing TURN servers - set to true to force all traffic through TURN
+const FORCE_RELAY_MODE = false;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Peer Connection Creation
@@ -25,10 +23,12 @@ const DEFAULT_DATA_CHANNEL_LABEL = "data";
 
 /**
  * Creates a new RTCPeerConnection with the specified configuration.
+ * @param config WebRTC configuration with required iceServers
  */
-export function createPeerConnection(config?: WebRTCConfig): RTCPeerConnection {
+export function createPeerConnection(config: WebRTCConfig): RTCPeerConnection {
   return new RTCPeerConnection({
-    iceServers: config?.iceServers ?? DEFAULT_ICE_SERVERS,
+    iceServers: config.iceServers,
+    iceTransportPolicy: FORCE_RELAY_MODE ? "relay" : "all",
   });
 }
 


### PR DESCRIPTION
Why
---
ICE Servers are needed to match the ones used on the local runtime. Now the CoordinatorClient has a method to fetch these.
In the local flow this is used by fetching the correspondent enpoint on the HTTP server.

What Changed
---
- Add method to get ICE servers from the coordinator.
- in Production mode it just returns the default Google STUN server. (temporarily)
- in Local mode it fetches the ones from the HTTP server.
- Add type for the ICE servers response.
- Add optional force relay mode to the WebRTC config for testing.

topic: add-ice-servers-endpoint-support-local
reviewers: bryce, massenz, amonta