### PR TITLE
Disable autoConnect for examples

### DIFF
--- a/examples/dynamic/app/page.tsx
+++ b/examples/dynamic/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           modelName={modelName}
           local={isLocal}
           jwtToken={jwtToken}
-          autoConnect
+          autoConnect={false}
         >
           <div className="flex flex-col gap-3">
             <ReactorView className="w-full aspect-video bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl border border-gray-700/50 shadow-xl overflow-hidden" />

--- a/examples/longlive/app/page.tsx
+++ b/examples/longlive/app/page.tsx
@@ -16,7 +16,11 @@ export default function Home() {
         <Header />
         <ApiKeyInput onJwtTokenChange={setJwtToken} />
 
-        <ReactorProvider modelName="longlive" jwtToken={jwtToken} autoConnect>
+        <ReactorProvider
+          modelName="longlive"
+          jwtToken={jwtToken}
+          autoConnect={false}
+        >
           <div className="flex flex-col gap-3">
             <ReactorView className="w-full aspect-video bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl border border-gray-700/50 shadow-xl overflow-hidden" />
             <ReactorStatus />

--- a/examples/matrix-2/app/page.tsx
+++ b/examples/matrix-2/app/page.tsx
@@ -17,7 +17,11 @@ export default function Home() {
         <Header />
         <ApiKeyInput onJwtTokenChange={setJwtToken} />
 
-        <ReactorProvider modelName="matrix-2" jwtToken={jwtToken} autoConnect>
+        <ReactorProvider
+          modelName="matrix-2"
+          jwtToken={jwtToken}
+          autoConnect={false}
+        >
           <div className="flex flex-col gap-3">
             <ReactorView className="w-full aspect-video bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl border border-gray-700/50 shadow-xl overflow-hidden" />
             <ReactorStatus />


### PR DESCRIPTION
Why
---
These examples require inputting manually an API key. We don't autoconnect upon load because this mean we would always get invalid connection.

What Changed
---
- Disable autoConnect for examples.

topic: disable-auto-connect-for-examples