### PR TITLE
JS-SDK less verbose error throw for terminate session

### DIFF
--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -151,11 +151,12 @@ export class CoordinatorClient {
 
   /**
    * Terminates the current session by sending a DELETE request to the coordinator.
-   * @throws Error if no active session exists or if the request fails (except for 404)
+   * No-op if no session has been created yet.
+   * @throws Error if the request fails (except for 404, which clears local state)
    */
   async terminateSession(): Promise<void> {
     if (!this.currentSessionId) {
-      throw new Error("No active session. Call createSession() first.");
+      return;
     }
 
     console.debug(


### PR DESCRIPTION
Why
---
When connect() fails before createSession() completes (e.g. during
getIceServers or createOffer), the catch block calls disconnect(false).
disconnect sees coordinatorClient exists and calls terminateSession(),
which throws "No active session" because currentSessionId was never set.
The try/catch in disconnect catches it, but it produces a misleading
"Error terminating session" console error on every failed connection.

What Changed
---
Make CoordinatorClient.terminateSession() a no-op when there is no
currentSessionId instead of throwing. Cleanup methods should be safe
to call regardless of state.

topic: less-verbose-error-throw
reviewers: bryce, ahmed, snow