### PR TITLE
[REA-630] Add two-level envelope to data channel messaging (JS-SDK)

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -4,6 +4,7 @@
  */
 
 import * as webrtc from "../utils/webrtc";
+import type { MessageChannel } from "../types";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -11,7 +12,7 @@ export type GPUMachineEvent =
   | "statusChanged"
   | "trackReceived"
   | "trackRemoved"
-  | "application";
+  | "message";
 
 export type GPUMachineStatus =
   | "disconnected"
@@ -164,14 +165,19 @@ export class GPUMachineClient {
    * Sends a command to the GPU machine via the data channel.
    * @param command The command to send
    * @param data The data to send with the command. These are the parameters for the command, matching the scheme in the capabilities dictionary.
+   * @param channel The message channel envelope – "application" (default) for model commands, "runtime" for platform-level messages.
    */
-  sendCommand(command: string, data: any): void {
+  sendCommand(
+    command: string,
+    data: any,
+    channel: MessageChannel = "application"
+  ): void {
     if (!this.dataChannel) {
       throw new Error("[GPUMachineClient] Data channel not available");
     }
 
     try {
-      webrtc.sendMessage(this.dataChannel, command, data);
+      webrtc.sendMessage(this.dataChannel, command, data, channel);
     } catch (error) {
       console.warn("[GPUMachineClient] Failed to send message:", error);
     }
@@ -339,11 +345,28 @@ export class GPUMachineClient {
     };
 
     this.dataChannel.onmessage = (event) => {
-      const data = webrtc.parseMessage(event.data);
-      console.debug("[GPUMachineClient] Received message:", data);
+      const rawData = webrtc.parseMessage(event.data) as any;
+      console.debug("[GPUMachineClient] Received message:", rawData);
 
       try {
-        this.emit("application", data);
+        // Parse the outer envelope { type: "application"|"runtime", data: ... }
+        if (
+          rawData?.type === "application" &&
+          rawData?.data !== undefined
+        ) {
+          this.emit("message", rawData.data, "application" as MessageChannel);
+        } else if (
+          rawData?.type === "runtime" &&
+          rawData?.data !== undefined
+        ) {
+          this.emit("message", rawData.data, "runtime" as MessageChannel);
+        } else {
+          // Legacy / unknown format – treat as application
+          console.warn(
+            "[GPUMachineClient] Received message without envelope, treating as application"
+          );
+          this.emit("message", rawData, "application" as MessageChannel);
+        }
       } catch (error) {
         console.error(
           "[GPUMachineClient] Failed to parse/validate message:",

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -350,10 +350,7 @@ export class GPUMachineClient {
 
       try {
         // Parse the outer envelope { scope: "application"|"runtime", data: ... }
-        if (
-          rawData?.scope === "application" &&
-          rawData?.data !== undefined
-        ) {
+        if (rawData?.scope === "application" && rawData?.data !== undefined) {
           this.emit("message", rawData.data, "application" as MessageScope);
         } else if (
           rawData?.scope === "runtime" &&

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -4,7 +4,7 @@
  */
 
 import * as webrtc from "../utils/webrtc";
-import type { MessageChannel } from "../types";
+import type { MessageScope } from "../types";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -165,19 +165,19 @@ export class GPUMachineClient {
    * Sends a command to the GPU machine via the data channel.
    * @param command The command to send
    * @param data The data to send with the command. These are the parameters for the command, matching the scheme in the capabilities dictionary.
-   * @param channel The message channel envelope – "application" (default) for model commands, "runtime" for platform-level messages.
+   * @param scope The message scope – "application" (default) for model commands, "runtime" for platform-level messages.
    */
   sendCommand(
     command: string,
     data: any,
-    channel: MessageChannel = "application"
+    scope: MessageScope = "application"
   ): void {
     if (!this.dataChannel) {
       throw new Error("[GPUMachineClient] Data channel not available");
     }
 
     try {
-      webrtc.sendMessage(this.dataChannel, command, data, channel);
+      webrtc.sendMessage(this.dataChannel, command, data, scope);
     } catch (error) {
       console.warn("[GPUMachineClient] Failed to send message:", error);
     }
@@ -349,23 +349,23 @@ export class GPUMachineClient {
       console.debug("[GPUMachineClient] Received message:", rawData);
 
       try {
-        // Parse the outer envelope { type: "application"|"runtime", data: ... }
+        // Parse the outer envelope { scope: "application"|"runtime", data: ... }
         if (
-          rawData?.type === "application" &&
+          rawData?.scope === "application" &&
           rawData?.data !== undefined
         ) {
-          this.emit("message", rawData.data, "application" as MessageChannel);
+          this.emit("message", rawData.data, "application" as MessageScope);
         } else if (
-          rawData?.type === "runtime" &&
+          rawData?.scope === "runtime" &&
           rawData?.data !== undefined
         ) {
-          this.emit("message", rawData.data, "runtime" as MessageChannel);
+          this.emit("message", rawData.data, "runtime" as MessageScope);
         } else {
           // Legacy / unknown format – treat as application
           console.warn(
             "[GPUMachineClient] Received message without envelope, treating as application"
           );
-          this.emit("message", rawData, "application" as MessageChannel);
+          this.emit("message", rawData, "application" as MessageScope);
         }
       } catch (error) {
         console.error(

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -3,7 +3,7 @@ import {
   type ReactorStatus,
   type ReactorState,
   type ReactorError,
-  type MessageChannel,
+  type MessageScope,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -70,14 +70,14 @@ export class Reactor {
    * Wraps the message in the specified channel envelope (defaults to "application").
    * @param command The command name to send.
    * @param data The command payload.
-   * @param channel The envelope channel – "application" (default) for model commands,
-   *                "runtime" for platform-level messages (e.g. requestCapabilities).
+   * @param scope The envelope scope – "application" (default) for model commands,
+   *              "runtime" for platform-level messages (e.g. requestCapabilities).
    * @throws Error if not in ready state
    */
   async sendCommand(
     command: string,
     data: any,
-    channel: MessageChannel = "application"
+    scope: MessageScope = "application"
   ): Promise<void> {
     // Synchronous validation - throw immediately
     if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
@@ -87,7 +87,7 @@ export class Reactor {
     }
 
     try {
-      this.machineClient?.sendCommand(command, data, channel);
+      this.machineClient?.sendCommand(command, data, scope);
     } catch (error) {
       // Async operational error - emit event only
       console.error("[Reactor] Failed to send message:", error);
@@ -268,10 +268,10 @@ export class Reactor {
 
     this.machineClient.on(
       "message",
-      (message: any, channel: MessageChannel) => {
+      (message: any, scope: MessageScope) => {
         // The outer envelope has already been stripped by GPUMachineClient.
-        // Forward the inner payload along with its channel to consumers.
-        this.emit("newMessage", message, channel);
+        // Forward the inner payload along with its scope to consumers.
+        this.emit("newMessage", message, scope);
       }
     );
 

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -3,6 +3,7 @@ import {
   type ReactorStatus,
   type ReactorState,
   type ReactorError,
+  type MessageChannel,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -66,11 +67,18 @@ export class Reactor {
 
   /**
    * Public method to send a message to the machine.
-   * Automatically wraps the message in an application message.
-   * @param message The message to send to the machine.
+   * Wraps the message in the specified channel envelope (defaults to "application").
+   * @param command The command name to send.
+   * @param data The command payload.
+   * @param channel The envelope channel – "application" (default) for model commands,
+   *                "runtime" for platform-level messages (e.g. requestCapabilities).
    * @throws Error if not in ready state
    */
-  async sendCommand(command: string, data: any): Promise<void> {
+  async sendCommand(
+    command: string,
+    data: any,
+    channel: MessageChannel = "application"
+  ): Promise<void> {
     // Synchronous validation - throw immediately
     if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
       const errorMessage = `Cannot send message, status is ${this.status}`;
@@ -79,7 +87,7 @@ export class Reactor {
     }
 
     try {
-      this.machineClient?.sendCommand(command, data);
+      this.machineClient?.sendCommand(command, data, channel);
     } catch (error) {
       // Async operational error - emit event only
       console.error("[Reactor] Failed to send message:", error);
@@ -258,18 +266,14 @@ export class Reactor {
   private setupMachineClientHandlers(): void {
     if (!this.machineClient) return;
 
-    this.machineClient.on("application", (message: any) => {
-      // Unwrap "application" envelope if present - the runtime wraps
-      // outgoing app messages in {type: "application", data: ...}
-      if (message?.type === "application" && message?.data !== undefined) {
-        this.emit("newMessage", message.data);
-      } else {
-        // Emit full message when no envelope wrapper is present.
-        // This is crucial for compatibility with capabilities responses
-        // which are sent as raw { commands: {...} } without envelope.
-        this.emit("newMessage", message);
+    this.machineClient.on(
+      "message",
+      (message: any, channel: MessageChannel) => {
+        // The outer envelope has already been stripped by GPUMachineClient.
+        // Forward the inner payload along with its channel to consumers.
+        this.emit("newMessage", message, channel);
       }
-    });
+    );
 
     this.machineClient.on("statusChanged", (status: GPUMachineStatus) => {
       switch (status) {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -266,14 +266,11 @@ export class Reactor {
   private setupMachineClientHandlers(): void {
     if (!this.machineClient) return;
 
-    this.machineClient.on(
-      "message",
-      (message: any, scope: MessageScope) => {
-        // The outer envelope has already been stripped by GPUMachineClient.
-        // Forward the inner payload along with its scope to consumers.
-        this.emit("newMessage", message, scope);
-      }
-    );
+    this.machineClient.on("message", (message: any, scope: MessageScope) => {
+      // The outer envelope has already been stripped by GPUMachineClient.
+      // Forward the inner payload along with its scope to consumers.
+      this.emit("newMessage", message, scope);
+    });
 
     this.machineClient.on("statusChanged", (status: GPUMachineStatus) => {
       switch (status) {

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -1,5 +1,5 @@
 import { StoreApi } from "zustand";
-import type { ReactorStatus, ReactorError } from "../types";
+import type { ReactorStatus, ReactorError, MessageChannel } from "../types";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
 import { create } from "zustand/react";
 import { createContext } from "react";
@@ -17,7 +17,11 @@ export interface ReactorState {
 }
 
 export interface ReactorActions {
-  sendCommand(command: string, data: any): Promise<void>;
+  sendCommand(
+    command: string,
+    data: any,
+    channel?: MessageChannel
+  ): Promise<void>;
   connect(jwtToken?: string): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
   publishVideoStream(stream: MediaStream): Promise<void>;
@@ -142,10 +146,18 @@ export const createReactorStore = (
           get().internal.reactor.off("newMessage", handler);
         };
       },
-      sendCommand: async (command: string, data: any) => {
-        console.debug("[ReactorStore] Sending command", { command, data });
+      sendCommand: async (
+        command: string,
+        data: any,
+        channel?: MessageChannel
+      ) => {
+        console.debug("[ReactorStore] Sending command", {
+          command,
+          data,
+          channel,
+        });
         try {
-          await get().internal.reactor.sendCommand(command, data);
+          await get().internal.reactor.sendCommand(command, data, channel);
           console.debug("[ReactorStore] Command sent successfully");
         } catch (error) {
           console.error("[ReactorStore] Failed to send command:", error);

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -17,11 +17,7 @@ export interface ReactorState {
 }
 
 export interface ReactorActions {
-  sendCommand(
-    command: string,
-    data: any,
-    scope?: MessageScope
-  ): Promise<void>;
+  sendCommand(command: string, data: any, scope?: MessageScope): Promise<void>;
   connect(jwtToken?: string): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
   publishVideoStream(stream: MediaStream): Promise<void>;
@@ -146,11 +142,7 @@ export const createReactorStore = (
           get().internal.reactor.off("newMessage", handler);
         };
       },
-      sendCommand: async (
-        command: string,
-        data: any,
-        scope?: MessageScope
-      ) => {
+      sendCommand: async (command: string, data: any, scope?: MessageScope) => {
         console.debug("[ReactorStore] Sending command", {
           command,
           data,

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -1,5 +1,5 @@
 import { StoreApi } from "zustand";
-import type { ReactorStatus, ReactorError, MessageChannel } from "../types";
+import type { ReactorStatus, ReactorError, MessageScope } from "../types";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
 import { create } from "zustand/react";
 import { createContext } from "react";
@@ -20,7 +20,7 @@ export interface ReactorActions {
   sendCommand(
     command: string,
     data: any,
-    channel?: MessageChannel
+    scope?: MessageScope
   ): Promise<void>;
   connect(jwtToken?: string): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
@@ -149,15 +149,15 @@ export const createReactorStore = (
       sendCommand: async (
         command: string,
         data: any,
-        channel?: MessageChannel
+        scope?: MessageScope
       ) => {
         console.debug("[ReactorStore] Sending command", {
           command,
           data,
-          channel,
+          scope,
         });
         try {
-          await get().internal.reactor.sendCommand(command, data, channel);
+          await get().internal.reactor.sendCommand(command, data, scope);
           console.debug("[ReactorStore] Command sent successfully");
         } catch (error) {
           console.error("[ReactorStore] Failed to send command:", error);

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useReactor, useReactorMessage } from "./hooks";
+import type { MessageChannel } from "../types";
 import React, { useState, useCallback } from "react";
 
 export interface ReactorControllerProps {
@@ -52,10 +53,10 @@ export function ReactorController({
     }
   }, [status]);
 
-  // Function to request capabilities
+  // Function to request capabilities (sent on the "runtime" channel)
   const requestCapabilities = useCallback(() => {
     if (status === "ready") {
-      sendCommand("requestCapabilities", {});
+      sendCommand("requestCapabilities", {}, "runtime");
     }
   }, [status, sendCommand]);
 
@@ -80,10 +81,18 @@ export function ReactorController({
     return () => clearInterval(interval);
   }, [status, commands, requestCapabilities]);
 
-  useReactorMessage((message) => {
-    // Check if message contains commands schema
-    if (message && typeof message === "object" && "commands" in message) {
-      const commandsMessage = message as CommandsMessage;
+  useReactorMessage((message, channel) => {
+    // Capabilities arrive on the "runtime" channel as
+    // { type: "modelCapabilities", data: { commands: {...} } }
+    if (
+      channel === "runtime" &&
+      message &&
+      typeof message === "object" &&
+      message.type === "modelCapabilities" &&
+      message.data &&
+      "commands" in message.data
+    ) {
+      const commandsMessage = message.data as CommandsMessage;
       setCommands(commandsMessage.commands);
 
       // Initialize form values for each command

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReactor, useReactorMessage } from "./hooks";
-import type { MessageChannel } from "../types";
+import type { MessageScope } from "../types";
 import React, { useState, useCallback } from "react";
 
 export interface ReactorControllerProps {
@@ -81,11 +81,11 @@ export function ReactorController({
     return () => clearInterval(interval);
   }, [status, commands, requestCapabilities]);
 
-  useReactorMessage((message, channel) => {
-    // Capabilities arrive on the "runtime" channel as
+  useReactorMessage((message, scope) => {
+    // Capabilities arrive on the "runtime" scope as
     // { type: "modelCapabilities", data: { commands: {...} } }
     if (
-      channel === "runtime" &&
+      scope === "runtime" &&
       message &&
       typeof message === "object" &&
       message.type === "modelCapabilities" &&

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -1,6 +1,6 @@
 import { useReactorStore } from "./ReactorProvider";
 import type { ReactorStore } from "../core/store";
-import type { MessageChannel } from "../types";
+import type { MessageScope } from "../types";
 import { useShallow } from "zustand/shallow";
 import { useEffect, useRef } from "react";
 
@@ -17,14 +17,14 @@ export function useReactor<T>(selector: (state: ReactorStore) => T): T {
 /**
  * Hook for handling message subscriptions with proper React lifecycle management.
  *
- * The handler receives the message payload and the channel it arrived on:
+ * The handler receives the message payload and the scope it arrived on:
  *   - "application" for model-defined messages (via get_ctx().send())
  *   - "runtime" for platform-level messages (e.g., capabilities response)
  *
- * @param handler - The message handler function (message, channel)
+ * @param handler - The message handler function (message, scope)
  */
 export function useReactorMessage(
-  handler: (message: any, channel: MessageChannel) => void
+  handler: (message: any, scope: MessageScope) => void
 ): void {
   const reactor = useReactor((state) => state.internal.reactor);
   const handlerRef = useRef(handler);
@@ -38,12 +38,12 @@ export function useReactorMessage(
     console.debug("[useReactorMessage] Setting up message subscription");
 
     // Create a stable handler that calls the current ref
-    const stableHandler = (message: any, channel: MessageChannel) => {
+    const stableHandler = (message: any, scope: MessageScope) => {
       console.debug("[useReactorMessage] Message received", {
         message,
-        channel,
+        scope,
       });
-      handlerRef.current(message, channel);
+      handlerRef.current(message, scope);
     };
 
     // Register the handler and get the cleanup function

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -1,5 +1,6 @@
 import { useReactorStore } from "./ReactorProvider";
 import type { ReactorStore } from "../core/store";
+import type { MessageChannel } from "../types";
 import { useShallow } from "zustand/shallow";
 import { useEffect, useRef } from "react";
 
@@ -16,9 +17,15 @@ export function useReactor<T>(selector: (state: ReactorStore) => T): T {
 /**
  * Hook for handling message subscriptions with proper React lifecycle management.
  *
- * @param handler - The message handler function
+ * The handler receives the message payload and the channel it arrived on:
+ *   - "application" for model-defined messages (via get_ctx().send())
+ *   - "runtime" for platform-level messages (e.g., capabilities response)
+ *
+ * @param handler - The message handler function (message, channel)
  */
-export function useReactorMessage(handler: (message: any) => void): void {
+export function useReactorMessage(
+  handler: (message: any, channel: MessageChannel) => void
+): void {
   const reactor = useReactor((state) => state.internal.reactor);
   const handlerRef = useRef(handler);
 
@@ -31,9 +38,12 @@ export function useReactorMessage(handler: (message: any) => void): void {
     console.debug("[useReactorMessage] Setting up message subscription");
 
     // Create a stable handler that calls the current ref
-    const stableHandler = (message: any) => {
-      console.debug("[useReactorMessage] Message received", { message });
-      handlerRef.current(message);
+    const stableHandler = (message: any, channel: MessageChannel) => {
+      console.debug("[useReactorMessage] Message received", {
+        message,
+        channel,
+      });
+      handlerRef.current(message, channel);
     };
 
     // Register the handler and get the cleanup function

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -4,6 +4,13 @@ export type ReactorStatus =
   | "waiting" // Connected to coordinator, waiting for GPU assignment
   | "ready"; // Connected to GPU machine, can send/receive messages
 
+/**
+ * The message channel identifies the envelope layer a data channel message belongs to.
+ * - "application": model-defined commands (client->runtime) and model-emitted payloads (runtime->client).
+ * - "runtime": platform-level control messages (e.g., capabilities exchange).
+ */
+export type MessageChannel = "application" | "runtime";
+
 // Error information
 export interface ReactorError {
   code: string;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -5,11 +5,11 @@ export type ReactorStatus =
   | "ready"; // Connected to GPU machine, can send/receive messages
 
 /**
- * The message channel identifies the envelope layer a data channel message belongs to.
+ * The message scope identifies the envelope layer a data channel message belongs to.
  * - "application": model-defined commands (client->runtime) and model-emitted payloads (runtime->client).
  * - "runtime": platform-level control messages (e.g., capabilities exchange).
  */
-export type MessageChannel = "application" | "runtime";
+export type MessageScope = "application" | "runtime";
 
 // Error information
 export interface ReactorError {

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -4,6 +4,7 @@
  */
 
 import { IceServersResponse } from "../core/types";
+import type { MessageChannel } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -226,18 +227,28 @@ export function removeAllTracks(pc: RTCPeerConnection): void {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Sends a message through a data channel.
+ * Sends a message through a data channel wrapped in the two-level envelope.
+ *
+ * Wire format:
+ *   { type: "application"|"runtime", data: { type: <command>, data: <payload> } }
+ *
+ * @param channel     The RTCDataChannel to send on.
+ * @param command     Inner command/message type (e.g. "set_prompt", "requestCapabilities").
+ * @param data        Payload for the command.
+ * @param messageChannel  Outer envelope channel – defaults to "application".
  */
 export function sendMessage(
   channel: RTCDataChannel,
   command: string,
-  data: any
+  data: any,
+  messageChannel: MessageChannel = "application"
 ): void {
   if (channel.readyState !== "open") {
     throw new Error(`Data channel not open: ${channel.readyState}`);
   }
   const jsonData = typeof data === "string" ? JSON.parse(data) : data;
-  const payload = { type: command, data: jsonData };
+  const inner = { type: command, data: jsonData };
+  const payload = { type: messageChannel, data: inner };
   channel.send(JSON.stringify(payload));
 }
 

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -4,7 +4,7 @@
  */
 
 import { IceServersResponse } from "../core/types";
-import type { MessageChannel } from "../types";
+import type { MessageScope } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -230,25 +230,25 @@ export function removeAllTracks(pc: RTCPeerConnection): void {
  * Sends a message through a data channel wrapped in the two-level envelope.
  *
  * Wire format:
- *   { type: "application"|"runtime", data: { type: <command>, data: <payload> } }
+ *   { scope: "application"|"runtime", data: { type: <command>, data: <payload> } }
  *
  * @param channel     The RTCDataChannel to send on.
  * @param command     Inner command/message type (e.g. "set_prompt", "requestCapabilities").
  * @param data        Payload for the command.
- * @param messageChannel  Outer envelope channel – defaults to "application".
+ * @param scope       Outer envelope scope – defaults to "application".
  */
 export function sendMessage(
   channel: RTCDataChannel,
   command: string,
   data: any,
-  messageChannel: MessageChannel = "application"
+  scope: MessageScope = "application"
 ): void {
   if (channel.readyState !== "open") {
     throw new Error(`Data channel not open: ${channel.readyState}`);
   }
   const jsonData = typeof data === "string" ? JSON.parse(data) : data;
   const inner = { type: command, data: jsonData };
-  const payload = { type: messageChannel, data: inner };
+  const payload = { scope, data: inner };
   channel.send(JSON.stringify(payload));
 }
 


### PR DESCRIPTION
Why
---

Companion to the runtime-side PR (same ticket). The runtime now wraps every
data channel message in a two-level envelope that splits traffic into two
channels: `"application"` (model-defined) and `"runtime"` (platform-level).

The SDK needs to match: outbound messages must be wrapped in the envelope, and
inbound messages must be unwrapped so consumers can tell which channel a
message arrived on (e.g. a model state update vs. a capabilities response).

Breaking Changes
---

**`useReactorMessage` handler signature** — the callback now receives a second
argument `channel: MessageChannel`:

```typescript
// Before
useReactorMessage((message) => { ... });

// After
useReactorMessage((message, channel) => { ... });
```

Existing code that ignores the second argument will continue to compile and
run, but TypeScript strict callers that destructure the handler type may need
updating.

**`sendCommand` accepts an optional third argument** — `channel?: MessageChannel`
(defaults to `"application"`). Fully backward compatible; no existing call
sites need to change.

**`GPUMachineClient` event name changed** — the internal event emitted on
incoming data channel messages changed from `"application"` to `"message"`.
This only affects code that listens directly on `GPUMachineClient` (not the
public `Reactor` API). The `GPUMachineEvent` union type is updated
accordingly.

**Wire format** — this PR changes what gets sent on the wire. It **must** be
deployed together with (or after) the runtime-side PR. If the SDK is updated
but the runtime is not, the runtime will log warnings and fall back to legacy
parsing. If the runtime is updated but the SDK is not, the old SDK's messages
will be handled via the runtime's legacy fallback path. Both directions
degrade gracefully but capabilities exchange will not work correctly until both
sides are updated.

What Changed
---

**`types.ts`** — Added `MessageChannel = "application" | "runtime"` type,
exported from the package.

**`webrtc.ts`** — `sendMessage()` now accepts a `messageChannel` parameter
(defaults to `"application"`). It builds the two-level envelope:
`{ type: channel, data: { type: command, data: payload } }`.

**`GPUMachineClient.ts`** —
- Event type changed from `"application"` to `"message"`.
- `sendCommand()` accepts an optional `channel` parameter, forwarded to
  `webrtc.sendMessage()`.
- `onmessage` handler now parses the outer envelope (`type` field) and emits
  `("message", innerPayload, channel)`. Unknown/legacy messages without an
  envelope are treated as `"application"` for backward compatibility.

**`Reactor.ts`** —
- `sendCommand()` accepts an optional `channel: MessageChannel` parameter.
- `setupMachineClientHandlers()` listens on the new `"message"` event and
  forwards `(message, channel)` through the `"newMessage"` emitter. The
  previous envelope-unwrapping logic (checking for `type === "application"`)
  is removed — `GPUMachineClient` now handles that.

**`store.ts`** — `sendCommand` action signature updated to accept optional
`channel` parameter, passed through to `Reactor.sendCommand()`.

**`hooks.ts`** — `useReactorMessage` handler signature updated to
`(message: any, channel: MessageChannel) => void`.

**`ReactorController.tsx`** —
- Sends `requestCapabilities` on the `"runtime"` channel instead of
  `"application"`.
- Listens for capabilities responses by checking
  `channel === "runtime" && message.type === "modelCapabilities"` and reads
  commands from `message.data.commands`.

Doc: https://www.notion.so/reactor-technologies/DATA-CHANNEL-MESSAGING-302cacd6a39680318be9ee2fe0f417aa

topic: REA-63--js-sdk-improve-messaging-layer-pattern
reviewers: bryce