### PR TITLE
[REA-694] Set track names as MIDs in SDP offer, use MID for receive matching

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -47,8 +47,6 @@ export class GPUMachineClient {
 
   private transceiverMap: Map<string, TransceiverEntry> = new Map();
   private publishedTracks: Map<string, MediaStreamTrack> = new Map();
-  private receiveTrackNames: string[] = [];
-  private receiveTrackIndex: number = 0;
   private statsInterval: ReturnType<typeof setInterval> | undefined;
   private stats: ConnectionStats | undefined;
 
@@ -105,8 +103,6 @@ export class GPUMachineClient {
     this.setupDataChannelHandlers();
 
     this.transceiverMap.clear();
-    this.receiveTrackNames = [];
-    this.receiveTrackIndex = 0;
 
     const entries = this.buildTransceiverEntries(tracks);
 
@@ -117,17 +113,14 @@ export class GPUMachineClient {
       entry.transceiver = transceiver;
       this.transceiverMap.set(entry.name, entry);
 
-      if (entry.direction === "recvonly" || entry.direction === "sendrecv") {
-        this.receiveTrackNames.push(entry.name);
-      }
-
       console.debug(
         `[GPUMachineClient] Transceiver added: "${entry.name}" (${entry.kind}, ${entry.direction})`
       );
     }
 
-    const offer = await webrtc.createOffer(this.peerConnection);
-    console.debug("[GPUMachineClient] Created SDP offer");
+    const trackNames = entries.map((e) => e.name);
+    const offer = await webrtc.createOffer(this.peerConnection, trackNames);
+    console.debug("[GPUMachineClient] Created SDP offer with MIDs:", trackNames);
     return offer;
   }
 
@@ -206,8 +199,6 @@ export class GPUMachineClient {
     }
 
     this.transceiverMap.clear();
-    this.receiveTrackNames = [];
-    this.receiveTrackIndex = 0;
     this.setStatus("disconnected");
     console.debug("[GPUMachineClient] Disconnected");
   }
@@ -458,14 +449,11 @@ export class GPUMachineClient {
     };
 
     this.peerConnection.ontrack = (event) => {
-      const trackName =
-        this.receiveTrackIndex < this.receiveTrackNames.length
-          ? this.receiveTrackNames[this.receiveTrackIndex]
-          : `unknown-${this.receiveTrackIndex}`;
-      this.receiveTrackIndex++;
+      const mid = event.transceiver.mid;
+      const trackName = mid ?? `unknown-${event.track.id}`;
 
       console.debug(
-        `[GPUMachineClient] Track received: "${trackName}" (${event.track.kind})`
+        `[GPUMachineClient] Track received: "${trackName}" (${event.track.kind}, mid=${mid})`
       );
       const stream = event.streams[0] ?? new MediaStream([event.track]);
       this.emit("trackReceived", trackName, event.track, stream);

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -50,12 +50,73 @@ export function createDataChannel(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Rewrites the `a=mid:` values in an SDP string so that each media
+ * transceiver uses the corresponding track name as its MID.
+ *
+ * The data-channel `m=application` section is left untouched.
+ * The `a=group:BUNDLE` line is updated to reflect the new MIDs.
+ */
+export function rewriteMids(sdp: string, trackNames: string[]): string {
+  const lines = sdp.split("\r\n");
+  let mediaIdx = 0;
+  const replacements = new Map<string, string>();
+  let inApplication = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("m=")) {
+      inApplication = lines[i].startsWith("m=application");
+    }
+    if (!inApplication && lines[i].startsWith("a=mid:")) {
+      const oldMid = lines[i].substring("a=mid:".length);
+      if (mediaIdx < trackNames.length) {
+        const newMid = trackNames[mediaIdx];
+        replacements.set(oldMid, newMid);
+        lines[i] = `a=mid:${newMid}`;
+        mediaIdx++;
+      }
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("a=group:BUNDLE ")) {
+      const parts = lines[i].split(" ");
+      for (let j = 1; j < parts.length; j++) {
+        const replacement = replacements.get(parts[j]);
+        if (replacement !== undefined) {
+          parts[j] = replacement;
+        }
+      }
+      lines[i] = parts.join(" ");
+      break;
+    }
+  }
+
+  return lines.join("\r\n");
+}
+
+/**
  * Creates an SDP offer on the peer connection.
+ *
+ * When `trackNames` is provided, the media MIDs in the SDP are
+ * rewritten to use those names before `setLocalDescription` is called.
+ * This allows the remote side to identify transceivers by name rather
+ * than by positional index.
+ *
  * Waits for ICE gathering to complete before returning.
  */
-export async function createOffer(pc: RTCPeerConnection): Promise<string> {
+export async function createOffer(
+  pc: RTCPeerConnection,
+  trackNames?: string[]
+): Promise<string> {
   const offer = await pc.createOffer();
-  await pc.setLocalDescription(offer);
+
+  if (trackNames && trackNames.length > 0 && offer.sdp) {
+    const munged = rewriteMids(offer.sdp, trackNames);
+    const mungedOffer = new RTCSessionDescription({ type: "offer", sdp: munged });
+    await pc.setLocalDescription(mungedOffer);
+  } else {
+    await pc.setLocalDescription(offer);
+  }
 
   await waitForIceGathering(pc);
 


### PR DESCRIPTION
Why
---
The JS-SDK matched received tracks to declared names positionally — a
sequential `receiveTrackIndex` counter was incremented on each
`ontrack` event and used to index into the ordered
`receiveTrackNames` array. This assumed `ontrack` fires in the exact
transceiver declaration order. It also meant the runtime had no way
to know which transceiver corresponds to which named track; both
sides relied on matching order by convention.

By writing track names directly into the SDP as MID values, the
runtime can read `transceiver.mid` after `setRemoteDescription` and
build a name-keyed dictionary — no positional coupling needed.

What Changed
---
- **`webrtc.ts`**: added `rewriteMids(sdp, trackNames)` that
  replaces auto-assigned numeric MIDs on media m=sections with the
  declared track names (skipping the data-channel `m=application`
  section) and updates the `a=group:BUNDLE` line. `createOffer()`
  now accepts an optional `trackNames` array and munges the SDP
  before `setLocalDescription`.

- **`GPUMachineClient.ts`**:
  - Removed `receiveTrackNames` array and `receiveTrackIndex`
    counter.
  - `createOffer()` passes `entries.map(e => e.name)` to
    `webrtc.createOffer()` so the SDP carries named MIDs.
  - `ontrack` handler reads `event.transceiver.mid` directly as the
    track name instead of using a sequential counter.

topic: REA-694-add-mid-multi-track-support
relative: REA-694-update-react-components-for-named-track-api
reviewers: bryce, douglas