### PR TITLE
[REA-694][1/3] Add multi-track types and core API for named tracks

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -1,10 +1,12 @@
 /**
- * The GPUMachineClient is responsible for handling the direct connection to the machine instance
- * after the coordinator has assigned a machine.
+ * Handles the direct WebRTC connection to a GPU machine instance.
+ *
+ * Transceivers are created from the declared {@link TracksConfig} and
+ * keyed by track name so that publish/unpublish/receive all route by name.
  */
 
 import * as webrtc from "../utils/webrtc";
-import type { MessageScope, ConnectionStats } from "../types";
+import type { MessageScope, TracksConfig, ConnectionStats } from "../types";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -26,6 +28,13 @@ export type GPUMachineStatus =
  * to the server so the runtime can detect stale connections quickly.
  */
 const PING_INTERVAL_MS = 5_000;
+
+interface TransceiverEntry {
+  name: string;
+  kind: "audio" | "video";
+  direction: RTCRtpTransceiverDirection;
+  transceiver?: RTCRtpTransceiver;
+}
 const STATS_INTERVAL_MS = 2_000;
 
 export class GPUMachineClient {
@@ -33,10 +42,13 @@ export class GPUMachineClient {
   private peerConnection: RTCPeerConnection | undefined;
   private dataChannel: RTCDataChannel | undefined;
   private status: GPUMachineStatus = "disconnected";
-  private publishedTrack: MediaStreamTrack | undefined;
-  private videoTransceiver: RTCRtpTransceiver | undefined;
   private config: webrtc.WebRTCConfig;
   private pingInterval: ReturnType<typeof setInterval> | undefined;
+
+  private transceiverMap: Map<string, TransceiverEntry> = new Map();
+  private publishedTracks: Map<string, MediaStreamTrack> = new Map();
+  private receiveTrackNames: string[] = [];
+  private receiveTrackIndex: number = 0;
   private statsInterval: ReturnType<typeof setInterval> | undefined;
   private stats: ConnectionStats | undefined;
 
@@ -68,10 +80,17 @@ export class GPUMachineClient {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * Creates an SDP offer for initiating a connection.
+   * Creates an SDP offer based on the declared tracks.
+   *
+   * Transceivers are added in a deterministic order:
+   * 1. Tracks that appear in both `receive` and `send` → `sendrecv`
+   * 2. Receive-only tracks → `recvonly`
+   * 3. Send-only tracks → `sendonly`
+   *
+   * The data channel is always created first (before transceivers).
    * Must be called before connect().
    */
-  async createOffer(): Promise<string> {
+  async createOffer(tracks: TracksConfig): Promise<string> {
     // Create peer connection if not exists
     if (!this.peerConnection) {
       this.peerConnection = webrtc.createPeerConnection(this.config);
@@ -85,14 +104,54 @@ export class GPUMachineClient {
     );
     this.setupDataChannelHandlers();
 
-    // Add sendrecv video transceiver for bidirectional video
-    this.videoTransceiver = this.peerConnection.addTransceiver("video", {
-      direction: "sendrecv",
-    });
+    this.transceiverMap.clear();
+    this.receiveTrackNames = [];
+    this.receiveTrackIndex = 0;
+
+    const entries = this.buildTransceiverEntries(tracks);
+
+    for (const entry of entries) {
+      const transceiver = this.peerConnection.addTransceiver(entry.kind, {
+        direction: entry.direction,
+      });
+      entry.transceiver = transceiver;
+      this.transceiverMap.set(entry.name, entry);
+
+      if (entry.direction === "recvonly" || entry.direction === "sendrecv") {
+        this.receiveTrackNames.push(entry.name);
+      }
+
+      console.debug(
+        `[GPUMachineClient] Transceiver added: "${entry.name}" (${entry.kind}, ${entry.direction})`
+      );
+    }
 
     const offer = await webrtc.createOffer(this.peerConnection);
     console.debug("[GPUMachineClient] Created SDP offer");
     return offer;
+  }
+
+  /**
+   * Builds an ordered list of transceiver entries from the tracks config.
+   * Merges send+receive entries that share a name into sendrecv.
+   */
+  private buildTransceiverEntries(tracks: TracksConfig): TransceiverEntry[] {
+    const map = new Map<string, TransceiverEntry>();
+
+    for (const t of tracks.receive) {
+      map.set(t.name, { name: t.name, kind: t.kind, direction: "recvonly" });
+    }
+
+    for (const t of tracks.send) {
+      const existing = map.get(t.name);
+      if (existing) {
+        existing.direction = "sendrecv";
+      } else {
+        map.set(t.name, { name: t.name, kind: t.kind, direction: "sendonly" });
+      }
+    }
+
+    return Array.from(map.values());
   }
 
   /**
@@ -132,8 +191,8 @@ export class GPUMachineClient {
     this.stopPing();
     this.stopStatsPolling();
 
-    if (this.publishedTrack) {
-      await this.unpublishTrack();
+    for (const name of Array.from(this.publishedTracks.keys())) {
+      await this.unpublishTrack(name);
     }
 
     if (this.dataChannel) {
@@ -146,7 +205,9 @@ export class GPUMachineClient {
       this.peerConnection = undefined;
     }
 
-    this.videoTransceiver = undefined;
+    this.transceiverMap.clear();
+    this.receiveTrackNames = [];
+    this.receiveTrackIndex = 0;
     this.setStatus("disconnected");
     console.debug("[GPUMachineClient] Disconnected");
   }
@@ -178,7 +239,7 @@ export class GPUMachineClient {
   /**
    * Sends a command to the GPU machine via the data channel.
    * @param command The command to send
-   * @param data The data to send with the command. These are the parameters for the command, matching the scheme in the capabilities dictionary.
+   * @param data The data to send with the command. These are the parameters for the command, matching the schema in the capabilities dictionary.
    * @param scope The message scope – "application" (default) for model commands, "runtime" for platform-level messages.
    */
   sendCommand(
@@ -202,68 +263,83 @@ export class GPUMachineClient {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
-   * Publishes a track to the GPU machine.
-   * Only one track can be published at a time.
-   * Uses the existing transceiver's sender to replace the track.
-   * @param track The MediaStreamTrack to publish
+   * Publishes a MediaStreamTrack to the named send track.
+   *
+   * @param name The declared track name (must exist in transceiverMap with a sendable direction).
+   * @param track The MediaStreamTrack to publish.
    */
-  async publishTrack(track: MediaStreamTrack): Promise<void> {
+  async publishTrack(name: string, track: MediaStreamTrack): Promise<void> {
     if (!this.peerConnection) {
       throw new Error(
-        "[GPUMachineClient] Cannot publish track - not initialized"
+        `[GPUMachineClient] Cannot publish track "${name}" - not initialized`
       );
     }
 
     if (this.status !== "connected") {
       throw new Error(
-        "[GPUMachineClient] Cannot publish track - not connected"
+        `[GPUMachineClient] Cannot publish track "${name}" - not connected`
       );
     }
 
-    if (!this.videoTransceiver) {
+    const entry = this.transceiverMap.get(name);
+    if (!entry || !entry.transceiver) {
       throw new Error(
-        "[GPUMachineClient] Cannot publish track - no video transceiver"
+        `[GPUMachineClient] Cannot publish track "${name}" - no transceiver (was it declared in tracks.send?)`
+      );
+    }
+
+    if (entry.direction === "recvonly") {
+      throw new Error(
+        `[GPUMachineClient] Cannot publish track "${name}" - transceiver is recvonly`
       );
     }
 
     try {
-      // Use replaceTrack on the existing transceiver's sender
-      // This doesn't require renegotiation
-      await this.videoTransceiver.sender.replaceTrack(track);
-      this.publishedTrack = track;
+      // Use replaceTrack on the existing transceiver's sender.
+      // This doesn't require renegotiation.
+      await entry.transceiver.sender.replaceTrack(track);
+      this.publishedTracks.set(name, track);
       console.debug(
-        "[GPUMachineClient] Track published successfully:",
-        track.kind
+        `[GPUMachineClient] Track "${name}" published successfully`
       );
     } catch (error) {
-      console.error("[GPUMachineClient] Failed to publish track:", error);
+      console.error(
+        `[GPUMachineClient] Failed to publish track "${name}":`,
+        error
+      );
       throw error;
     }
   }
 
   /**
-   * Unpublishes the currently published track.
+   * Unpublishes the track with the given name.
    */
-  async unpublishTrack(): Promise<void> {
-    if (!this.videoTransceiver || !this.publishedTrack) return;
+  async unpublishTrack(name: string): Promise<void> {
+    const entry = this.transceiverMap.get(name);
+    if (!entry?.transceiver || !this.publishedTracks.has(name)) return;
 
     try {
       // Replace with null to stop sending without renegotiation
-      await this.videoTransceiver.sender.replaceTrack(null);
-      console.debug("[GPUMachineClient] Track unpublished successfully");
+      await entry.transceiver.sender.replaceTrack(null);
+      console.debug(
+        `[GPUMachineClient] Track "${name}" unpublished successfully`
+      );
     } catch (error) {
-      console.error("[GPUMachineClient] Failed to unpublish track:", error);
+      console.error(
+        `[GPUMachineClient] Failed to unpublish track "${name}":`,
+        error
+      );
       throw error;
     } finally {
-      this.publishedTrack = undefined;
+      this.publishedTracks.delete(name);
     }
   }
 
   /**
-   * Returns the currently published track.
+   * Returns the currently published track for the given name.
    */
-  getPublishedTrack(): MediaStreamTrack | undefined {
-    return this.publishedTrack;
+  getPublishedTrack(name: string): MediaStreamTrack | undefined {
+    return this.publishedTracks.get(name);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -300,7 +376,7 @@ export class GPUMachineClient {
         try {
           webrtc.sendMessage(this.dataChannel, "ping", {}, "runtime");
         } catch {
-          // Silently ignore – data channel may be closing
+          // Silently ignore -- data channel may be closing
         }
       }
     }, PING_INTERVAL_MS);
@@ -382,9 +458,17 @@ export class GPUMachineClient {
     };
 
     this.peerConnection.ontrack = (event) => {
-      console.debug("[GPUMachineClient] Track received:", event.track.kind);
+      const trackName =
+        this.receiveTrackIndex < this.receiveTrackNames.length
+          ? this.receiveTrackNames[this.receiveTrackIndex]
+          : `unknown-${this.receiveTrackIndex}`;
+      this.receiveTrackIndex++;
+
+      console.debug(
+        `[GPUMachineClient] Track received: "${trackName}" (${event.track.kind})`
+      );
       const stream = event.streams[0] ?? new MediaStream([event.track]);
-      this.emit("trackReceived", event.track, stream);
+      this.emit("trackReceived", trackName, event.track, stream);
     };
 
     this.peerConnection.onicecandidate = (event) => {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -5,6 +5,7 @@ import {
   type ReactorError,
   type MessageScope,
   type ConnectOptions,
+  type TracksConfig,
   type ConnectionStats,
   ConflictError,
 } from "../types";
@@ -16,10 +17,26 @@ import { z } from "zod";
 const LOCAL_COORDINATOR_URL = "http://localhost:8080";
 export const PROD_COORDINATOR_URL = "https://api.reactor.inc";
 
+const TrackConfigSchema = z.object({
+  name: z.string(),
+  kind: z.enum(["audio", "video"]),
+});
+
+const TracksConfigSchema = z.object({
+  send: z.array(TrackConfigSchema).default([]),
+  receive: z.array(TrackConfigSchema).default([]),
+});
+
+const DEFAULT_TRACKS: TracksConfig = {
+  send: [],
+  receive: [{ name: "video-0", kind: "video" }],
+};
+
 const OptionsSchema = z.object({
   coordinatorUrl: z.string().default(PROD_COORDINATOR_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
+  tracks: TracksConfigSchema.default(DEFAULT_TRACKS),
 });
 export type Options = z.input<typeof OptionsSchema>;
 
@@ -34,6 +51,7 @@ export class Reactor {
   private model: string;
   private sessionExpiration?: number;
   private local: boolean;
+  private tracks: TracksConfig;
   private sessionId?: string;
 
   constructor(options: Options) {
@@ -43,6 +61,7 @@ export class Reactor {
     // TODO(REA-146) Properly accept version from parameter.
     this.model = validatedOptions.modelName;
     this.local = validatedOptions.local;
+    this.tracks = validatedOptions.tracks;
     if (this.local) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
     }
@@ -68,13 +87,11 @@ export class Reactor {
   }
 
   /**
-   * Public method to send a message to the machine.
-   * Wraps the message in the specified channel envelope (defaults to "application").
-   * @param command The command name to send.
+   * Sends a command to the model via the data channel.
+   *
+   * @param command The command name.
    * @param data The command payload.
-   * @param scope The envelope scope – "application" (default) for model commands,
-   *              "runtime" for platform-level messages (e.g. requestCapabilities).
-   * @throws Error if not in ready state
+   * @param scope "application" (default) for model commands, "runtime" for platform messages.
    */
   async sendCommand(
     command: string,
@@ -104,24 +121,26 @@ export class Reactor {
   }
 
   /**
-   * Public method to publish a track to the machine.
-   * @param track The track to send to the machine.
+   * Publishes a MediaStreamTrack to a named send track.
+   *
+   * @param name The declared send track name (e.g. "webcam").
+   * @param track The MediaStreamTrack to publish.
    */
-  async publishTrack(track: MediaStreamTrack): Promise<void> {
-    // Synchronous validation - throw immediately
+  async publishTrack(name: string, track: MediaStreamTrack): Promise<void> {
     if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
-      const errorMessage = `Cannot publish track, status is ${this.status}`;
-      console.warn("[Reactor]", errorMessage);
+      console.warn(
+        `[Reactor] Cannot publish track "${name}", status is ${this.status}`
+      );
       return;
     }
 
     try {
-      await this.machineClient?.publishTrack(track);
+      await this.machineClient?.publishTrack(name, track);
     } catch (error) {
-      console.error("[Reactor] Failed to publish track:", error);
+      console.error(`[Reactor] Failed to publish track "${name}":`, error);
       this.createError(
         "TRACK_PUBLISH_FAILED",
-        `Failed to publish track: ${error}`,
+        `Failed to publish track "${name}": ${error}`,
         "gpu",
         true
       );
@@ -129,16 +148,18 @@ export class Reactor {
   }
 
   /**
-   * Public method to unpublish the currently published track.
+   * Unpublishes the track with the given name.
+   *
+   * @param name The declared send track name to unpublish.
    */
-  async unpublishTrack(): Promise<void> {
+  async unpublishTrack(name: string): Promise<void> {
     try {
-      await this.machineClient?.unpublishTrack();
+      await this.machineClient?.unpublishTrack(name);
     } catch (error) {
-      console.error("[Reactor] Failed to unpublish track:", error);
+      console.error(`[Reactor] Failed to unpublish track "${name}":`, error);
       this.createError(
         "TRACK_UNPUBLISH_FAILED",
-        `Failed to unpublish track: ${error}`,
+        `Failed to unpublish track "${name}": ${error}`,
         "gpu",
         true
       );
@@ -165,13 +186,12 @@ export class Reactor {
     if (!this.machineClient) {
       // Get ICE servers from coordinator
       const iceServers = await this.coordinatorClient.getIceServers();
-
       this.machineClient = new GPUMachineClient({ iceServers });
       this.setupMachineClientHandlers();
     }
 
     // We always calculate a new offer for reconnection.
-    const sdpOffer = await this.machineClient.createOffer();
+    const sdpOffer = await this.machineClient.createOffer(this.tracks);
 
     // Send offer to coordinator and get answer.
     try {
@@ -180,7 +200,6 @@ export class Reactor {
         sdpOffer,
         options?.maxAttempts
       );
-
       // Connect to GPU machine with the answer
       await this.machineClient.connect(sdpAnswer);
       this.setStatus("ready");
@@ -190,7 +209,7 @@ export class Reactor {
         recoverable = true;
       }
       console.error("[Reactor] Failed to reconnect:", error);
-      // disconnect without recovery, as the session "connect" call on the coordinator failed
+      // Disconnect without recovery, as the session "connect" call on the coordinator failed
       this.disconnect(recoverable);
       this.createError(
         "RECONNECTION_FAILED",
@@ -215,7 +234,6 @@ export class Reactor {
       throw new Error("No authentication provided and not in local mode");
     }
 
-    // Synchronous validation - throw immediately
     if (this.status !== "disconnected") {
       throw new Error("Already connected or connecting");
     }
@@ -241,9 +259,9 @@ export class Reactor {
       this.machineClient = new GPUMachineClient({ iceServers });
       this.setupMachineClientHandlers();
 
-      const sdpOffer = await this.machineClient.createOffer();
+      const sdpOffer = await this.machineClient.createOffer(this.tracks);
 
-      // Create session passing sdp offer. We will get the answer polling the sdp_offer endpoint.
+      // Create session passing SDP offer. We will get the answer polling the sdp_offer endpoint.
       const sessionId = await this.coordinatorClient.createSession(sdpOffer);
       this.setSessionId(sessionId);
 
@@ -315,8 +333,8 @@ export class Reactor {
 
     this.machineClient.on(
       "trackReceived",
-      (track: MediaStreamTrack, stream: MediaStream) => {
-        this.emit("streamChanged", track, stream);
+      (name: string, track: MediaStreamTrack, stream: MediaStream) => {
+        this.emit("trackReceived", name, track, stream);
       }
     );
 

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -13,11 +13,10 @@ export type ReactorStoreApi = ReturnType<typeof createReactorStore>;
 
 export interface ReactorState {
   status: ReactorStatus;
-  videoTrack: MediaStreamTrack | null;
+  receivedTracks: Record<string, MediaStreamTrack>;
   lastError?: ReactorError;
   sessionId?: string;
   sessionExpiration?: number;
-  insecureApiKey?: string;
   jwtToken?: string;
 }
 
@@ -25,8 +24,8 @@ export interface ReactorActions {
   sendCommand(command: string, data: any, scope?: MessageScope): Promise<void>;
   connect(jwtToken?: string, options?: ConnectOptions): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
-  publishVideoStream(stream: MediaStream): Promise<void>;
-  unpublishVideoStream(): Promise<void>;
+  publish(name: string, track: MediaStreamTrack): Promise<void>;
+  unpublish(name: string): Promise<void>;
   reconnect(options?: ConnectOptions): Promise<void>;
 }
 
@@ -46,15 +45,15 @@ export type ReactorStore = ReactorState &
 
 // We introduce two methods to perform authentication:
 //  - putting the auth information inside of the ReactorProvider props, and then calling connect() without arguments.
-//  - not putting the anything in the props, and then calling connect() passing as arguments the auth information.
-// When in the first case, the auth information is saved in the STATE. Then, when you call connect() without arguments, the actual auth information is fetched
-// from that STATE. In the second case, you pass the auth information directly into the function in the Reactor core.
+//  - not putting anything in the props, and then calling connect() passing as arguments the auth information.
+// When in the first case, the auth information is saved in the STATE. Then, when you call connect() without arguments,
+// the actual auth information is fetched from that STATE.
+// In the second case, you pass the auth information directly into the function in the Reactor core.
 export const defaultInitState: ReactorState = {
   status: "disconnected",
-  videoTrack: null,
+  receivedTracks: {},
   lastError: undefined,
   sessionExpiration: undefined,
-  insecureApiKey: undefined,
   jwtToken: undefined,
   sessionId: undefined,
 };
@@ -107,13 +106,13 @@ export const createReactorStore = (
       }
     );
 
-    reactor.on("streamChanged", (videoTrack: MediaStreamTrack | null) => {
-      console.debug("[ReactorStore] Stream changed", {
-        hasVideoTrack: !!videoTrack,
-        videoTrackKind: videoTrack?.kind,
-        videoTrackId: videoTrack?.id,
+    reactor.on("trackReceived", (name: string, track: MediaStreamTrack) => {
+      console.debug("[ReactorStore] Track received", {
+        name,
+        kind: track.kind,
+        id: track.id,
       });
-      set({ videoTrack: videoTrack });
+      set({ receivedTracks: { ...get().receivedTracks, [name]: track } });
     });
 
     reactor.on("error", (error: ReactorError) => {
@@ -188,29 +187,33 @@ export const createReactorStore = (
           throw error;
         }
       },
-      publishVideoStream: async (stream: MediaStream) => {
-        console.debug("[ReactorStore] Publishing video stream");
+      publish: async (name: string, track: MediaStreamTrack) => {
+        console.debug(`[ReactorStore] Publishing track "${name}"`);
 
         try {
-          await get().internal.reactor.publishTrack(stream.getVideoTracks()[0]);
-          console.debug("[ReactorStore] Video stream published successfully");
+          await get().internal.reactor.publishTrack(name, track);
+          console.debug(
+            `[ReactorStore] Track "${name}" published successfully`
+          );
         } catch (error) {
           console.error(
-            "[ReactorStore] Failed to publish video stream:",
+            `[ReactorStore] Failed to publish track "${name}":`,
             error
           );
           throw error;
         }
       },
-      unpublishVideoStream: async () => {
-        console.debug("[ReactorStore] Unpublishing video stream");
+      unpublish: async (name: string) => {
+        console.debug(`[ReactorStore] Unpublishing track "${name}"`);
 
         try {
-          await get().internal.reactor.unpublishTrack();
-          console.debug("[ReactorStore] Video stream unpublished successfully");
+          await get().internal.reactor.unpublishTrack(name);
+          console.debug(
+            `[ReactorStore] Track "${name}" unpublished successfully`
+          );
         } catch (error) {
           console.error(
-            "[ReactorStore] Failed to unpublish video stream:",
+            `[ReactorStore] Failed to unpublish track "${name}":`,
             error
           );
           throw error;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -11,14 +11,34 @@ export type ReactorStatus =
  */
 export type MessageScope = "application" | "runtime";
 
-// Error information
+/**
+ * Describes a single named media track for SDP negotiation.
+ */
+export interface TrackConfig {
+  name: string;
+  kind: "audio" | "video";
+}
+
+/**
+ * Declares the media tracks for a Reactor session.
+ *
+ * - `send`: tracks the client publishes towards the model.
+ * - `receive`: tracks the client receives from the model.
+ *
+ * Tracks appear in the SDP offer in declaration order.
+ */
+export interface TracksConfig {
+  send: TrackConfig[];
+  receive: TrackConfig[];
+}
+
 export interface ReactorError {
   code: string;
   message: string;
   timestamp: number;
   recoverable: boolean;
   component: "coordinator" | "gpu" | "livekit";
-  retryAfter?: number; // Suggested retry delay in seconds
+  retryAfter?: number;
 }
 
 export class ConflictError extends Error {
@@ -27,10 +47,9 @@ export class ConflictError extends Error {
   }
 }
 
-// Enhanced state with metadata
 export interface ReactorState {
   status: ReactorStatus;
-  lastError?: ReactorError; // Most recent error
+  lastError?: ReactorError;
 }
 
 /**
@@ -62,7 +81,7 @@ export type ReactorEvent =
   | "sessionIdChanged" //updates on the session ID.
   | "message" //application-scoped messages from the model
   | "runtimeMessage" //internal platform-level control messages (e.g. capabilities)
-  | "streamChanged" //video stream has changed (LiveKit)
+  | "trackReceived"  // (name: string, track: MediaStreamTrack, stream: MediaStream)
   | "error" //error events with ReactorError details
   | "sessionExpirationChanged" //session expiration has changed
   | "statsUpdate"; //WebRTC stats update (RTT, etc.)


### PR DESCRIPTION
Why
---
The SDK currently hardcodes a single video transceiver (`sendrecv`) and
exposes tracks by kind (`videoTrack`, `publishVideoStream`). This makes
it impossible to support models that produce multiple video/audio outputs
or accept multiple inputs. We need tracks to be addressable by name so
the SDP offer can declare an arbitrary set of transceivers that match
the model's track layout.

What Changed
---
- **types.ts**: Added `TrackConfig` and `TracksConfig` interfaces that
  describe named send/receive tracks. Renamed the `streamChanged` event
  to `trackReceived` which now carries `(name, track, stream)`.
- **Reactor.ts**: `Options` gains a `tracks: TracksConfig` field
  (defaults to receiving one video track named `video-0`).
  `publishTrack` and `unpublishTrack` now take a required `name` arg
  that routes to the correct transceiver. SDP offer creation forwards
  the tracks config to `GPUMachineClient`.
- **GPUMachineClient.ts**: `createOffer()` now accepts a `TracksConfig`
  and builds one transceiver per declared track in deterministic order,
  merging send+receive names into `sendrecv`. Incoming tracks are mapped
  back to their declared names by SDP order. Single `videoTransceiver`
  + `publishedTrack` replaced by `transceiverMap` and `publishedTracks`
  keyed by name.
- **store.ts**: `videoTrack: MediaStreamTrack | null` replaced by
  `receivedTracks: Record<string, MediaStreamTrack>`. Actions renamed
  from `publishVideoStream`/`unpublishVideoStream` to
  `publish(name, track)` / `unpublish(name)`.

Upcoming Changes
---
- [2/3] Update React components (`ReactorProvider`, `ReactorView`,
  `WebcamStream`) to use the new named-track API.
- [3/3] Update example apps.

topic: REA-694-add-multi-track-support-api-to-js-sdk
reviewers: bryce