### PR TITLE
Fix Firefox WebRTC: cross-browser MID rewriting for SDP negotiation

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -212,7 +212,10 @@ export class GPUMachineClient {
     try {
       let answer = sdpAnswer;
       if (this.midMapping) {
-        answer = webrtc.restoreAnswerMids(answer, this.midMapping.remoteToLocal);
+        answer = webrtc.restoreAnswerMids(
+          answer,
+          this.midMapping.remoteToLocal
+        );
       }
       await webrtc.setRemoteDescription(this.peerConnection, answer);
       console.debug("[GPUMachineClient] Remote description set");

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -53,6 +53,14 @@ export class GPUMachineClient {
   private peerConnected = false;
   private dataChannelOpen = false;
 
+  /**
+   * Browser-assigned MID ↔ track-name translation tables.
+   * Populated after {@link createOffer} so that:
+   *  - the outgoing offer carries track names as MIDs (server expectation)
+   *  - the incoming answer can be translated back to browser MIDs
+   */
+  private midMapping?: webrtc.MidMapping;
+
   constructor(config: webrtc.WebRTCConfig) {
     this.config = config;
   }
@@ -126,12 +134,23 @@ export class GPUMachineClient {
     }
 
     const trackNames = entries.map((e) => e.name);
-    const offer = await webrtc.createOffer(this.peerConnection, trackNames);
-    console.debug(
-      "[GPUMachineClient] Created SDP offer with MIDs:",
+    const { sdp, needsAnswerRestore } = await webrtc.createOffer(
+      this.peerConnection,
       trackNames
     );
-    return offer;
+
+    if (needsAnswerRestore) {
+      this.midMapping = webrtc.buildMidMapping(entries);
+    } else {
+      this.midMapping = undefined;
+    }
+
+    console.debug(
+      "[GPUMachineClient] Created SDP offer with MIDs:",
+      trackNames,
+      needsAnswerRestore ? "(needs answer restore)" : "(native munging)"
+    );
+    return sdp;
   }
 
   /**
@@ -191,7 +210,11 @@ export class GPUMachineClient {
     this.setStatus("connecting");
 
     try {
-      await webrtc.setRemoteDescription(this.peerConnection, sdpAnswer);
+      let answer = sdpAnswer;
+      if (this.midMapping) {
+        answer = webrtc.restoreAnswerMids(answer, this.midMapping.remoteToLocal);
+      }
+      await webrtc.setRemoteDescription(this.peerConnection, answer);
       console.debug("[GPUMachineClient] Remote description set");
     } catch (error) {
       console.error("[GPUMachineClient] Failed to connect:", error);
@@ -222,6 +245,7 @@ export class GPUMachineClient {
     }
 
     this.transceiverMap.clear();
+    this.midMapping = undefined;
     this.peerConnected = false;
     this.dataChannelOpen = false;
     this.setStatus("disconnected");
@@ -483,11 +507,19 @@ export class GPUMachineClient {
     };
 
     this.peerConnection.ontrack = (event) => {
-      const mid = event.transceiver.mid;
-      const trackName = mid ?? `unknown-${event.track.id}`;
+      // Resolve track name via transceiver object identity (reliable
+      // across browsers regardless of MID rewriting).
+      let trackName: string | undefined;
+      for (const [name, entry] of this.transceiverMap) {
+        if (entry.transceiver === event.transceiver) {
+          trackName = name;
+          break;
+        }
+      }
+      trackName ??= event.transceiver.mid ?? `unknown-${event.track.id}`;
 
       console.debug(
-        `[GPUMachineClient] Track received: "${trackName}" (${event.track.kind}, mid=${mid})`
+        `[GPUMachineClient] Track received: "${trackName}" (${event.track.kind}, mid=${event.transceiver.mid})`
       );
       const stream = event.streams[0] ?? new MediaStream([event.track]);
       this.emit("trackReceived", trackName, event.track, stream);

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -97,26 +97,40 @@ export function rewriteMids(sdp: string, trackNames: string[]): string {
 /**
  * Creates an SDP offer on the peer connection.
  *
- * When `trackNames` is provided, the media MIDs in the SDP are
- * rewritten to use those names before `setLocalDescription` is called.
- * This allows the remote side to identify transceivers by name rather
- * than by positional index.
+ * When `trackNames` is provided the media MIDs in the SDP are rewritten
+ * to use those names so the remote side identifies transceivers by name.
  *
- * Waits for ICE gathering to complete before returning.
+ * **Strategy** – try to apply the rewrite *before* `setLocalDescription`
+ * (Chrome accepts this; it means the browser's internal MIDs match the
+ * server's, so RTP MID header extensions agree).  If the browser rejects
+ * the modification (Firefox throws `InvalidModificationError`), fall
+ * back to setting the original offer and rewriting only the outgoing SDP
+ * string.  In the fallback case the caller **must** translate MIDs on
+ * the answer via {@link restoreAnswerMids} before `setRemoteDescription`.
+ *
+ * @returns An object with the SDP string and a flag indicating whether
+ *          MID munging was applied natively (`needsAnswerRestore = false`)
+ *          or only on the wire (`needsAnswerRestore = true`).
  */
 export async function createOffer(
   pc: RTCPeerConnection,
   trackNames?: string[]
-): Promise<string> {
+): Promise<{ sdp: string; needsAnswerRestore: boolean }> {
   const offer = await pc.createOffer();
+
+  let needsAnswerRestore = false;
 
   if (trackNames && trackNames.length > 0 && offer.sdp) {
     const munged = rewriteMids(offer.sdp, trackNames);
-    const mungedOffer = new RTCSessionDescription({
-      type: "offer",
-      sdp: munged,
-    });
-    await pc.setLocalDescription(mungedOffer);
+    try {
+      await pc.setLocalDescription(
+        new RTCSessionDescription({ type: "offer", sdp: munged })
+      );
+    } catch {
+      // Firefox: "Changing the mid of m-sections is not allowed"
+      await pc.setLocalDescription(offer);
+      needsAnswerRestore = true;
+    }
   } else {
     await pc.setLocalDescription(offer);
   }
@@ -128,7 +142,13 @@ export async function createOffer(
     throw new Error("Failed to create local description");
   }
 
-  return localDescription.sdp;
+  let sdp = localDescription.sdp;
+
+  if (needsAnswerRestore && trackNames && trackNames.length > 0) {
+    sdp = rewriteMids(sdp, trackNames);
+  }
+
+  return { sdp, needsAnswerRestore };
 }
 
 /**
@@ -152,6 +172,75 @@ export async function createAnswer(
   }
 
   return localDescription.sdp;
+}
+
+export interface MidMapping {
+  localToRemote: Map<string, string>;
+  remoteToLocal: Map<string, string>;
+}
+
+/**
+ * Builds bidirectional maps between browser-assigned numeric MIDs and
+ * the human-readable track names used by the server.
+ *
+ * Must be called after `setLocalDescription` so that each transceiver
+ * has a non-null `mid`.
+ *
+ * @param transceivers Ordered list of `{ name, transceiver }` pairs
+ *                     matching the declared track entries.
+ */
+export function buildMidMapping(
+  transceivers: { name: string; transceiver?: RTCRtpTransceiver }[]
+): MidMapping {
+  const localToRemote = new Map<string, string>();
+  const remoteToLocal = new Map<string, string>();
+  for (const entry of transceivers) {
+    const mid = entry.transceiver?.mid;
+    if (mid) {
+      localToRemote.set(mid, entry.name);
+      remoteToLocal.set(entry.name, mid);
+    }
+  }
+  return { localToRemote, remoteToLocal };
+}
+
+/**
+ * Translates named MIDs in an SDP answer back to the browser-assigned
+ * numeric MIDs.  This is the inverse of the {@link rewriteMids}
+ * transformation applied to the outgoing offer.
+ *
+ * @param sdp            The SDP answer from the remote peer.
+ * @param remoteToLocal  Map from server-side MID names to the browser's
+ *                       original numeric MID values.
+ */
+export function restoreAnswerMids(
+  sdp: string,
+  remoteToLocal: Map<string, string>
+): string {
+  const lines = sdp.split("\r\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("a=mid:")) {
+      const remoteMid = lines[i].substring("a=mid:".length);
+      const localMid = remoteToLocal.get(remoteMid);
+      if (localMid !== undefined) {
+        lines[i] = `a=mid:${localMid}`;
+      }
+    }
+
+    if (lines[i].startsWith("a=group:BUNDLE ")) {
+      const parts = lines[i].split(" ");
+      for (let j = 1; j < parts.length; j++) {
+        const localMid = remoteToLocal.get(parts[j]);
+        if (localMid !== undefined) {
+          parts[j] = localMid;
+        }
+      }
+      lines[i] = parts.join(" ");
+    }
+  }
+
+  return lines.join("\r\n");
 }
 
 /**


### PR DESCRIPTION
Why
---
Firefox strictly enforces the WebRTC spec and rejects `setLocalDescription`
when `a=mid:` values are modified from what `createOffer()` produced,
throwing `InvalidModificationError: Changing the mid of m-sections is not
allowed`. Chrome is lenient about this and accepts munged MIDs.

What Changed
---
- `webrtc.createOffer` now tries MID munging before `setLocalDescription`
  (works on Chrome), and falls back to setting the original offer when
  the browser rejects it (Firefox). In the fallback path the outgoing SDP
  string is rewritten separately so the server still sees named MIDs.
- Added `restoreAnswerMids()` to translate the server's named MIDs back
  to browser-assigned numeric MIDs before `setRemoteDescription`.
- Added `buildMidMapping()` to build the bidirectional MID ↔ track-name
  translation tables from transceiver state after `setLocalDescription`.
- `GPUMachineClient.connect()` conditionally restores answer MIDs only
  when the fallback path was used (`needsAnswerRestore` flag).
- `GPUMachineClient.ontrack` resolves track names via transceiver object
  identity against `transceiverMap`, reliable regardless of MID values.

topic: firefox-compatibility-internal-map-of-sdp-params
reviewers: bryce, ahmed