### PR TITLE
Update endpoint schemas to match Coordinator

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -84,7 +84,7 @@ export class CoordinatorClient {
     console.debug("[CoordinatorClient] Creating session...");
 
     const requestBody: CreateSessionRequest = {
-      model: this.model,
+      model: { name: this.model },
       sdp_offer: sdp_offer,
       extra_args: {},
     };

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -5,17 +5,22 @@
 import { z } from "zod";
 
 export enum SessionState {
-  SESSION_STATE_UNKNOWN = 0,
-  SESSION_STATE_WAITING = 1,
-  SESSION_STATE_ACTIVE = 2,
-  SESSION_STATE_DISCONNECTED = 3,
-  SESSION_STATE_CLOSED = 4,
-  UNRECOGNIZED = -1,
+  CREATED,
+  PENDING,
+  SUSPENDED,
+  WAITING,
+  ACTIVE,
+  INACTIVE,
+  CLOSED,
 }
+
+export const ModelSchema = z.object({
+  name: z.string(),
+});
 
 // Schema used for the HTTP POST request to start a session from the CLIENT to the COORDINATOR.
 export const CreateSessionRequestSchema = z.object({
-  model: z.string(),
+  model: ModelSchema,
   sdp_offer: z.string(),
   extra_args: z.record(z.string(), z.any()), // Dictionary
 });


### PR DESCRIPTION
Why
---
The schema for the request structure of POST /sessions (for starting a session) has been updated in the Coordinator API.
We need to update it on the JS SDK so that it matches the new schema aswell.

Also on we are starting to use real enum values for the session state, right now they were only placeholders.

What Changed
---
- Update endpoint schemas to match Coordinator
- Use real enum values for the session state

The GET /sessions/{session_id} endpoint is also updated automatically, because it was extending the CreateSessionRequestSchema.

topic: update-endpoint-schemas-for-sess-creation
reviewers: snow, bryce, massenz