### PR TITLE
[REA-961] React SDK TOCTOU condition on SDP polling

### DIFF
--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -11,6 +11,7 @@ import {
   SDPParamsResponse,
   SessionInfoResponse,
 } from "./types";
+import { AbortError } from "../types";
 import { transformIceServers } from "../utils/webrtc";
 
 export interface CoordinatorClientOptions {
@@ -30,11 +31,30 @@ export class CoordinatorClient {
   private jwtToken: string;
   private model: string;
   private currentSessionId?: string;
+  private abortController: AbortController;
 
   constructor(options: CoordinatorClientOptions) {
     this.baseUrl = options.baseUrl;
     this.jwtToken = options.jwtToken;
     this.model = options.model;
+    this.abortController = new AbortController();
+  }
+
+  /**
+   * Aborts any in-flight HTTP requests and polling loops.
+   * A fresh AbortController is created so the client remains reusable.
+   */
+  abort(): void {
+    this.abortController.abort();
+    this.abortController = new AbortController();
+  }
+
+  /**
+   * The current abort signal, passed to every fetch() and sleep() call.
+   * Protected so subclasses can forward it to their own fetch calls.
+   */
+  protected get signal(): AbortSignal {
+    return this.abortController.signal;
   }
 
   /**
@@ -58,6 +78,7 @@ export class CoordinatorClient {
       {
         method: "GET",
         headers: this.getAuthHeaders(),
+        signal: this.signal,
       }
     );
 
@@ -97,6 +118,7 @@ export class CoordinatorClient {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
+      signal: this.signal,
     });
 
     if (!response.ok) {
@@ -136,6 +158,7 @@ export class CoordinatorClient {
       {
         method: "GET",
         headers: this.getAuthHeaders(),
+        signal: this.signal,
       }
     );
 
@@ -168,6 +191,7 @@ export class CoordinatorClient {
       {
         method: "DELETE",
         headers: this.getAuthHeaders(),
+        signal: this.signal,
       }
     );
 
@@ -229,6 +253,7 @@ export class CoordinatorClient {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
+        signal: this.signal,
       }
     );
 
@@ -271,6 +296,10 @@ export class CoordinatorClient {
     let attempt = 0;
 
     while (true) {
+      if (this.signal.aborted) {
+        throw new AbortError("SDP polling aborted");
+      }
+
       if (attempt >= maxAttempts) {
         throw new Error(
           `SDP polling exceeded maximum attempts (${maxAttempts}) for session ${sessionId}`
@@ -290,6 +319,7 @@ export class CoordinatorClient {
             ...this.getAuthHeaders(),
             "Content-Type": "application/json",
           },
+          signal: this.signal,
         }
       );
 
@@ -350,9 +380,25 @@ export class CoordinatorClient {
   }
 
   /**
-   * Utility function to sleep for a given number of milliseconds
+   * Abort-aware sleep. Resolves after `ms` milliseconds unless the
+   * abort signal fires first, in which case it rejects with AbortError.
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve, reject) => {
+      const { signal } = this;
+      if (signal.aborted) {
+        reject(new AbortError("Sleep aborted"));
+        return;
+      }
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new AbortError("Sleep aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
   }
 }

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -30,6 +30,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     console.debug("[LocalCoordinatorClient] Fetching ICE servers...");
     const response = await fetch(`${this.localBaseUrl}/ice_servers`, {
       method: "GET",
+      signal: this.signal,
     });
 
     if (!response.ok) {
@@ -56,6 +57,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     this.sdpOffer = sdpOffer;
     const response = await fetch(`${this.localBaseUrl}/start_session`, {
       method: "POST",
+      signal: this.signal,
     });
 
     if (!response.ok) {
@@ -85,6 +87,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(sdpBody),
+      signal: this.signal,
     });
 
     if (!response.ok) {
@@ -103,6 +106,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     console.debug("[LocalCoordinatorClient] Stopping local session...");
     await fetch(`${this.localBaseUrl}/stop_session`, {
       method: "POST",
+      signal: this.signal,
     });
   }
 }

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -7,6 +7,7 @@ import {
   type ConnectOptions,
   type TrackConfig,
   type ConnectionStats,
+  AbortError,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -216,6 +217,9 @@ export class Reactor {
       await this.machineClient.connect(sdpAnswer);
       this.setStatus("ready");
     } catch (error) {
+      // disconnect() already aborted the polling and cleaned up state — nothing to do.
+      if (error instanceof AbortError) return;
+
       let recoverable = false;
       if (error instanceof ConflictError) {
         recoverable = true;
@@ -291,6 +295,9 @@ export class Reactor {
       // Connect to GPU machine with the answer
       await this.machineClient.connect(sdpAnswer);
     } catch (error) {
+      // disconnect() already aborted the polling and cleaned up state — nothing to do.
+      if (error instanceof AbortError) return;
+
       console.error("[Reactor] Connection failed:", error);
       this.createError(
         "CONNECTION_FAILED",
@@ -367,6 +374,11 @@ export class Reactor {
       console.warn("[Reactor] Already disconnected");
       return;
     }
+
+    // Abort any in-flight coordinator requests (SDP polling, pending fetches)
+    // before tearing down. abort() resets the controller so terminateSession()
+    // below can still make its own HTTP call.
+    this.coordinatorClient?.abort();
 
     if (this.coordinatorClient && !recoverable) {
       try {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -7,7 +7,7 @@ import {
   type ConnectOptions,
   type TrackConfig,
   type ConnectionStats,
-  AbortError,
+  isAbortError,
   ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -218,7 +218,7 @@ export class Reactor {
       this.setStatus("ready");
     } catch (error) {
       // disconnect() already aborted the polling and cleaned up state — nothing to do.
-      if (error instanceof AbortError) return;
+      if (isAbortError(error)) return;
 
       let recoverable = false;
       if (error instanceof ConflictError) {
@@ -296,7 +296,7 @@ export class Reactor {
       await this.machineClient.connect(sdpAnswer);
     } catch (error) {
       // disconnect() already aborted the polling and cleaned up state — nothing to do.
-      if (error instanceof AbortError) return;
+      if (isAbortError(error)) return;
 
       console.error("[Reactor] Connection failed:", error);
       this.createError(

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -112,6 +112,12 @@ export class ConflictError extends Error {
   }
 }
 
+export class AbortError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export interface ReactorState {
   status: ReactorStatus;
   lastError?: ReactorError;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -118,6 +118,14 @@ export class AbortError extends Error {
   }
 }
 
+/** Matches both our custom AbortError and the native DOMException thrown by fetch(). */
+export function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof AbortError ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
 export interface ReactorState {
   status: ReactorStatus;
   lastError?: ReactorError;


### PR DESCRIPTION
Why
---
When disconnecting while SDP polling is in-flight, the polling loop
in CoordinatorClient has no cancellation mechanism. The disconnect()
call nullifies the coordinator reference on Reactor, but the async
pollSdpAnswer() closure keeps running — making HTTP requests to a
terminated session and throwing errors that surface as spurious
connection failures.

What Changed
---
- Added AbortController to CoordinatorClient; all fetch() calls and
  the backoff sleep now carry its signal and are immediately cancelled
  when abort() is called.
- Added AbortError class (matching the ConflictError pattern) so
  callers can distinguish intentional aborts from real failures.
- Reactor.disconnect() calls coordinatorClient.abort() before
  terminateSession(), killing any in-flight polling. The controller
  resets after abort so terminateSession() still works.
- Reactor.connect() and reconnect() silently swallow AbortError since
  disconnect() already handled all state cleanup.
- LocalCoordinatorClient fetch calls also carry the abort signal.

topic: js-sdk-toctou-condition-on-sdp-polling
reviewers: bryce, snow, ahmed