### PR TITLE
fix: catch terminateSession errors during disconnect

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -369,7 +369,11 @@ export class Reactor {
     }
 
     if (this.coordinatorClient && !recoverable) {
-      await this.coordinatorClient.terminateSession();
+      try {
+        await this.coordinatorClient.terminateSession();
+      } catch (error) {
+        console.error("[Reactor] Error terminating session:", error);
+      }
       this.coordinatorClient = undefined;
     }
 


### PR DESCRIPTION
## Summary

`Reactor.disconnect()` calls `coordinatorClient.terminateSession()` to clean up the server-side session. If the session was never fully created (e.g. coordinator returned a 503 during connect), `terminateSession()` throws "No active session". Because this call was not wrapped in a try/catch, the thrown error prevented `disconnect()` from completing — `setStatus("disconnected")` never ran, leaving the Reactor stuck in a non-disconnected state.

This meant the next `connect()` call would hit the `status !== "disconnected"` guard and throw "Already connected or connecting", making the client unable to reconnect without a full page reload.

## What changed

Wrapped `coordinatorClient.terminateSession()` in a try/catch inside `disconnect()`. The error is logged but no longer blocks cleanup. The coordinator client reference is still cleared, status is still set to "disconnected", and the session ID is still cleared — regardless of whether `terminateSession()` succeeded.

## Test plan

- Connect to a model, then disconnect and reconnect — no "Already connected or connecting" error
- Force a failed initial connect (e.g. 503 from coordinator), then try connecting again — disconnect cleanup completes and reconnect works