### PR TITLE
fix: wait for data channel open before reporting connected

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -50,6 +50,8 @@ export class GPUMachineClient {
   private publishedTracks: Map<string, MediaStreamTrack> = new Map();
   private statsInterval: ReturnType<typeof setInterval> | undefined;
   private stats: ConnectionStats | undefined;
+  private peerConnected = false;
+  private dataChannelOpen = false;
 
   constructor(config: webrtc.WebRTCConfig) {
     this.config = config;
@@ -220,6 +222,8 @@ export class GPUMachineClient {
     }
 
     this.transceiverMap.clear();
+    this.peerConnected = false;
+    this.dataChannelOpen = false;
     this.setStatus("disconnected");
     console.debug("[GPUMachineClient] Disconnected");
   }
@@ -438,6 +442,13 @@ export class GPUMachineClient {
   // Private Helpers
   // ─────────────────────────────────────────────────────────────────────────────
 
+  private checkFullyConnected(): void {
+    if (this.peerConnected && this.dataChannelOpen) {
+      this.setStatus("connected");
+      this.startStatsPolling();
+    }
+  }
+
   private setStatus(newStatus: GPUMachineStatus): void {
     if (this.status !== newStatus) {
       this.status = newStatus;
@@ -455,14 +466,16 @@ export class GPUMachineClient {
       if (state) {
         switch (state) {
           case "connected":
-            this.setStatus("connected");
-            this.startStatsPolling();
+            this.peerConnected = true;
+            this.checkFullyConnected();
             break;
           case "disconnected":
           case "closed":
+            this.peerConnected = false;
             this.setStatus("disconnected");
             break;
           case "failed":
+            this.peerConnected = false;
             this.setStatus("error");
             break;
         }
@@ -503,11 +516,14 @@ export class GPUMachineClient {
 
     this.dataChannel.onopen = () => {
       console.debug("[GPUMachineClient] Data channel open");
+      this.dataChannelOpen = true;
       this.startPing();
+      this.checkFullyConnected();
     };
 
     this.dataChannel.onclose = () => {
       console.debug("[GPUMachineClient] Data channel closed");
+      this.dataChannelOpen = false;
       this.stopPing();
     };
 


### PR DESCRIPTION
## Summary

`GPUMachineClient` emitted `"connected"` status as soon as the WebRTC peer connection state reached `"connected"`. However, a WebRTC connection involves two independent readiness signals:

1. **Peer connection** — the ICE/DTLS transport is established
2. **Data channel** — the SCTP data channel has completed its handshake and is open

These events fire independently and in no guaranteed order. In practice, the peer connection often reaches `"connected"` *before* the data channel's `onopen` fires. When the Reactor layer saw `"connected"`, it set status to `"ready"` and `ReactorController` immediately tried to send `requestCapabilities` over the data channel — which was still in `"connecting"` state, causing a "Data channel not open" error.

## What changed

Added `peerConnected` and `dataChannelOpen` boolean flags that track the two signals independently. A new `checkFullyConnected()` method only transitions to `"connected"` status when **both** are true. This means consumers of the `"connected"` event are guaranteed the data channel is open and ready for messages.

- `onconnectionstatechange("connected")` → sets `peerConnected = true`, calls `checkFullyConnected()`
- `dataChannel.onopen` → sets `dataChannelOpen = true`, calls `checkFullyConnected()`
- `disconnect()` resets both flags before setting status to `"disconnected"`
- `onconnectionstatechange("disconnected"/"closed"/"failed")` resets `peerConnected`
- `dataChannel.onclose` resets `dataChannelOpen`

The order the two events fire in no longer matters — `"connected"` is only emitted once both conditions are satisfied.

## Test plan

- Connect to a model — verify `requestCapabilities` is sent successfully (no "Data channel not open" error)
- Disconnect and reconnect — works cleanly without errors
- Check that stats polling starts only after both peer and data channel are ready