### PR TITLE
[REA-888] Hide MessageScope from API for easier DX

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -285,9 +285,11 @@ export class Reactor {
     if (!this.machineClient) return;
 
     this.machineClient.on("message", (message: any, scope: MessageScope) => {
-      // The outer envelope has already been stripped by GPUMachineClient.
-      // Forward the inner payload along with its scope to consumers.
-      this.emit("newMessage", message, scope);
+      if (scope === "application") {
+        this.emit("message", message);
+      } else if (scope === "runtime") {
+        this.emit("runtimeMessage", message);
+      }
     });
 
     this.machineClient.on("statusChanged", (status: GPUMachineStatus) => {

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -138,13 +138,11 @@ export const createReactorStore = (
       onMessage: (handler: (message: any) => void) => {
         console.debug("[ReactorStore] Registering message handler");
 
-        // Simply register the handler
-        get().internal.reactor.on("newMessage", handler);
+        get().internal.reactor.on("message", handler);
 
-        // Return a cleanup function that can be called to unregister
         return () => {
           console.debug("[ReactorStore] Cleaning up message handler");
-          get().internal.reactor.off("newMessage", handler);
+          get().internal.reactor.off("message", handler);
         };
       },
       sendCommand: async (command: string, data: any, scope?: MessageScope) => {

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useReactor, useReactorMessage } from "./hooks";
-import type { MessageScope } from "../types";
+import { useReactor, useReactorInternalMessage } from "./hooks";
 import React, { useState, useCallback } from "react";
 
 export interface ReactorControllerProps {
@@ -81,11 +80,8 @@ export function ReactorController({
     return () => clearInterval(interval);
   }, [status, commands, requestCapabilities]);
 
-  useReactorMessage((message, scope) => {
-    // Capabilities arrive on the "runtime" scope as
-    // { type: "modelCapabilities", data: { commands: {...} } }
+  useReactorInternalMessage((message) => {
     if (
-      scope === "runtime" &&
       message &&
       typeof message === "object" &&
       message.type === "modelCapabilities" &&

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -21,9 +21,7 @@ export function useReactor<T>(selector: (state: ReactorStore) => T): T {
  *
  * @param handler - Callback invoked with each application message payload.
  */
-export function useReactorMessage(
-  handler: (message: any) => void
-): void {
+export function useReactorMessage(handler: (message: any) => void): void {
   const reactor = useReactor((state) => state.internal.reactor);
   const handlerRef = useRef(handler);
 

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -1,6 +1,5 @@
 import { useReactorStore } from "./ReactorProvider";
 import type { ReactorStore } from "../core/store";
-import type { MessageScope } from "../types";
 import { useShallow } from "zustand/shallow";
 import { useEffect, useRef } from "react";
 
@@ -15,46 +14,65 @@ export function useReactor<T>(selector: (state: ReactorStore) => T): T {
 }
 
 /**
- * Hook for handling message subscriptions with proper React lifecycle management.
+ * Hook for receiving model application messages.
  *
- * The handler receives the message payload and the scope it arrived on:
- *   - "application" for model-defined messages (via get_ctx().send())
- *   - "runtime" for platform-level messages (e.g., capabilities response)
+ * Only fires for messages sent by the model via `get_ctx().send()`.
+ * Internal platform-level messages (e.g. capabilities) are NOT delivered here.
  *
- * @param handler - The message handler function (message, scope)
+ * @param handler - Callback invoked with each application message payload.
  */
 export function useReactorMessage(
-  handler: (message: any, scope: MessageScope) => void
+  handler: (message: any) => void
 ): void {
   const reactor = useReactor((state) => state.internal.reactor);
   const handlerRef = useRef(handler);
 
-  // Update the ref when handler changes
   useEffect(() => {
     handlerRef.current = handler;
   }, [handler]);
 
   useEffect(() => {
-    console.debug("[useReactorMessage] Setting up message subscription");
-
-    // Create a stable handler that calls the current ref
-    const stableHandler = (message: any, scope: MessageScope) => {
-      console.debug("[useReactorMessage] Message received", {
-        message,
-        scope,
-      });
-      handlerRef.current(message, scope);
+    const stableHandler = (message: any) => {
+      handlerRef.current(message);
     };
 
-    // Register the handler and get the cleanup function
-    reactor.on("newMessage", stableHandler);
+    reactor.on("message", stableHandler);
 
-    console.debug("[useReactorMessage] Message handler registered");
-
-    // Return the cleanup function
     return () => {
-      console.debug("[useReactorMessage] Cleaning up message subscription");
-      reactor.off("newMessage", stableHandler);
+      reactor.off("message", stableHandler);
+    };
+  }, [reactor]);
+}
+
+/**
+ * Hook for receiving internal platform-level (runtime) messages.
+ *
+ * This is intended for advanced use cases that need access to the runtime
+ * control layer, such as capabilities negotiation. Model application messages
+ * sent via `get_ctx().send()` are NOT delivered through this hook — use
+ * {@link useReactorMessage} for those.
+ *
+ * @param handler - Callback invoked with each runtime message payload.
+ */
+export function useReactorInternalMessage(
+  handler: (message: any) => void
+): void {
+  const reactor = useReactor((state) => state.internal.reactor);
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const stableHandler = (message: any) => {
+      handlerRef.current(message);
+    };
+
+    reactor.on("runtimeMessage", stableHandler);
+
+    return () => {
+      reactor.off("runtimeMessage", stableHandler);
     };
   }, [reactor]);
 }

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -44,7 +44,8 @@ export interface ConnectOptions {
 export type ReactorEvent =
   | "statusChanged" //updates on the reactor status
   | "sessionIdChanged" //updates on the session ID.
-  | "newMessage" //new messages from the machine (coordinator handled internally)
+  | "message" //application-scoped messages from the model
+  | "runtimeMessage" //internal platform-level control messages (e.g. capabilities)
   | "streamChanged" //video stream has changed (LiveKit)
   | "error" //error events with ReactorError details
   | "sessionExpirationChanged"; //session expiration has changed


### PR DESCRIPTION
Why
---
Developers building on the SDK should not need to understand or filter
by MessageScope. The only consumers of runtime-scoped messages are
internal SDK components (e.g. ReactorController for capabilities).

What Changed
---
- useReactorMessage now only fires for application messages; handler
  signature simplified from (message, scope) to (message).
- Added useReactorInternalMessage for runtime/platform-level messages,
  with docs clarifying model messages do not flow through it.
- Replaced the single "newMessage" event with "message" (application)
  and "runtimeMessage" (runtime) on the Reactor event emitter.
- ReactorController switched to useReactorInternalMessage.
- Store onMessage action updated to use the new "message" event.
- Added js doc to clearly explain that the useReactorInternalMessage is for INTERNAL messages.

Example API Usage
---
```tsx
// Application messages (default — what most developers use)
useReactorMessage((message) => {
  console.log("Model says:", message);
});

// Internal/runtime messages (power-user, e.g. capabilities)
useReactorInternalMessage((message) => {
  if (message.type === "modelCapabilities") { ... }
});
```

topic: REA-888-hide-messagescope-from-api
reviewers: bryce, ahmed