### PR TITLE
[REA-391] Frontend SDK update Start Session flow to use Ice Servers

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -6,10 +6,12 @@
 import {
   CreateSessionRequest,
   CreateSessionResponse,
+  IceServersResponseSchema,
   SDPParamsRequest,
   SDPParamsResponse,
   SessionInfoResponse,
 } from "./types";
+import { transformIceServers } from "../utils/webrtc";
 
 export interface CoordinatorClientOptions {
   baseUrl: string;
@@ -43,10 +45,33 @@ export class CoordinatorClient {
     };
   }
 
+  /**
+   * Fetches ICE servers from the coordinator.
+   * @returns Array of RTCIceServer objects for WebRTC peer connection configuration
+   */
   async getIceServers(): Promise<RTCIceServer[]> {
-    // Default to Google's public STUN server
-    // TODO(REA-341) Define how the flow is in here for getting the ice servers from the coordinator.
-    return [{ urls: "stun:stun.l.google.com:19302" }];
+    console.debug("[CoordinatorClient] Fetching ICE servers...");
+
+    const response = await fetch(`${this.baseUrl}/ice_servers?model=${this.model}`, {
+      method: "GET",
+      headers: this.getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch ICE servers: ${response.status}`
+      );
+    }
+
+    const data = await response.json();
+    const parsed = IceServersResponseSchema.parse(data);
+    const iceServers = transformIceServers(parsed);
+
+    console.debug(
+      "[CoordinatorClient] Received ICE servers:",
+      iceServers.length
+    );
+    return iceServers;
   }
 
   /**

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -52,15 +52,16 @@ export class CoordinatorClient {
   async getIceServers(): Promise<RTCIceServer[]> {
     console.debug("[CoordinatorClient] Fetching ICE servers...");
 
-    const response = await fetch(`${this.baseUrl}/ice_servers?model=${this.model}`, {
-      method: "GET",
-      headers: this.getAuthHeaders(),
-    });
+    const response = await fetch(
+      `${this.baseUrl}/ice_servers?model=${this.model}`,
+      {
+        method: "GET",
+        headers: this.getAuthHeaders(),
+      }
+    );
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to fetch ICE servers: ${response.status}`
-      );
+      throw new Error(`Failed to fetch ICE servers: ${response.status}`);
     }
 
     const data = await response.json();

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -4,8 +4,9 @@
  */
 
 import { ConflictError } from "../types";
+import { transformIceServers } from "../utils/webrtc";
 import { CoordinatorClient } from "./CoordinatorClient";
-import { IceServersResponse } from "./types";
+import { IceServersResponseSchema } from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
   private localBaseUrl: string;
@@ -35,12 +36,15 @@ export class LocalCoordinatorClient extends CoordinatorClient {
       throw new Error("Failed to get ICE servers from local coordinator.");
     }
 
-    const data: IceServersResponse = await response.json();
+    const data = await response.json();
+    const parsed = IceServersResponseSchema.parse(data);
+    const iceServers = transformIceServers(parsed);
+
     console.debug(
       "[LocalCoordinatorClient] Received ICE servers:",
-      data.ice_servers
+      iceServers.length
     );
-    return data.ice_servers;
+    return iceServers;
   }
 
   /**

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -51,13 +51,17 @@ export const SDPParamsResponseSchema = z.object({
   extra_args: z.record(z.string(), z.any()), // Dictionary
 });
 
-// Response from GET /ice_servers endpoint (local HTTP runtime)
+// Response from GET /ice_servers endpoint (coordinator)
 export const IceServersResponseSchema = z.object({
   ice_servers: z.array(
     z.object({
-      urls: z.union([z.string(), z.array(z.string())]),
-      username: z.string().optional(),
-      credential: z.string().optional(),
+      uris: z.array(z.string()),
+      credentials: z
+        .object({
+          username: z.string(),
+          password: z.string(),
+        })
+        .optional(),
     })
   ),
 });

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -3,6 +3,8 @@
  * Uses @roamhq/wrtc for stable Node.js WebRTC support.
  */
 
+import { IceServersResponse } from "../core/types";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
 // ─────────────────────────────────────────────────────────────────────────────
@@ -113,6 +115,24 @@ export function getLocalDescription(pc: RTCPeerConnection): string | undefined {
 // ─────────────────────────────────────────────────────────────────────────────
 // ICE Handling
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Transforms ICE servers from the coordinator API format to RTCIceServer format.
+ * @param response The parsed IceServersResponse from the coordinator
+ * @returns Array of RTCIceServer objects for WebRTC peer connection configuration
+ */
+export function transformIceServers(response: IceServersResponse): RTCIceServer[] {
+  return response.ice_servers.map((server) => {
+    const rtcServer: RTCIceServer = {
+      urls: server.uris,
+    };
+    if (server.credentials) {
+      rtcServer.username = server.credentials.username;
+      rtcServer.credential = server.credentials.password;
+    }
+    return rtcServer;
+  });
+}
 
 /**
  * Adds an ICE candidate to the peer connection.

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -121,7 +121,9 @@ export function getLocalDescription(pc: RTCPeerConnection): string | undefined {
  * @param response The parsed IceServersResponse from the coordinator
  * @returns Array of RTCIceServer objects for WebRTC peer connection configuration
  */
-export function transformIceServers(response: IceServersResponse): RTCIceServer[] {
+export function transformIceServers(
+  response: IceServersResponse
+): RTCIceServer[] {
   return response.ice_servers.map((server) => {
     const rtcServer: RTCIceServer = {
       urls: server.uris,


### PR DESCRIPTION
Why
---
We now have the endpoint on the deployed coordinator to get the ICE servers for a given model.
We should use those ICE config servers for doing the gathering.

What Changed
---

- On the production flow (With CoordinatorClient) we properly use the endpoint to fetch the ICE config.
- Update the LocalCoordinator to expect the same pattern as the production flow, for consistency.
- Unify the function that converts the API return schema into proper ICEConfig format types that the WebRTC lib uses.
- Update version

Dependencies
---
REA-393 update the Local Coordinator to use the same pattern as the production flow.

topic: REA-391-update-start-session-flow-to-use-ice-servers
reviewers: bryce, snow, massenz