### PR TITLE
fix premature "ready" status in reconnect()

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -212,9 +212,10 @@ export class Reactor {
         sdpOffer,
         options?.maxAttempts
       );
-      // Connect to GPU machine with the answer
+      // Connect to GPU machine with the answer.
+      // Status transitions to "ready" via the statusChanged handler once
+      // the peer connection and data channel are fully open.
       await this.machineClient.connect(sdpAnswer);
-      this.setStatus("ready");
     } catch (error) {
       let recoverable = false;
       if (error instanceof ConflictError) {


### PR DESCRIPTION
Why
---
reconnect() set status to "ready" immediately after machineClient.connect(),
but that method only sets the remote SDP description — the ICE/DTLS handshake
is still in progress. The store saw "ready" and tried to publish tracks before
the peer connection was actually established, causing GPUMachineClient to
reject with "not connected".

What Changed
---
Remove the explicit setStatus("ready") from reconnect(), matching how
connect() already works: the status transitions to "ready" via the
statusChanged: "connected" event handler once the peer connection and
data channel are both fully open.

topic: fix-premature-ready-status-in-reconnect
reviewers: bryce, alberto, ahmed