### PR TITLE
[REA-694][2/3] Update React components for named-track API

### DIFF
--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -57,10 +57,7 @@ export function ReactorProvider({
   // Destructure connectOptions with defaults
   const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
-  // Fan out props to individual variables so that the
-  // useEffect hook can be optimized by only re-running when the
-  // props that actually change.
-  const { coordinatorUrl, modelName, local } = props;
+  const { coordinatorUrl, modelName, local, tracks } = props;
   const maxAttempts = pollingOptions.maxAttempts;
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
@@ -137,6 +134,7 @@ export function ReactorProvider({
         coordinatorUrl,
         modelName,
         local,
+        tracks,
         jwtToken,
       } satisfies ReactorInitializationProps)
     );
@@ -181,7 +179,15 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-  }, [coordinatorUrl, modelName, autoConnect, local, jwtToken, maxAttempts]);
+  }, [
+    coordinatorUrl,
+    modelName,
+    autoConnect,
+    local,
+    tracks,
+    jwtToken,
+    maxAttempts,
+  ]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useReactor } from "./hooks";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import React from "react";
 
 export interface ReactorViewProps {
+  /** The name of the video track to render. Defaults to "video-0". */
+  track?: string;
+  /** Optional: the name of an audio track to play alongside the video (e.g. "audio-0"). */
+  audioTrack?: string;
   width?: number;
   height?: number;
   className?: string;
@@ -12,57 +16,70 @@ export interface ReactorViewProps {
   videoObjectFit?: NonNullable<
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
+  /** Controls whether inbound audio plays. Default true (muted) to satisfy browser autoplay policies. */
+  muted?: boolean;
 }
 
 export function ReactorView({
+  track = "video-0",
+  audioTrack,
   width,
   height,
   className,
   style,
   videoObjectFit = "contain",
+  muted = true,
 }: ReactorViewProps) {
-  const { videoTrack, status } = useReactor((state) => ({
-    videoTrack: state.videoTrack,
+  const { videoMediaTrack, audioMediaTrack, status } = useReactor((state) => ({
+    videoMediaTrack: state.receivedTracks[track] ?? null,
+    audioMediaTrack: audioTrack
+      ? (state.receivedTracks[audioTrack] ?? null)
+      : null,
     status: state.status,
   }));
 
   const videoRef = useRef<HTMLVideoElement>(null);
 
+  const mediaStream = useMemo(() => {
+    const tracks: MediaStreamTrack[] = [];
+    if (videoMediaTrack) tracks.push(videoMediaTrack);
+    if (audioMediaTrack) tracks.push(audioMediaTrack);
+    if (tracks.length === 0) return null;
+    return new MediaStream(tracks);
+  }, [videoMediaTrack, audioMediaTrack]);
+
   useEffect(() => {
-    console.debug("[ReactorView] Video track effect triggered", {
+    console.debug("[ReactorView] Media track effect triggered", {
+      track,
       hasVideoElement: !!videoRef.current,
-      hasVideoTrack: !!videoTrack,
-      videoTrackKind: videoTrack?.kind,
+      hasVideoTrack: !!videoMediaTrack,
+      hasAudioTrack: !!audioMediaTrack,
     });
 
-    if (videoRef.current && videoTrack) {
-      console.debug("[ReactorView] Attaching video track to element");
+    if (videoRef.current && mediaStream) {
+      console.debug("[ReactorView] Attaching media stream to element");
       try {
-        // Create a MediaStream from the track and attach to video element
-        const stream = new MediaStream([videoTrack]);
-        videoRef.current.srcObject = stream;
+        videoRef.current.srcObject = mediaStream;
         videoRef.current.play().catch((e) => {
           console.warn("[ReactorView] Auto-play failed:", e);
         });
-        console.debug("[ReactorView] Video track attached successfully");
+        console.debug("[ReactorView] Media stream attached successfully");
       } catch (error) {
-        console.error("[ReactorView] Failed to attach video track:", error);
+        console.error("[ReactorView] Failed to attach media stream:", error);
       }
 
-      // Cleanup: remove srcObject when track changes or component unmounts
       return () => {
-        console.debug("[ReactorView] Detaching video track from element");
+        console.debug("[ReactorView] Detaching media stream from element");
         if (videoRef.current) {
           videoRef.current.srcObject = null;
-          console.debug("[ReactorView] Video track detached successfully");
         }
       };
     } else {
-      console.debug("[ReactorView] No video track or element to attach");
+      console.debug("[ReactorView] No tracks or element to attach");
     }
-  }, [videoTrack]);
+  }, [mediaStream]);
 
-  const showPlaceholder = !videoTrack;
+  const showPlaceholder = !videoMediaTrack;
 
   return (
     <div
@@ -83,7 +100,7 @@ export function ReactorView({
           objectFit: videoObjectFit,
           display: showPlaceholder ? "none" : "block",
         }}
-        muted
+        muted={muted}
         playsInline
       />
       {showPlaceholder && (

--- a/packages/js-sdk/src/react/WebcamStream.tsx
+++ b/packages/js-sdk/src/react/WebcamStream.tsx
@@ -4,7 +4,9 @@ import { useReactor } from "./hooks";
 import { useEffect, useRef, useState } from "react";
 import React from "react";
 
-interface Props {
+export interface WebcamStreamProps {
+  /** The name of the send track to publish the webcam to. Defaults to "webcam". */
+  track?: string;
   className?: string;
   style?: React.CSSProperties;
   videoConstraints?: MediaTrackConstraints;
@@ -15,6 +17,7 @@ interface Props {
 }
 
 export function WebcamStream({
+  track = "webcam",
   className,
   style,
   videoConstraints = {
@@ -23,18 +26,17 @@ export function WebcamStream({
   },
   showWebcam = true,
   videoObjectFit = "contain",
-}: Props) {
+}: WebcamStreamProps) {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
   const [permissionDenied, setPermissionDenied] = useState(false);
 
-  const { status, publishVideoStream, unpublishVideoStream, reactor } =
-    useReactor((state) => ({
-      status: state.status,
-      publishVideoStream: state.publishVideoStream,
-      unpublishVideoStream: state.unpublishVideoStream,
-      reactor: state.internal.reactor,
-    }));
+  const { status, publish, unpublish, reactor } = useReactor((state) => ({
+    status: state.status,
+    publish: state.publish,
+    unpublish: state.unpublish,
+    reactor: state.internal.reactor,
+  }));
 
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -71,7 +73,7 @@ export function WebcamStream({
 
     // Unpublish if currently publishing
     try {
-      await unpublishVideoStream();
+      await unpublish(track);
       console.debug("[WebcamPublisher] Unpublished before stopping");
     } catch (err) {
       console.error("[WebcamPublisher] Error unpublishing before stop:", err);
@@ -80,9 +82,9 @@ export function WebcamStream({
     setIsPublishing(false);
 
     // Stop all tracks
-    stream?.getTracks().forEach((track) => {
-      track.stop();
-      console.debug("[WebcamPublisher] Stopped track:", track.kind);
+    stream?.getTracks().forEach((t) => {
+      t.stop();
+      console.debug("[WebcamPublisher] Stopped track:", t.kind);
     });
     setStream(null);
 
@@ -120,17 +122,20 @@ export function WebcamStream({
       console.debug(
         "[WebcamPublisher] Reactor ready, auto-publishing webcam stream"
       );
-      publishVideoStream(stream)
-        .then(() => {
-          console.debug("[WebcamPublisher] Auto-publish successful");
-          setIsPublishing(true);
-        })
-        .catch((err) => {
-          console.error("[WebcamPublisher] Auto-publish failed:", err);
-        });
+      const videoTrack = stream.getVideoTracks()[0];
+      if (videoTrack) {
+        publish(track, videoTrack)
+          .then(() => {
+            console.debug("[WebcamPublisher] Auto-publish successful");
+            setIsPublishing(true);
+          })
+          .catch((err) => {
+            console.error("[WebcamPublisher] Auto-publish failed:", err);
+          });
+      }
     } else if (status !== "ready" && isPublishing) {
       console.debug("[WebcamPublisher] Reactor not ready, auto-unpublishing");
-      unpublishVideoStream()
+      unpublish(track)
         .then(() => {
           console.debug("[WebcamPublisher] Auto-unpublish successful");
           setIsPublishing(false);
@@ -139,17 +144,17 @@ export function WebcamStream({
           console.error("[WebcamPublisher] Auto-unpublish failed:", err);
         });
     }
-  }, [status, stream, isPublishing, publishVideoStream, unpublishVideoStream]);
+  }, [status, stream, isPublishing, publish, unpublish, track]);
 
   // Listen for error events from Reactor
   useEffect(() => {
     const handleError = (error: any) => {
       console.debug("[WebcamPublisher] Received error event:", error);
 
-      // Handle video publish failures by resetting state
-      if (error.code === "VIDEO_PUBLISH_FAILED") {
+      // Handle track publish failures by resetting state
+      if (error.code === "TRACK_PUBLISH_FAILED") {
         console.debug(
-          "[WebcamPublisher] Video publish failed, resetting isPublishing state"
+          "[WebcamPublisher] Track publish failed, resetting isPublishing state"
         );
         setIsPublishing(false);
       }


### PR DESCRIPTION
Why
---
The core SDK (commit 1/3) replaced `videoTrack`/`publishVideoStream` with
a named-track map (`receivedTracks`, `publish(name, track)`).  The React
layer still referenced the old fields, so it needs to be updated to
consume the new API.

What Changed
---
- **ReactorProvider.tsx**: Passes the new `tracks` prop through to the
  store initializer and includes it in the useEffect dependency array so
  the store is recreated when the track config changes.
- **ReactorView.tsx**: New optional `track` prop (defaults to `"video-0"`)
  and optional `audioTrack` prop. Looks up tracks from
  `state.receivedTracks` by name, composes them into a single
  `MediaStream`, and adds a controllable `muted` prop (defaults to
  `true` for autoplay-policy compliance).
- **WebcamStream.tsx**: New optional `track` prop (defaults to
  `"webcam"`). Replaces `publishVideoStream(stream)` /
  `unpublishVideoStream()` with `publish(name, videoTrack)` /
  `unpublish(name)`. Error code check updated from
  `VIDEO_PUBLISH_FAILED` to `TRACK_PUBLISH_FAILED`. All existing
  behavior (placeholder UI, permission handling, auto-start/stop,
  `showWebcam`, `videoConstraints`) is preserved.

Upcoming Changes
---
- [3/3] Update example apps to use the new component props.

topic: REA-694-update-react-components-for-named-track-api
relative: REA-694-add-multi-track-support-api-to-js-sdk
reviewers: bryce