### PR TITLE
[REA-472] Send periodic ping on the runtime channel for fast disconnect detection

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -20,6 +20,12 @@ export type GPUMachineStatus =
   | "connected"
   | "error";
 
+/**
+ * Interval (ms) at which the client sends runtime-channel "ping" messages
+ * to the server so the runtime can detect stale connections quickly.
+ */
+const PING_INTERVAL_MS = 5_000;
+
 export class GPUMachineClient {
   private eventListeners: Map<GPUMachineEvent, Set<EventHandler>> = new Map();
   private peerConnection: RTCPeerConnection | undefined;
@@ -28,6 +34,7 @@ export class GPUMachineClient {
   private publishedTrack: MediaStreamTrack | undefined;
   private videoTransceiver: RTCRtpTransceiver | undefined;
   private config: webrtc.WebRTCConfig;
+  private pingInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor(config: webrtc.WebRTCConfig) {
     this.config = config;
@@ -118,6 +125,8 @@ export class GPUMachineClient {
    * Disconnects from the GPU machine and cleans up resources.
    */
   async disconnect(): Promise<void> {
+    this.stopPing();
+
     if (this.publishedTrack) {
       await this.unpublishTrack();
     }
@@ -272,6 +281,37 @@ export class GPUMachineClient {
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // Ping (Client Liveness)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Starts sending periodic "ping" messages on the runtime channel so the
+   * server can detect stale connections quickly.
+   */
+  private startPing(): void {
+    this.stopPing();
+    this.pingInterval = setInterval(() => {
+      if (this.dataChannel?.readyState === "open") {
+        try {
+          webrtc.sendMessage(this.dataChannel, "ping", {}, "runtime");
+        } catch {
+          // Silently ignore – data channel may be closing
+        }
+      }
+    }, PING_INTERVAL_MS);
+  }
+
+  /**
+   * Stops the periodic ping.
+   */
+  private stopPing(): void {
+    if (this.pingInterval !== undefined) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = undefined;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Private Helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
@@ -334,10 +374,12 @@ export class GPUMachineClient {
 
     this.dataChannel.onopen = () => {
       console.debug("[GPUMachineClient] Data channel open");
+      this.startPing();
     };
 
     this.dataChannel.onclose = () => {
       console.debug("[GPUMachineClient] Data channel closed");
+      this.stopPing();
     };
 
     this.dataChannel.onerror = (error) => {


### PR DESCRIPTION
Why
---

Companion to the runtime-side PR (same ticket). The runtime now runs a ping
watchdog on its WebRTC client: if no `ping` message arrives within 10 s it
fires `CLIENT_DISCONNECTED` and transitions to ORPHANED, freeing GPU resources
much faster than relying on WebRTC connection state changes alone.

This PR adds the client side — the SDK automatically sends the ping while the
data channel is open. No action is required from consumers.

What Changed
---

**`GPUMachineClient.ts`** — single-file change:
- Added a `PING_INTERVAL_MS` constant (5 000 ms) at module scope.
- Added a `pingInterval` private member for the timer handle.
- Added `startPing()` — called from `dataChannel.onopen`. Starts a
  `setInterval` that sends `{ type: "runtime", data: { type: "ping", data: {} } }`
  every 5 s via the existing `webrtc.sendMessage` helper.
- Added `stopPing()` — clears the interval. Called from `dataChannel.onclose`
  and `disconnect()`.

No new public API, no breaking changes, no consumer-facing behaviour change
beyond faster disconnect detection on the runtime side.

topic: REA-472-add-ping-to-js-sdk
relative: REA-63--js-sdk-improve-messaging-layer-pattern
reviewers: bryce