### PR TITLE
REA-886: Add WebRTC stats polling with RTT measurement

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -330,19 +330,8 @@ export class GPUMachineClient {
       if (!this.peerConnection) return;
       try {
         const report = await this.peerConnection.getStats();
-        report.forEach((stat) => {
-          if (
-            stat.type === "candidate-pair" &&
-            stat.state === "succeeded" &&
-            stat.currentRoundTripTime !== undefined
-          ) {
-            this.stats = {
-              rtt: stat.currentRoundTripTime * 1000,
-              timestamp: Date.now(),
-            };
-            this.emit("statsUpdate", this.stats);
-          }
-        });
+        this.stats = webrtc.extractConnectionStats(report);
+        this.emit("statsUpdate", this.stats);
       } catch {
         // Silently ignore – connection may be closing
       }

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -4,7 +4,7 @@
  */
 
 import * as webrtc from "../utils/webrtc";
-import type { MessageScope } from "../types";
+import type { MessageScope, ConnectionStats } from "../types";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -12,7 +12,8 @@ export type GPUMachineEvent =
   | "statusChanged"
   | "trackReceived"
   | "trackRemoved"
-  | "message";
+  | "message"
+  | "statsUpdate";
 
 export type GPUMachineStatus =
   | "disconnected"
@@ -25,6 +26,7 @@ export type GPUMachineStatus =
  * to the server so the runtime can detect stale connections quickly.
  */
 const PING_INTERVAL_MS = 5_000;
+const STATS_INTERVAL_MS = 2_000;
 
 export class GPUMachineClient {
   private eventListeners: Map<GPUMachineEvent, Set<EventHandler>> = new Map();
@@ -35,6 +37,8 @@ export class GPUMachineClient {
   private videoTransceiver: RTCRtpTransceiver | undefined;
   private config: webrtc.WebRTCConfig;
   private pingInterval: ReturnType<typeof setInterval> | undefined;
+  private statsInterval: ReturnType<typeof setInterval> | undefined;
+  private stats: ConnectionStats | undefined;
 
   constructor(config: webrtc.WebRTCConfig) {
     this.config = config;
@@ -126,6 +130,7 @@ export class GPUMachineClient {
    */
   async disconnect(): Promise<void> {
     this.stopPing();
+    this.stopStatsPolling();
 
     if (this.publishedTrack) {
       await this.unpublishTrack();
@@ -312,6 +317,47 @@ export class GPUMachineClient {
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // Stats Polling (RTT)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  getStats(): ConnectionStats | undefined {
+    return this.stats;
+  }
+
+  private startStatsPolling(): void {
+    this.stopStatsPolling();
+    this.statsInterval = setInterval(async () => {
+      if (!this.peerConnection) return;
+      try {
+        const report = await this.peerConnection.getStats();
+        report.forEach((stat) => {
+          if (
+            stat.type === "candidate-pair" &&
+            stat.state === "succeeded" &&
+            stat.currentRoundTripTime !== undefined
+          ) {
+            this.stats = {
+              rtt: stat.currentRoundTripTime * 1000,
+              timestamp: Date.now(),
+            };
+            this.emit("statsUpdate", this.stats);
+          }
+        });
+      } catch {
+        // Silently ignore – connection may be closing
+      }
+    }, STATS_INTERVAL_MS);
+  }
+
+  private stopStatsPolling(): void {
+    if (this.statsInterval !== undefined) {
+      clearInterval(this.statsInterval);
+      this.statsInterval = undefined;
+    }
+    this.stats = undefined;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Private Helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
@@ -333,6 +379,7 @@ export class GPUMachineClient {
         switch (state) {
           case "connected":
             this.setStatus("connected");
+            this.startStatsPolling();
             break;
           case "disconnected":
           case "closed":

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -5,6 +5,7 @@ import {
   type ReactorError,
   type MessageScope,
   type ConnectOptions,
+  type ConnectionStats,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -318,6 +319,10 @@ export class Reactor {
         this.emit("streamChanged", track, stream);
       }
     );
+
+    this.machineClient.on("statsUpdate", (stats: ConnectionStats) => {
+      this.emit("statsUpdate", stats);
+    });
   }
 
   /**
@@ -414,6 +419,10 @@ export class Reactor {
    */
   getLastError(): ReactorError | undefined {
     return this.lastError;
+  }
+
+  getStats(): ConnectionStats | undefined {
+    return this.machineClient?.getStats();
   }
 
   /**

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -1,7 +1,8 @@
 import { useReactorStore } from "./ReactorProvider";
 import type { ReactorStore } from "../core/store";
+import type { ConnectionStats } from "../types";
 import { useShallow } from "zustand/shallow";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Generic hook for accessing selected parts of the Reactor store.
@@ -73,4 +74,28 @@ export function useReactorInternalMessage(
       reactor.off("runtimeMessage", stableHandler);
     };
   }, [reactor]);
+}
+
+/**
+ * Hook that returns the current connection stats (RTT, etc.).
+ * Updates every ~2s while connected. Returns undefined when disconnected.
+ */
+export function useStats(): ConnectionStats | undefined {
+  const reactor = useReactor((state) => state.internal.reactor);
+  const [stats, setStats] = useState<ConnectionStats | undefined>(undefined);
+
+  useEffect(() => {
+    const handler = (newStats: ConnectionStats) => {
+      setStats(newStats);
+    };
+
+    reactor.on("statsUpdate", handler);
+
+    return () => {
+      reactor.off("statsUpdate", handler);
+      setStats(undefined);
+    };
+  }, [reactor]);
+
+  return stats;
 }

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -41,6 +41,12 @@ export interface ConnectOptions {
   maxAttempts?: number;
 }
 
+export interface ConnectionStats {
+  /** ICE candidate-pair round-trip time in milliseconds */
+  rtt?: number;
+  timestamp: number;
+}
+
 export type ReactorEvent =
   | "statusChanged" //updates on the reactor status
   | "sessionIdChanged" //updates on the session ID.
@@ -48,4 +54,5 @@ export type ReactorEvent =
   | "runtimeMessage" //internal platform-level control messages (e.g. capabilities)
   | "streamChanged" //video stream has changed (LiveKit)
   | "error" //error events with ReactorError details
-  | "sessionExpirationChanged"; //session expiration has changed
+  | "sessionExpirationChanged" //session expiration has changed
+  | "statsUpdate"; //WebRTC stats update (RTT, etc.)

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -44,6 +44,16 @@ export interface ConnectOptions {
 export interface ConnectionStats {
   /** ICE candidate-pair round-trip time in milliseconds */
   rtt?: number;
+  /** ICE candidate type: "host", "srflx", "prflx", or "relay" (TURN) */
+  candidateType?: string;
+  /** Estimated available outgoing bitrate in bits/second */
+  availableOutgoingBitrate?: number;
+  /** Received video frames per second */
+  framesPerSecond?: number;
+  /** Ratio of packets lost (0-1) */
+  packetLossRatio?: number;
+  /** Network jitter in seconds (from inbound-rtp) */
+  jitter?: number;
   timestamp: number;
 }
 

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -4,7 +4,7 @@
  */
 
 import { IceServersResponse } from "../core/types";
-import type { MessageScope } from "../types";
+import type { MessageScope, ConnectionStats } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -289,4 +289,70 @@ export function isClosed(pc: RTCPeerConnection): boolean {
  */
 export function closePeerConnection(pc: RTCPeerConnection): void {
   pc.close();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats Extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extracts ConnectionStats from an RTCStatsReport.
+ * Reads candidate-pair, local-candidate, and inbound-rtp (video) reports.
+ */
+export function extractConnectionStats(
+  report: RTCStatsReport
+): ConnectionStats {
+  let rtt: number | undefined;
+  let availableOutgoingBitrate: number | undefined;
+  let localCandidateId: string | undefined;
+  let framesPerSecond: number | undefined;
+  let jitter: number | undefined;
+  let packetLossRatio: number | undefined;
+
+  report.forEach((stat) => {
+    if (stat.type === "candidate-pair" && stat.state === "succeeded") {
+      if (stat.currentRoundTripTime !== undefined) {
+        rtt = stat.currentRoundTripTime * 1000;
+      }
+      if (stat.availableOutgoingBitrate !== undefined) {
+        availableOutgoingBitrate = stat.availableOutgoingBitrate;
+      }
+      localCandidateId = stat.localCandidateId;
+    }
+
+    if (stat.type === "inbound-rtp" && stat.kind === "video") {
+      if (stat.framesPerSecond !== undefined) {
+        framesPerSecond = stat.framesPerSecond;
+      }
+      if (stat.jitter !== undefined) {
+        jitter = stat.jitter;
+      }
+      if (
+        stat.packetsReceived !== undefined &&
+        stat.packetsLost !== undefined &&
+        stat.packetsReceived + stat.packetsLost > 0
+      ) {
+        packetLossRatio =
+          stat.packetsLost / (stat.packetsReceived + stat.packetsLost);
+      }
+    }
+  });
+
+  let candidateType: string | undefined;
+  if (localCandidateId) {
+    const localCandidate = report.get(localCandidateId);
+    if (localCandidate?.candidateType) {
+      candidateType = localCandidate.candidateType;
+    }
+  }
+
+  return {
+    rtt,
+    candidateType,
+    availableOutgoingBitrate,
+    framesPerSecond,
+    packetLossRatio,
+    jitter,
+    timestamp: Date.now(),
+  };
 }


### PR DESCRIPTION
## Why

We need to measure client-side RTT (and eventually other WebRTC stats like jitter, packet loss, bitrate) when running models so we can monitor connection quality, debug latency issues, and surface network health to users.

## What

Adds internal WebRTC stats polling to the JS SDK, following the Agora/LiveKit pattern: poll `getStats()` every 2s, extract `currentRoundTripTime` from the succeeded ICE candidate-pair, and expose it reactively through a generalized `ConnectionStats` interface.

**Core plumbing:**
- `GPUMachineClient` polls `RTCPeerConnection.getStats()` on a 2s interval when connected, emits `"statsUpdate"` events with a `ConnectionStats` object
- `Reactor` forwards the event and exposes a `getStats()` getter for imperative access

**Consumer API:**
- `useStats()` React hook — subscribes to stats updates, returns `ConnectionStats | undefined`
- Stats are kept out of the Zustand store intentionally — they're diagnostic metrics, not core state. Only components that call `useStats()` pay the re-render cost
- `ConnectionStats` is designed to be extensible (add `jitter`, `packetLoss`, `bitrate` etc. without API changes)

**Usage:**
```tsx
import { useStats } from "@reactor-team/js-sdk";

const stats = useStats();
// stats?.rtt       — RTT in ms, updates ~2s
// stats?.timestamp — when this measurement was taken
```

## Files changed

| File | Change |
|------|--------|
| `types.ts` | `ConnectionStats` interface, `"statsUpdate"` event |
| `core/GPUMachineClient.ts` | Stats polling interval, `getStats()` getter |
| `core/Reactor.ts` | Forward event, `getStats()` getter |
| `react/hooks.ts` | `useStats()` hook |