### PR TITLE
[REA-716] Session should be cancelled by the client if it SDP params are not accepted after X seconds

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -23,6 +23,7 @@ export interface CoordinatorClientOptions {
 const INITIAL_BACKOFF_MS = 500;
 const MAX_BACKOFF_MS = 15000;
 const BACKOFF_MULTIPLIER = 2;
+const DEFAULT_MAX_ATTEMPTS = 6;
 
 export class CoordinatorClient {
   private baseUrl: string;
@@ -259,7 +260,7 @@ export class CoordinatorClient {
    */
   private async pollSdpAnswer(
     sessionId: string,
-    maxAttempts?: number
+    maxAttempts: number = DEFAULT_MAX_ATTEMPTS
   ): Promise<string> {
     console.debug(
       "[CoordinatorClient] Polling for SDP answer for session:",
@@ -270,7 +271,7 @@ export class CoordinatorClient {
     let attempt = 0;
 
     while (true) {
-      if (maxAttempts !== undefined && attempt >= maxAttempts) {
+      if (attempt >= maxAttempts) {
         throw new Error(
           `SDP polling exceeded maximum attempts (${maxAttempts}) for session ${sessionId}`
         );
@@ -278,7 +279,7 @@ export class CoordinatorClient {
 
       attempt++;
       console.debug(
-        `[CoordinatorClient] SDP poll attempt ${attempt}${maxAttempts !== undefined ? `/${maxAttempts}` : ""} for session ${sessionId}`
+        `[CoordinatorClient] SDP poll attempt ${attempt}/${maxAttempts} for session ${sessionId}`
       );
 
       const response = await fetch(

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -21,7 +21,7 @@ export interface CoordinatorClientOptions {
 
 // Polling configuration
 const INITIAL_BACKOFF_MS = 500;
-const MAX_BACKOFF_MS = 30000;
+const MAX_BACKOFF_MS = 15000;
 const BACKOFF_MULTIPLIER = 2;
 
 export class CoordinatorClient {
@@ -251,12 +251,16 @@ export class CoordinatorClient {
   }
 
   /**
-   * Polls for the SDP answer with geometric backoff.
+   * Polls for the SDP answer with exponential backoff.
    * Used for async reconnection when the answer is not immediately available.
    * @param sessionId - The session ID to poll for
+   * @param maxAttempts - Optional maximum number of polling attempts before giving up
    * @returns The SDP answer from the server
    */
-  private async pollSdpAnswer(sessionId: string): Promise<string> {
+  private async pollSdpAnswer(
+    sessionId: string,
+    maxAttempts?: number
+  ): Promise<string> {
     console.debug(
       "[CoordinatorClient] Polling for SDP answer for session:",
       sessionId
@@ -266,9 +270,15 @@ export class CoordinatorClient {
     let attempt = 0;
 
     while (true) {
+      if (maxAttempts !== undefined && attempt >= maxAttempts) {
+        throw new Error(
+          `SDP polling exceeded maximum attempts (${maxAttempts}) for session ${sessionId}`
+        );
+      }
+
       attempt++;
       console.debug(
-        `[CoordinatorClient] SDP poll attempt ${attempt} for session ${sessionId}`
+        `[CoordinatorClient] SDP poll attempt ${attempt}${maxAttempts !== undefined ? `/${maxAttempts}` : ""} for session ${sessionId}`
       );
 
       const response = await fetch(
@@ -295,7 +305,7 @@ export class CoordinatorClient {
 
         await this.sleep(backoffMs);
 
-        // Geometric backoff
+        // Exponential backoff capped at MAX_BACKOFF_MS (15s)
         backoffMs = Math.min(backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
         continue;
       }
@@ -314,9 +324,14 @@ export class CoordinatorClient {
    * falls back to polling. If no sdpOffer is provided, goes directly to polling.
    * @param sessionId - The session ID to connect to
    * @param sdpOffer - Optional SDP offer from the local WebRTC peer connection
+   * @param maxAttempts - Optional maximum number of polling attempts before giving up
    * @returns The SDP answer from the server
    */
-  async connect(sessionId: string, sdpOffer?: string): Promise<string> {
+  async connect(
+    sessionId: string,
+    sdpOffer?: string,
+    maxAttempts?: number
+  ): Promise<string> {
     console.debug("[CoordinatorClient] Connecting to session:", sessionId);
 
     if (sdpOffer) {
@@ -330,7 +345,7 @@ export class CoordinatorClient {
     }
 
     // No SDP offer = async reconnection, poll until server has the answer
-    return this.pollSdpAnswer(sessionId);
+    return this.pollSdpAnswer(sessionId, maxAttempts);
   }
 
   /**

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -4,6 +4,7 @@ import {
   type ReactorState,
   type ReactorError,
   type MessageScope,
+  type ConnectOptions,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -145,8 +146,9 @@ export class Reactor {
 
   /**
    * Public method for reconnecting to an existing session, that may have been interrupted but can be recovered.
+   * @param options Optional connect options (e.g. maxAttempts for SDP polling)
    */
-  async reconnect(): Promise<void> {
+  async reconnect(options?: ConnectOptions): Promise<void> {
     if (!this.sessionId || !this.coordinatorClient) {
       console.warn("[Reactor] No active session to reconnect to.");
       return;
@@ -174,7 +176,8 @@ export class Reactor {
     try {
       const sdpAnswer = await this.coordinatorClient.connect(
         this.sessionId,
-        sdpOffer
+        sdpOffer,
+        options?.maxAttempts
       );
 
       // Connect to GPU machine with the answer
@@ -201,8 +204,10 @@ export class Reactor {
    * Connects to the coordinator and waits for a GPU to be assigned.
    * Once a GPU is assigned, the Reactor will connect to the gpu machine via WebRTC.
    * If no authentication is provided and not in local mode, an error is thrown.
+   * @param jwtToken Optional JWT token for authentication
+   * @param options Optional connect options (e.g. maxAttempts for SDP polling)
    */
-  async connect(jwtToken?: string): Promise<void> {
+  async connect(jwtToken?: string, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);
 
     if (jwtToken == undefined && !this.local) {
@@ -224,7 +229,7 @@ export class Reactor {
         ? new LocalCoordinatorClient(this.coordinatorUrl)
         : new CoordinatorClient({
             baseUrl: this.coordinatorUrl,
-            jwtToken: jwtToken!, // Safe: validated on line 186-188
+            jwtToken: jwtToken!, // Safe: validated above
             model: this.model,
           });
 
@@ -243,7 +248,11 @@ export class Reactor {
 
       // Connect to coordinator and get SDP Answer.
       // We don't pass the sdp offer here because we passed it already when creating the session.
-      const sdpAnswer = await this.coordinatorClient.connect(sessionId);
+      const sdpAnswer = await this.coordinatorClient.connect(
+        sessionId,
+        undefined,
+        options?.maxAttempts
+      );
 
       // Connect to GPU machine with the answer
       await this.machineClient.connect(sdpAnswer);
@@ -255,7 +264,16 @@ export class Reactor {
         "coordinator",
         true
       );
-      this.setStatus("disconnected");
+      // Non-recoverable disconnect: terminates the server-side session (DELETE)
+      // and cleans up all local state (machine client, session ID, etc.)
+      try {
+        await this.disconnect(false);
+      } catch (disconnectError) {
+        console.error(
+          "[Reactor] Failed to clean up after connection failure:",
+          disconnectError
+        );
+      }
       throw error;
     }
   }

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -1,5 +1,10 @@
 import { StoreApi } from "zustand";
-import type { ReactorStatus, ReactorError, MessageScope } from "../types";
+import type {
+  ReactorStatus,
+  ReactorError,
+  MessageScope,
+  ConnectOptions,
+} from "../types";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
 import { create } from "zustand/react";
 import { createContext } from "react";
@@ -18,11 +23,11 @@ export interface ReactorState {
 
 export interface ReactorActions {
   sendCommand(command: string, data: any, scope?: MessageScope): Promise<void>;
-  connect(jwtToken?: string): Promise<void>;
+  connect(jwtToken?: string, options?: ConnectOptions): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
   publishVideoStream(stream: MediaStream): Promise<void>;
   unpublishVideoStream(): Promise<void>;
-  reconnect(): Promise<void>;
+  reconnect(options?: ConnectOptions): Promise<void>;
 }
 
 // Internal state not exposed to components
@@ -156,7 +161,7 @@ export const createReactorStore = (
           throw error;
         }
       },
-      connect: async (jwtToken?: string) => {
+      connect: async (jwtToken?: string, options?: ConnectOptions) => {
         if (jwtToken === undefined) {
           // If no JWT Token, it might have been passed in the constructor props. So read from it.
           jwtToken = get().jwtToken;
@@ -165,7 +170,7 @@ export const createReactorStore = (
         console.debug("[ReactorStore] Connect called.");
 
         try {
-          await get().internal.reactor.connect(jwtToken);
+          await get().internal.reactor.connect(jwtToken, options);
           console.debug("[ReactorStore] Connect completed successfully");
         } catch (error) {
           console.error("[ReactorStore] Connect failed:", error);
@@ -213,10 +218,10 @@ export const createReactorStore = (
           throw error;
         }
       },
-      reconnect: async () => {
+      reconnect: async (options?: ConnectOptions) => {
         console.debug("[ReactorStore] Reconnecting");
         try {
-          await get().internal.reactor.reconnect();
+          await get().internal.reactor.reconnect(options);
           console.debug("[ReactorStore] Reconnect completed successfully");
         } catch (error) {
           console.error("[ReactorStore] Failed to reconnect:", error);

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -10,10 +10,20 @@ import {
   type ReactorInitializationProps,
 } from "../core/store";
 import { useStore } from "zustand";
+import type { ConnectOptions } from "../types";
+
+/**
+ * Options for the React provider's connect behavior.
+ * Extends the core ConnectOptions with autoConnect for the React lifecycle.
+ */
+export interface ReactorConnectOptions extends ConnectOptions {
+  /** Whether to automatically connect when the provider mounts. Default: true. */
+  autoConnect?: boolean;
+}
 
 // Provider props
 interface ReactorProviderProps extends ReactorInitializationProps {
-  autoConnect?: boolean;
+  connectOptions?: ReactorConnectOptions;
   jwtToken?: string;
   children: ReactNode;
 }
@@ -21,7 +31,7 @@ interface ReactorProviderProps extends ReactorInitializationProps {
 // tsx component
 export function ReactorProvider({
   children,
-  autoConnect = true,
+  connectOptions,
   jwtToken,
   ...props
 }: ReactorProviderProps) {
@@ -44,10 +54,14 @@ export function ReactorProvider({
     console.debug("[ReactorProvider] Reactor store created successfully");
   }
 
+  // Destructure connectOptions with defaults
+  const { autoConnect = true, ...pollingOptions } = connectOptions ?? {};
+
   // Fan out props to individual variables so that the
   // useEffect hook can be optimized by only re-running when the
   // props that actually change.
   const { coordinatorUrl, modelName, local } = props;
+  const maxAttempts = pollingOptions.maxAttempts;
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
   useEffect(() => {
@@ -83,7 +97,7 @@ export function ReactorProvider({
         );
         current
           .getState()
-          .connect(jwtToken)
+          .connect(jwtToken, pollingOptions)
           .then(() => {
             console.debug(
               "[ReactorProvider] Autoconnect successful in first render"
@@ -144,7 +158,7 @@ export function ReactorProvider({
       console.debug("[ReactorProvider] Starting autoconnect...");
       current
         .getState()
-        .connect(jwtToken)
+        .connect(jwtToken, pollingOptions)
         .then(() => {
           console.debug("[ReactorProvider] Autoconnect successful");
         })
@@ -167,7 +181,7 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-  }, [coordinatorUrl, modelName, autoConnect, local, jwtToken]);
+  }, [coordinatorUrl, modelName, autoConnect, local, jwtToken, maxAttempts]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -17,7 +17,7 @@ import type { ConnectOptions } from "../types";
  * Extends the core ConnectOptions with autoConnect for the React lifecycle.
  */
 export interface ReactorConnectOptions extends ConnectOptions {
-  /** Whether to automatically connect when the provider mounts. Default: true. */
+  /** Whether to automatically connect when the provider mounts. Default: false. */
   autoConnect?: boolean;
 }
 
@@ -55,7 +55,7 @@ export function ReactorProvider({
   }
 
   // Destructure connectOptions with defaults
-  const { autoConnect = true, ...pollingOptions } = connectOptions ?? {};
+  const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
   // Fan out props to individual variables so that the
   // useEffect hook can be optimized by only re-running when the

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -33,6 +33,14 @@ export interface ReactorState {
   lastError?: ReactorError; // Most recent error
 }
 
+/**
+ * Options for configuring the connect polling behavior.
+ */
+export interface ConnectOptions {
+  /** Maximum number of SDP polling attempts before giving up. Default: unlimited. */
+  maxAttempts?: number;
+}
+
 export type ReactorEvent =
   | "statusChanged" //updates on the reactor status
   | "sessionIdChanged" //updates on the session ID.

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -37,7 +37,7 @@ export interface ReactorState {
  * Options for configuring the connect polling behavior.
  */
 export interface ConnectOptions {
-  /** Maximum number of SDP polling attempts before giving up. Default: unlimited. */
+  /** Maximum number of SDP polling attempts before giving up. Default: 6. */
   maxAttempts?: number;
 }
 


### PR DESCRIPTION
Why
---
The SDP polling loop had no maximum attempt limit, meaning a client could poll indefinitely if the server never returned an answer. Additionally, the backoff ceiling was set at 30s which was unnecessarily high, and when connection failed the server-side session was never terminated (no DELETE call), leaving orphaned sessions.

What Changed
---
- Added a `ConnectOptions` type with an optional `maxAttempts` field, threaded through `Reactor.connect()`, `reconnect()`, the Zustand store, and down into `CoordinatorClient.pollSdpAnswer()`. When the limit is hit, polling throws and the session is terminated.
- Reduced the exponential backoff ceiling from 30s to 15s.
- On connection failure, `Reactor.connect()` now calls `disconnect(false)` to send the DELETE request and clean up all local state, instead of only resetting the status.
- In the React layer, replaced the standalone `autoConnect` prop on `ReactorProvider` with a `connectOptions` prop (`ReactorConnectOptions`) that bundles `autoConnect` (default: `true`) alongside `maxAttempts`.

topic: REA-716-session-should-be-cancelled-by-the-client-if-it-sdp-params-are-not-accepted-after-x-seconds
reviewers: bryce, massenz, ahmed