### PR TITLE
[REA-694] Remove bidirectional (sendrecv) track support from SDK

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -84,7 +84,8 @@ export class GPUMachineClient {
    * **RECEIVE** = client receives from the model (model → client) → `recvonly`
    * **SEND**    = client sends to the model (client → model)     → `sendonly`
    *
-   * A track name in both arrays negotiates a single `sendrecv` transceiver.
+   * Track names must be unique across both arrays. A name that appears in
+   * both `receive` and `send` will throw — use distinct names instead.
    *
    * The data channel is always created first (before transceivers).
    * Must be called before connect().
@@ -133,7 +134,10 @@ export class GPUMachineClient {
 
   /**
    * Builds an ordered list of transceiver entries from the receive/send arrays.
-   * Merges send+receive entries that share a name into a single sendrecv entry.
+   *
+   * Each track produces exactly one transceiver — `recvonly` for receive,
+   * `sendonly` for send.  Bidirectional (`sendrecv`) transceivers are not
+   * supported; the same track name in both arrays is an error.
    */
   private buildTransceiverEntries(tracks: {
     send: TrackConfig[];
@@ -142,16 +146,23 @@ export class GPUMachineClient {
     const map = new Map<string, TransceiverEntry>();
 
     for (const t of tracks.receive) {
+      if (map.has(t.name)) {
+        throw new Error(
+          `Duplicate receive track name "${t.name}". Track names must be unique.`
+        );
+      }
       map.set(t.name, { name: t.name, kind: t.kind, direction: "recvonly" });
     }
 
     for (const t of tracks.send) {
-      const existing = map.get(t.name);
-      if (existing) {
-        existing.direction = "sendrecv";
-      } else {
-        map.set(t.name, { name: t.name, kind: t.kind, direction: "sendonly" });
+      if (map.has(t.name)) {
+        throw new Error(
+          `Track name "${t.name}" appears in both receive and send. ` +
+            `Bidirectional tracks are not supported — use distinct names ` +
+            `for the inbound and outbound directions (e.g. "${t.name}_in" and "${t.name}_out").`
+        );
       }
+      map.set(t.name, { name: t.name, kind: t.kind, direction: "sendonly" });
     }
 
     return Array.from(map.values());

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -30,8 +30,13 @@ const OptionsSchema = z.object({
    * Tracks the client **RECEIVES** from the model (model → client).
    * Each entry produces a `recvonly` transceiver.
    * Names must be unique across both `receive` and `send`.
+   *
+   * When omitted, defaults to a single video track named `"main_video"`.
+   * Pass an explicit empty array to opt out of the default.
    */
-  receive: z.array(TrackConfigSchema).default([]),
+  receive: z
+    .array(TrackConfigSchema)
+    .default([{ name: "main_video", kind: "video" }]),
   /**
    * Tracks the client **SENDS** to the model (client → model).
    * Each entry produces a `sendonly` transceiver.

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -28,14 +28,14 @@ const OptionsSchema = z.object({
   local: z.boolean().default(false),
   /**
    * Tracks the client **RECEIVES** from the model (model → client).
-   * Each entry produces a `recvonly` transceiver (or `sendrecv` if the
-   * same name also appears in `send`).
+   * Each entry produces a `recvonly` transceiver.
+   * Names must be unique across both `receive` and `send`.
    */
   receive: z.array(TrackConfigSchema).default([]),
   /**
    * Tracks the client **SENDS** to the model (client → model).
-   * Each entry produces a `sendonly` transceiver (or `sendrecv` if the
-   * same name also appears in `receive`).
+   * Each entry produces a `sendonly` transceiver.
+   * Names must be unique across both `receive` and `send`.
    */
   send: z.array(TrackConfigSchema).default([]),
 });

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -98,7 +98,11 @@ export const createReactorStore = (
         oldStatus: get().status,
         newStatus,
       });
-      set({ status: newStatus });
+      if (newStatus === "disconnected") {
+        set({ status: newStatus, tracks: {} });
+      } else {
+        set({ status: newStatus });
+      }
     });
 
     reactor.on(

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -8,8 +8,9 @@ export interface ReactorViewProps {
   /**
    * The name of the **receive** track to render.
    * Must match a track name declared in the `receive` array (model → client).
+   * Defaults to `"main_video"`.
    */
-  track: string;
+  track?: string;
   /**
    * Optional name of a **receive** audio track to play alongside the video
    * (e.g. `"main_audio"`).  The audio is mixed into the same `<video>` element.
@@ -27,7 +28,7 @@ export interface ReactorViewProps {
 }
 
 export function ReactorView({
-  track,
+  track = "main_video",
   audioTrack,
   width,
   height,

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -53,8 +53,8 @@ export interface AudioTrackOptions {
  * A track declared in the **`send`** array means the client will
  * **SEND** video frames **to the model** (client → model).
  *
- * If the same name appears in both `receive` and `send`, a single
- * bidirectional (`sendrecv`) WebRTC transceiver is negotiated.
+ * Track names must be unique across both arrays — the same name cannot
+ * appear in `receive` and `send`.
  *
  * @param name    - The track name.  Must match the model's declared track attribute name.
  * @param options - Reserved for future constraints (e.g. `maxFramerate`).
@@ -78,8 +78,8 @@ export function video(name: string, _options?: VideoTrackOptions): TrackConfig {
  * A track declared in the **`send`** array means the client will
  * **SEND** audio samples **to the model** (client → model).
  *
- * If the same name appears in both `receive` and `send`, a single
- * bidirectional (`sendrecv`) WebRTC transceiver is negotiated.
+ * Track names must be unique across both arrays — the same name cannot
+ * appear in `receive` and `send`.
  *
  * @param name    - The track name.  Must match the model's declared track attribute name.
  * @param options - Reserved for future constraints (e.g. `sampleRate`).

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -59,6 +59,9 @@ export interface AudioTrackOptions {
  * @param name    - The track name.  Must match the model's declared track attribute name.
  * @param options - Reserved for future constraints (e.g. `maxFramerate`).
  *
+ * When no `receive` array is provided to the Reactor constructor, a single
+ * `video("main_video")` track is used by default.
+ *
  * @example
  * ```ts
  * receive: [video("main_video")]          // receive video from the model


### PR DESCRIPTION
Why
---
`sendrecv` is a WebRTC-specific concept that doesn't map to other
transports.  Model developers think in terms of "tracks in" and
"tracks out" — bidirectional is extra cognitive overhead with no real
benefit.  Keeping send and receive strictly separate gives clearer
code structure (distinct inbound/outbound track objects) and a simpler
mental model across both the SDKs and the runtime.

What Changed
---
- **`GPUMachineClient.ts`** — `buildTransceiverEntries()` now throws
  if a track name appears in both `receive` and `send` instead of
  merging into a `sendrecv` transceiver.  Duplicate names within
  `receive` also error.  JSDoc on `createOffer()` updated.
- **`types.ts`** — `video()` / `audio()` JSDoc: replaced the
  bidirectional paragraph with "names must be unique across both
  arrays".
- **`Reactor.ts`** — JSDoc on `receive` / `send` Zod fields: removed
  `(or sendrecv if …)` note, added uniqueness constraint.

Code Example
---
```ts
// ERROR — same name in both arrays
new Reactor({
  receive: [video("webcam")],
  send:    [video("webcam")],  // throws
});

// Correct — distinct names per direction
new Reactor({
  receive: [video("webcam_out")],
  send:    [video("webcam_in")],
});
```

topic: REA-694-make-sdk-tracks-non-sendrecv
relative: REA-694-update-api-to-match-spec
reviewers: bryce, douglas