### PR TITLE
[REA-531] Longlive frontend: match new model protocol

### DIFF
--- a/examples/longlive/app/page.tsx
+++ b/examples/longlive/app/page.tsx
@@ -9,16 +9,21 @@ import { LongLiveController } from "@/components/LongLiveController";
 
 export default function Home() {
   const [jwtToken, setJwtToken] = useState<string | undefined>(undefined);
+  const [isLocalMode, setIsLocalMode] = useState(false);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 p-4 sm:p-6">
       <div className="w-full max-w-3xl mx-auto flex flex-col gap-4">
         <Header />
-        <ApiKeyInput onJwtTokenChange={setJwtToken} />
+        <ApiKeyInput 
+          onJwtTokenChange={setJwtToken} 
+          onLocalModeChange={setIsLocalMode}
+        />
 
         <ReactorProvider
           modelName="longlive"
           jwtToken={jwtToken}
+          local={isLocalMode}
           autoConnect={false}
         >
           <div className="flex flex-col gap-3">

--- a/examples/longlive/components/ApiKeyInput.tsx
+++ b/examples/longlive/components/ApiKeyInput.tsx
@@ -10,14 +10,29 @@ import {
 
 interface ApiKeyInputProps {
   onJwtTokenChange: (token: string | undefined) => void;
+  onLocalModeChange: (isLocal: boolean) => void;
 }
 
-export function ApiKeyInput({ onJwtTokenChange }: ApiKeyInputProps) {
+export function ApiKeyInput({ onJwtTokenChange, onLocalModeChange }: ApiKeyInputProps) {
   const [apiKey, setApiKey] = useState("");
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isLocalMode, setIsLocalMode] = useState(false);
 
   useEffect(() => {
+    // Check if user entered "local" to enable local mode
+    if (apiKey.toLowerCase() === "local") {
+      setIsLocalMode(true);
+      onLocalModeChange(true);
+      onJwtTokenChange(undefined);
+      setError(null);
+      return;
+    }
+
+    // Not local mode
+    setIsLocalMode(false);
+    onLocalModeChange(false);
+
     if (!apiKey) {
       onJwtTokenChange(undefined);
       setError(null);
@@ -39,7 +54,7 @@ export function ApiKeyInput({ onJwtTokenChange }: ApiKeyInputProps) {
     }, 500);
 
     return () => clearTimeout(timeoutId);
-  }, [apiKey, onJwtTokenChange]);
+  }, [apiKey, onJwtTokenChange, onLocalModeChange]);
 
   return (
     <div className="flex flex-wrap items-center gap-4 p-3 bg-gray-800/40 rounded-lg border border-gray-700/50">
@@ -55,7 +70,9 @@ export function ApiKeyInput({ onJwtTokenChange }: ApiKeyInputProps) {
                 className={`bg-gray-900/60 border rounded-md px-3 py-1.5 w-64 placeholder-gray-500 focus:outline-none focus:ring-1 text-white ${
                   error
                     ? "border-red-500 focus:border-red-500 focus:ring-red-500/50"
-                    : "border-orange-500/50 focus:border-orange-500 focus:ring-orange-500/50"
+                    : isLocalMode
+                      ? "border-green-500/50 focus:border-green-500 focus:ring-green-500/50"
+                      : "border-orange-500/50 focus:border-orange-500 focus:ring-orange-500/50"
                 }`}
                 placeholder="rk_..."
               />
@@ -68,9 +85,15 @@ export function ApiKeyInput({ onJwtTokenChange }: ApiKeyInputProps) {
           </label>
         </TooltipTrigger>
         <TooltipContent>
-          <p>⚠️ DANGEROUS: Never deploy with your API key in client code!</p>
+          <p>⚠️ Enter API key or type &quot;local&quot; for local mode</p>
         </TooltipContent>
       </Tooltip>
+      {isLocalMode && (
+        <span className="text-xs text-green-400 flex items-center gap-1">
+          <span className="w-1.5 h-1.5 bg-green-500 rounded-full"></span>
+          Local Mode
+        </span>
+      )}
       {error && <span className="text-xs text-red-400">{error}</span>}
     </div>
   );

--- a/examples/longlive/components/LongLiveController.tsx
+++ b/examples/longlive/components/LongLiveController.tsx
@@ -9,25 +9,55 @@ interface LongLiveControllerProps {
   className?: string;
 }
 
+// Types for the LongLive model message protocol
+interface ModelState {
+  current_frame: number;
+  current_prompt: string | null;
+  paused: boolean;
+  scheduled_prompts: Record<number, string>;
+}
+
+interface StateMessage {
+  type: "state";
+  data: ModelState;
+}
+
+interface EventMessage {
+  type: "event";
+  data: {
+    event: string;
+    frame?: number;
+    message?: string;
+    new_prompt?: string;
+    previous_prompt?: string;
+  };
+}
+
+type LongLiveMessage = StateMessage | EventMessage;
+
 /**
  * LongLiveController
  *
  * A simple prompt input component for the LongLive model that:
- * - Tracks the current frame position from progress messages
+ * - Tracks the current frame position from state messages
  * - Automatically calculates timestamps for prompts (0 for first, currentFrame + 3 for subsequent)
  * - Sends "schedule_prompt" messages to queue prompts at specific frames
  * - Sends a "start" message on the first prompt to begin video generation
- * - Displays the current frame number to help users understand where they are in the generation
+ * - Displays the current frame number and paused state to help users understand the generation status
  */
 export function LongLiveController({ className }: LongLiveControllerProps) {
   const [prompt, setPrompt] = useState("");
   // Track the current frame position in the video generation
-  const [currentStartFrame, setCurrentStartFrame] = useState(0);
+  const [currentFrame, setCurrentFrame] = useState(0);
   // Track the selected story and current step
   const [selectedStoryId, setSelectedStoryId] = useState<string | null>(null);
   const [currentStep, setCurrentStep] = useState(0);
-  // Track the current active prompt
-  const [currentPrompt, setCurrentPrompt] = useState<string>("");
+  // Track the current active prompt (from model state)
+  const [currentPrompt, setCurrentPrompt] = useState<string | null>(null);
+  // Track paused state
+  const [isPaused, setIsPaused] = useState(true);
+  // Track scheduled prompts
+  const [scheduledPrompts, setScheduledPrompts] = useState<Record<number, string>>({});
   // Voice recording state
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -40,24 +70,36 @@ export function LongLiveController({ className }: LongLiveControllerProps) {
     status: state.status,
   }));
 
-  // Listen for progress messages from the LongLive model
-  // These messages contain the current_start_frame which tells us where we are in the generation
-  useReactorMessage((message: any) => {
-    if (
-      message?.type === "progress" &&
-      message?.data?.current_start_frame !== undefined
-    ) {
-      setCurrentStartFrame(message.data.current_start_frame);
+  // Listen for messages from the LongLive model
+  useReactorMessage((message: LongLiveMessage) => {
+    if (message?.type === "state") {
+      // Handle state messages - update all state from the model
+      const state = message.data;
+      setCurrentFrame(state.current_frame);
+      setCurrentPrompt(state.current_prompt);
+      setIsPaused(state.paused);
+      setScheduledPrompts(state.scheduled_prompts);
+    } else if (message?.type === "event") {
+      // Handle event messages
+      const event = message.data;
+      console.log("LongLive event:", event.event, event);
+      
+      if (event.event === "error") {
+        // Show error to user
+        console.error("LongLive error:", event.message);
+      }
     }
   });
 
   // Reset all UI state to initial values
   const resetUIState = () => {
     setPrompt("");
-    setCurrentStartFrame(0);
+    setCurrentFrame(0);
     setSelectedStoryId(null);
     setCurrentStep(0);
-    setCurrentPrompt("");
+    setCurrentPrompt(null);
+    setIsPaused(true);
+    setScheduledPrompts({});
   };
 
   // Reset the frame counter and story progress when we disconnect from the model
@@ -70,13 +112,10 @@ export function LongLiveController({ className }: LongLiveControllerProps) {
   const handleSubmitPrompt = async (promptText: string) => {
     if (!promptText.trim()) return;
 
-    // Update the current prompt display
-    setCurrentPrompt(promptText.trim());
-
     // Calculate the timestamp for this prompt:
     // - First prompt (frame 0): use timestamp 0 to start from the beginning
     // - Subsequent prompts: use current frame + 3 to avoid conflicts with the current generation
-    const timestamp = currentStartFrame === 0 ? 0 : currentStartFrame + 3;
+    const timestamp = currentFrame === 0 ? 0 : currentFrame + 3;
 
     // Send the prompt with the calculated timestamp
     await sendCommand("schedule_prompt", {
@@ -85,7 +124,7 @@ export function LongLiveController({ className }: LongLiveControllerProps) {
     });
 
     // On the first prompt, also send a "start" message to begin the generation process
-    if (currentStartFrame === 0) {
+    if (currentFrame === 0) {
       await sendCommand("start", {});
     }
   };
@@ -207,20 +246,73 @@ export function LongLiveController({ className }: LongLiveControllerProps) {
     }
   };
 
+  // Toggle pause/resume
+  const handlePauseResume = async () => {
+    try {
+      if (isPaused) {
+        await sendCommand("resume", {});
+        console.log("Resume message sent");
+      } else {
+        await sendCommand("pause", {});
+        console.log("Pause message sent");
+      }
+    } catch (error) {
+      console.error("Failed to send pause/resume:", error);
+    }
+  };
+
   return (
     <div
       className={`bg-gray-900/40 rounded-lg p-3 border border-gray-700/30 space-y-3 ${className}`}
     >
-      {/* Header with Reset Button */}
+      {/* Header with Pause and Reset Buttons */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-gray-400">Prompts</span>
-        <button
-          onClick={handleReset}
-          disabled={status === "disconnected"}
-          className="px-3 py-1.5 rounded-md bg-red-500/20 text-red-400 border border-red-500/40 hover:bg-red-500/30 active:scale-95 transition-all duration-200 text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          Reset
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handlePauseResume}
+            disabled={status === "disconnected" || currentFrame === 0}
+            className={`px-3 py-1.5 rounded-md border active:scale-95 transition-all duration-200 text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed ${
+              isPaused
+                ? "bg-green-500/20 text-green-400 border-green-500/40 hover:bg-green-500/30"
+                : "bg-yellow-500/20 text-yellow-400 border-yellow-500/40 hover:bg-yellow-500/30"
+            }`}
+          >
+            {isPaused ? "Resume" : "Pause"}
+          </button>
+          <button
+            onClick={handleReset}
+            disabled={status === "disconnected"}
+            className="px-3 py-1.5 rounded-md bg-red-500/20 text-red-400 border border-red-500/40 hover:bg-red-500/30 active:scale-95 transition-all duration-200 text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Status Bar */}
+      <div className="flex items-center gap-2">
+        {/* Paused/Running indicator */}
+        <div className={`flex items-center gap-1.5 px-2 py-1 rounded-md border ${
+          isPaused 
+            ? "bg-yellow-500/10 border-yellow-500/30 text-yellow-400" 
+            : "bg-green-500/10 border-green-500/30 text-green-400"
+        }`}>
+          <div className={`w-1.5 h-1.5 rounded-full ${
+            isPaused ? "bg-yellow-500" : "bg-green-500 animate-pulse"
+          }`} />
+          <span className="text-xs font-medium">
+            {isPaused ? "Paused" : "Running"}
+          </span>
+        </div>
+        
+        {/* Frame counter */}
+        <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-800/50 rounded-md border border-gray-700/30">
+          <span className="text-xs text-gray-500">Frame:</span>
+          <span className="text-xs font-semibold text-gray-300 tabular-nums">
+            {currentFrame}
+          </span>
+        </div>
       </div>
 
       {/* Current Prompt Display */}
@@ -249,12 +341,6 @@ export function LongLiveController({ className }: LongLiveControllerProps) {
           <span className="text-xs font-medium text-gray-400">
             Or write your own
           </span>
-          <div className="flex items-center gap-1.5 px-2 py-0.5 bg-gray-800/50 rounded-md">
-            <span className="text-xs text-gray-500">Frame:</span>
-            <span className="text-xs font-semibold text-gray-300 tabular-nums">
-              {currentStartFrame}
-            </span>
-          </div>
         </div>
         <form onSubmit={handleManualSubmit} className="flex gap-2">
           <input


### PR DESCRIPTION
Why
---
The model's message protocol changed from simple `progress` messages to a richer `state` and
`event` system. The frontend needed to be updated to consume these new messages and expose
the additional information to users.

What Changed
---
**LongLiveController.tsx:**
- Updated message handling from `type: "progress"` to `type: "state"`
- Now tracks full model state: `current_frame`, `current_prompt`, `paused`, `scheduled_prompts`
- Added TypeScript interfaces for the new message protocol
- Added status bar showing Paused/Running indicator with visual feedback
- Added Pause/Resume button that toggles based on current state
- Event messages are logged to console for debugging
- Current prompt now comes from model state instead of local tracking

**ApiKeyInput.tsx:**
- Added local mode detection: typing "local" as API key enables local mode
- Visual feedback when local mode is active (green border + indicator)
- Passes `onLocalModeChange` callback to parent

**page.tsx:**
- Added `isLocalMode` state management
- Passes `local={isLocalMode}` prop to ReactorProvider for local development

topic: REA-531-longlive-frontend-match-new-model-protocol
relative: REA529-unwrap-application-messages
reviewers: snow, bryce, ahmed