### PR TITLE
Always offer to receive audio/video

### DIFF
--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -53,10 +53,38 @@ export function createDataChannel(
  * Waits for ICE gathering to complete before returning.
  */
 export async function createOffer(pc: RTCPeerConnection): Promise<string> {
-  const offer = await pc.createOffer({
-    offerToReceiveVideo: true,
-    offerToReceiveAudio: true,
-  });
+  let hasAudio = false;
+  let hasVideo = false;
+
+  for (const t of pc.getTransceivers()) {
+    if (t.receiver?.track?.kind === "audio") {
+      hasAudio = true;
+    }
+    if (t.receiver?.track?.kind === "video") {
+      hasVideo = true;
+    }
+
+    // Fallback: check mid / direction if track not yet set
+    if (t.direction) {
+      if (t.sender?.track?.kind === "audio") hasAudio = true;
+      if (t.sender?.track?.kind === "video") hasVideo = true;
+    }
+  }
+
+  if (!hasAudio) {
+    pc.addTransceiver("audio", {
+      direction: "recvonly",
+    });
+  }
+
+  if (!hasVideo) {
+    pc.addTransceiver("video", {
+      direction: "recvonly",
+    });
+  }
+
+  const offer = await pc.createOffer();
+
   await pc.setLocalDescription(offer);
 
   await waitForIceGathering(pc);

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -53,7 +53,10 @@ export function createDataChannel(
  * Waits for ICE gathering to complete before returning.
  */
 export async function createOffer(pc: RTCPeerConnection): Promise<string> {
-  const offer = await pc.createOffer();
+  const offer = await pc.createOffer({
+    offerToReceiveVideo: true,
+    offerToReceiveAudio: true,
+  });
   await pc.setLocalDescription(offer);
 
   await waitForIceGathering(pc);

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -57,17 +57,11 @@ export async function createOffer(pc: RTCPeerConnection): Promise<string> {
   let hasVideo = false;
 
   for (const t of pc.getTransceivers()) {
-    if (t.receiver?.track?.kind === "audio") {
+    if (t.receiver?.track?.kind === "audio" || t.sender?.track?.kind === "audio") {
       hasAudio = true;
     }
-    if (t.receiver?.track?.kind === "video") {
+    if (t.receiver?.track?.kind === "video" || t.sender?.track?.kind === "video") {
       hasVideo = true;
-    }
-
-    // Fallback: check mid / direction if track not yet set
-    if (t.direction) {
-      if (t.sender?.track?.kind === "audio") hasAudio = true;
-      if (t.sender?.track?.kind === "video") hasVideo = true;
     }
   }
 


### PR DESCRIPTION
### The Problem

The SDP Offer from client should describe ALL codecs and options that client supports. When SDP Offer doesn't have any video info, it means that it doesn't support video at all.

WebRTC in browser adds video/audio in SDP offer based on two conditions:

1 - Is there any attached video? If yes, offer video in SDP
2 - If there is no video, check the `offerToReceiveAudio` and `offerToReceiveVideo` in `pc.createOffer()` options.

This PR solves an inconsistency in our SDP offer for models that doesn't receive any video as input.


BUT wait, why current implementation works? Because we are essentially adding an H264 stream ignoring completely what client is saying in the SDP offer... And this is wrong. We are lucky that most part of browsers supports H264 by default :) 