### PR TITLE
[REA-694] Align external SDK API with multi-track specification

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -1,12 +1,13 @@
 /**
  * Handles the direct WebRTC connection to a GPU machine instance.
  *
- * Transceivers are created from the declared {@link TracksConfig} and
- * keyed by track name so that publish/unpublish/receive all route by name.
+ * Transceivers are created from the declared `receive` and `send` track
+ * arrays and keyed by track name so that publish/unpublish/receive all
+ * route by name.
  */
 
 import * as webrtc from "../utils/webrtc";
-import type { MessageScope, TracksConfig, ConnectionStats } from "../types";
+import type { MessageScope, TrackConfig, ConnectionStats } from "../types";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -80,15 +81,18 @@ export class GPUMachineClient {
   /**
    * Creates an SDP offer based on the declared tracks.
    *
-   * Transceivers are added in a deterministic order:
-   * 1. Tracks that appear in both `receive` and `send` → `sendrecv`
-   * 2. Receive-only tracks → `recvonly`
-   * 3. Send-only tracks → `sendonly`
+   * **RECEIVE** = client receives from the model (model → client) → `recvonly`
+   * **SEND**    = client sends to the model (client → model)     → `sendonly`
+   *
+   * A track name in both arrays negotiates a single `sendrecv` transceiver.
    *
    * The data channel is always created first (before transceivers).
    * Must be called before connect().
    */
-  async createOffer(tracks: TracksConfig): Promise<string> {
+  async createOffer(tracks: {
+    send: TrackConfig[];
+    receive: TrackConfig[];
+  }): Promise<string> {
     // Create peer connection if not exists
     if (!this.peerConnection) {
       this.peerConnection = webrtc.createPeerConnection(this.config);
@@ -120,15 +124,21 @@ export class GPUMachineClient {
 
     const trackNames = entries.map((e) => e.name);
     const offer = await webrtc.createOffer(this.peerConnection, trackNames);
-    console.debug("[GPUMachineClient] Created SDP offer with MIDs:", trackNames);
+    console.debug(
+      "[GPUMachineClient] Created SDP offer with MIDs:",
+      trackNames
+    );
     return offer;
   }
 
   /**
-   * Builds an ordered list of transceiver entries from the tracks config.
-   * Merges send+receive entries that share a name into sendrecv.
+   * Builds an ordered list of transceiver entries from the receive/send arrays.
+   * Merges send+receive entries that share a name into a single sendrecv entry.
    */
-  private buildTransceiverEntries(tracks: TracksConfig): TransceiverEntry[] {
+  private buildTransceiverEntries(tracks: {
+    send: TrackConfig[];
+    receive: TrackConfig[];
+  }): TransceiverEntry[] {
     const map = new Map<string, TransceiverEntry>();
 
     for (const t of tracks.receive) {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -5,7 +5,7 @@ import {
   type ReactorError,
   type MessageScope,
   type ConnectOptions,
-  type TracksConfig,
+  type TrackConfig,
   type ConnectionStats,
   ConflictError,
 } from "../types";
@@ -22,21 +22,22 @@ const TrackConfigSchema = z.object({
   kind: z.enum(["audio", "video"]),
 });
 
-const TracksConfigSchema = z.object({
-  send: z.array(TrackConfigSchema).default([]),
-  receive: z.array(TrackConfigSchema).default([]),
-});
-
-const DEFAULT_TRACKS: TracksConfig = {
-  send: [],
-  receive: [{ name: "video-0", kind: "video" }],
-};
-
 const OptionsSchema = z.object({
   coordinatorUrl: z.string().default(PROD_COORDINATOR_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
-  tracks: TracksConfigSchema.default(DEFAULT_TRACKS),
+  /**
+   * Tracks the client **RECEIVES** from the model (model → client).
+   * Each entry produces a `recvonly` transceiver (or `sendrecv` if the
+   * same name also appears in `send`).
+   */
+  receive: z.array(TrackConfigSchema).default([]),
+  /**
+   * Tracks the client **SENDS** to the model (client → model).
+   * Each entry produces a `sendonly` transceiver (or `sendrecv` if the
+   * same name also appears in `receive`).
+   */
+  send: z.array(TrackConfigSchema).default([]),
 });
 export type Options = z.input<typeof OptionsSchema>;
 
@@ -51,7 +52,10 @@ export class Reactor {
   private model: string;
   private sessionExpiration?: number;
   private local: boolean;
-  private tracks: TracksConfig;
+  /** Tracks the client RECEIVES from the model (model → client). */
+  private receive: TrackConfig[];
+  /** Tracks the client SENDS to the model (client → model). */
+  private send: TrackConfig[];
   private sessionId?: string;
 
   constructor(options: Options) {
@@ -61,7 +65,8 @@ export class Reactor {
     // TODO(REA-146) Properly accept version from parameter.
     this.model = validatedOptions.modelName;
     this.local = validatedOptions.local;
-    this.tracks = validatedOptions.tracks;
+    this.receive = validatedOptions.receive;
+    this.send = validatedOptions.send;
     if (this.local) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
     }
@@ -190,8 +195,10 @@ export class Reactor {
       this.setupMachineClientHandlers();
     }
 
-    // We always calculate a new offer for reconnection.
-    const sdpOffer = await this.machineClient.createOffer(this.tracks);
+    const sdpOffer = await this.machineClient.createOffer({
+      send: this.send,
+      receive: this.receive,
+    });
 
     // Send offer to coordinator and get answer.
     try {
@@ -259,7 +266,10 @@ export class Reactor {
       this.machineClient = new GPUMachineClient({ iceServers });
       this.setupMachineClientHandlers();
 
-      const sdpOffer = await this.machineClient.createOffer(this.tracks);
+      const sdpOffer = await this.machineClient.createOffer({
+        send: this.send,
+        receive: this.receive,
+      });
 
       // Create session passing SDP offer. We will get the answer polling the sdp_offer endpoint.
       const sessionId = await this.coordinatorClient.createSession(sdpOffer);

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -13,7 +13,13 @@ export type ReactorStoreApi = ReturnType<typeof createReactorStore>;
 
 export interface ReactorState {
   status: ReactorStatus;
-  receivedTracks: Record<string, MediaStreamTrack>;
+  /**
+   * Media tracks received from the model, keyed by track name.
+   *
+   * Each entry maps a declared **receive** track name (e.g. `"main_video"`,
+   * `"main_audio"`) to the live `MediaStreamTrack` delivered by the model.
+   */
+  tracks: Record<string, MediaStreamTrack>;
   lastError?: ReactorError;
   sessionId?: string;
   sessionExpiration?: number;
@@ -51,7 +57,7 @@ export type ReactorStore = ReactorState &
 // In the second case, you pass the auth information directly into the function in the Reactor core.
 export const defaultInitState: ReactorState = {
   status: "disconnected",
-  receivedTracks: {},
+  tracks: {},
   lastError: undefined,
   sessionExpiration: undefined,
   jwtToken: undefined,
@@ -112,7 +118,7 @@ export const createReactorStore = (
         kind: track.kind,
         id: track.id,
       });
-      set({ receivedTracks: { ...get().receivedTracks, [name]: track } });
+      set({ tracks: { ...get().tracks, [name]: track } });
     });
 
     reactor.on("error", (error: ReactorError) => {

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -57,7 +57,7 @@ export function ReactorProvider({
   // Destructure connectOptions with defaults
   const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
-  const { coordinatorUrl, modelName, local, tracks } = props;
+  const { coordinatorUrl, modelName, local, receive, send } = props;
   const maxAttempts = pollingOptions.maxAttempts;
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
@@ -134,7 +134,8 @@ export function ReactorProvider({
         coordinatorUrl,
         modelName,
         local,
-        tracks,
+        receive,
+        send,
         jwtToken,
       } satisfies ReactorInitializationProps)
     );
@@ -184,7 +185,8 @@ export function ReactorProvider({
     modelName,
     autoConnect,
     local,
-    tracks,
+    receive,
+    send,
     jwtToken,
     maxAttempts,
   ]);

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -5,9 +5,15 @@ import { useEffect, useMemo, useRef } from "react";
 import React from "react";
 
 export interface ReactorViewProps {
-  /** The name of the video track to render. Defaults to "video-0". */
-  track?: string;
-  /** Optional: the name of an audio track to play alongside the video (e.g. "audio-0"). */
+  /**
+   * The name of the **receive** track to render.
+   * Must match a track name declared in the `receive` array (model → client).
+   */
+  track: string;
+  /**
+   * Optional name of a **receive** audio track to play alongside the video
+   * (e.g. `"main_audio"`).  The audio is mixed into the same `<video>` element.
+   */
   audioTrack?: string;
   width?: number;
   height?: number;
@@ -21,7 +27,7 @@ export interface ReactorViewProps {
 }
 
 export function ReactorView({
-  track = "video-0",
+  track,
   audioTrack,
   width,
   height,
@@ -31,10 +37,8 @@ export function ReactorView({
   muted = true,
 }: ReactorViewProps) {
   const { videoMediaTrack, audioMediaTrack, status } = useReactor((state) => ({
-    videoMediaTrack: state.receivedTracks[track] ?? null,
-    audioMediaTrack: audioTrack
-      ? (state.receivedTracks[audioTrack] ?? null)
-      : null,
+    videoMediaTrack: state.tracks[track] ?? null,
+    audioMediaTrack: audioTrack ? (state.tracks[audioTrack] ?? null) : null,
     status: state.status,
   }));
 

--- a/packages/js-sdk/src/react/WebcamStream.tsx
+++ b/packages/js-sdk/src/react/WebcamStream.tsx
@@ -5,8 +5,11 @@ import { useEffect, useRef, useState } from "react";
 import React from "react";
 
 export interface WebcamStreamProps {
-  /** The name of the send track to publish the webcam to. Defaults to "webcam". */
-  track?: string;
+  /**
+   * The name of the **send** track to publish the webcam to.
+   * Must match a track name declared in the `send` array (client → model).
+   */
+  track: string;
   className?: string;
   style?: React.CSSProperties;
   videoConstraints?: MediaTrackConstraints;
@@ -17,7 +20,7 @@ export interface WebcamStreamProps {
 }
 
 export function WebcamStream({
-  track = "webcam",
+  track,
   className,
   style,
   videoConstraints = {

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
 export type ReactorStatus =
   | "disconnected" // Not connected to anything
   | "connecting" // Establishing connection to coordinator
@@ -13,6 +15,13 @@ export type MessageScope = "application" | "runtime";
 
 /**
  * Describes a single named media track for SDP negotiation.
+ *
+ * Track names must exactly match the class attribute names defined on the
+ * model's Python code.  The name is encoded as the SDP MID so both sides
+ * can route media by name rather than by positional index.
+ *
+ * Use the {@link video} and {@link audio} helper functions to create
+ * instances instead of constructing this interface directly.
  */
 export interface TrackConfig {
   name: string;
@@ -20,16 +29,69 @@ export interface TrackConfig {
 }
 
 /**
- * Declares the media tracks for a Reactor session.
- *
- * - `send`: tracks the client publishes towards the model.
- * - `receive`: tracks the client receives from the model.
- *
- * Tracks appear in the SDP offer in declaration order.
+ * Optional configuration for a video track (reserved for future use).
  */
-export interface TracksConfig {
-  send: TrackConfig[];
-  receive: TrackConfig[];
+export interface VideoTrackOptions {
+  /** Maximum framerate constraint for the video track. */
+  maxFramerate?: number;
+}
+
+/**
+ * Optional configuration for an audio track (reserved for future use).
+ */
+export interface AudioTrackOptions {
+  /** Sample rate constraint for the audio track. */
+  sampleRate?: number;
+}
+
+/**
+ * Creates a **video** {@link TrackConfig}.
+ *
+ * A track declared in the **`receive`** array means the client will
+ * **RECEIVE** video frames **from the model** (model → client).
+ *
+ * A track declared in the **`send`** array means the client will
+ * **SEND** video frames **to the model** (client → model).
+ *
+ * If the same name appears in both `receive` and `send`, a single
+ * bidirectional (`sendrecv`) WebRTC transceiver is negotiated.
+ *
+ * @param name    - The track name.  Must match the model's declared track attribute name.
+ * @param options - Reserved for future constraints (e.g. `maxFramerate`).
+ *
+ * @example
+ * ```ts
+ * receive: [video("main_video")]          // receive video from the model
+ * send:    [video("webcam")]              // send webcam video to the model
+ * ```
+ */
+export function video(name: string, _options?: VideoTrackOptions): TrackConfig {
+  return { name, kind: "video" };
+}
+
+/**
+ * Creates an **audio** {@link TrackConfig}.
+ *
+ * A track declared in the **`receive`** array means the client will
+ * **RECEIVE** audio samples **from the model** (model → client).
+ *
+ * A track declared in the **`send`** array means the client will
+ * **SEND** audio samples **to the model** (client → model).
+ *
+ * If the same name appears in both `receive` and `send`, a single
+ * bidirectional (`sendrecv`) WebRTC transceiver is negotiated.
+ *
+ * @param name    - The track name.  Must match the model's declared track attribute name.
+ * @param options - Reserved for future constraints (e.g. `sampleRate`).
+ *
+ * @example
+ * ```ts
+ * receive: [audio("main_audio")]          // receive audio from the model
+ * send:    [audio("mic")]                 // send microphone audio to the model
+ * ```
+ */
+export function audio(name: string, _options?: AudioTrackOptions): TrackConfig {
+  return { name, kind: "audio" };
 }
 
 export interface ReactorError {
@@ -81,7 +143,7 @@ export type ReactorEvent =
   | "sessionIdChanged" //updates on the session ID.
   | "message" //application-scoped messages from the model
   | "runtimeMessage" //internal platform-level control messages (e.g. capabilities)
-  | "trackReceived"  // (name: string, track: MediaStreamTrack, stream: MediaStream)
+  | "trackReceived" // (name: string, track: MediaStreamTrack, stream: MediaStream)
   | "error" //error events with ReactorError details
   | "sessionExpirationChanged" //session expiration has changed
   | "statsUpdate"; //WebRTC stats update (RTT, etc.)

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -112,7 +112,10 @@ export async function createOffer(
 
   if (trackNames && trackNames.length > 0 && offer.sdp) {
     const munged = rewriteMids(offer.sdp, trackNames);
-    const mungedOffer = new RTCSessionDescription({ type: "offer", sdp: munged });
+    const mungedOffer = new RTCSessionDescription({
+      type: "offer",
+      sdp: munged,
+    });
     await pc.setLocalDescription(mungedOffer);
   } else {
     await pc.setLocalDescription(offer);


### PR DESCRIPTION
Why
---
The SDK's external API used a nested `tracks: { send, receive }` object,
which diverges from the multi-track runtime proposal (Section 6.2). This
PR flattens the API to top-level `receive` and `send` arrays and adds
`video()` / `audio()` helper functions so the client-side declaration
mirrors the model-side track attribute pattern.

What Changed
---
- **`types.ts`** — Removed `TracksConfig` interface. Added `video(name)`
  and `audio(name)` factory helpers with `VideoTrackOptions` /
  `AudioTrackOptions` reserved for future constraints. Extensive JSDoc
  clarifying that **SEND = client → model** and **RECEIVE = model → client**.
- **`Reactor.ts`** — Constructor options now accept top-level `receive`
  and `send` arrays (both default to `[]`) instead of `tracks`.
- **`GPUMachineClient.ts`** — Imports `TrackConfig` instead of
  `TracksConfig`; `createOffer` / `buildTransceiverEntries` accept
  `{ send, receive }` inline.
- **`store.ts`** — Renamed `receivedTracks` → `tracks` in the Zustand
  store state to match the spec.
- **`ReactorProvider.tsx`** — Destructures `receive` / `send` instead of
  `tracks` from props; updated dependency array.
- **`ReactorView.tsx`** — `track` prop is now **required** (no default);
  reads from `state.tracks`.
- **`WebcamStream.tsx`** — `track` prop is now **required** (no default).

No backwards compatibility is maintained — this is a breaking change.

Code Example
---
```tsx
import { video, audio, ReactorProvider, ReactorView } from "@reactor-team/js-sdk";

<ReactorProvider
  modelName="brightness-template"
  receive={[video("main_video"), audio("main_audio")]}
  send={[video("webcam")]}
>
  <ReactorView track="main_video" audioTrack="main_audio" />
  <WebcamStream track="webcam" />
</ReactorProvider>
```

topic: REA-694-update-api-to-match-spec
relative: REA-694-add-mid-multi-track-support
reviewers: bryce, douglas