### PR TITLE
[REA-897] Enforce limit on data channel size

### DIFF
--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -253,6 +253,14 @@ export class GPUMachineClient {
   // ─────────────────────────────────────────────────────────────────────────────
 
   /**
+   * Returns the negotiated SCTP max message size (bytes) if available,
+   * otherwise `undefined` so `sendMessage` falls back to its built-in default.
+   */
+  private get maxMessageBytes(): number | undefined {
+    return this.peerConnection?.sctp?.maxMessageSize ?? undefined;
+  }
+
+  /**
    * Sends a command to the GPU machine via the data channel.
    * @param command The command to send
    * @param data The data to send with the command. These are the parameters for the command, matching the schema in the capabilities dictionary.
@@ -268,7 +276,13 @@ export class GPUMachineClient {
     }
 
     try {
-      webrtc.sendMessage(this.dataChannel, command, data, scope);
+      webrtc.sendMessage(
+        this.dataChannel,
+        command,
+        data,
+        scope,
+        this.maxMessageBytes
+      );
     } catch (error) {
       console.warn("[GPUMachineClient] Failed to send message:", error);
     }

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -20,6 +20,14 @@ const DEFAULT_DATA_CHANNEL_LABEL = "data";
 // Force relay mode for testing TURN servers - set to true to force all traffic through TURN
 const FORCE_RELAY_MODE = false;
 
+/**
+ * Safe cross-browser default for the maximum data channel message size (bytes).
+ * Most browsers negotiate 256 KiB via SCTP; we use a slightly lower value to
+ * leave room for framing overhead. Callers can override by passing a different
+ * limit to {@link sendMessage}.
+ */
+const DEFAULT_MAX_MESSAGE_BYTES = 256 * 1024; // 256 KiB
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Peer Connection Creation
 // ─────────────────────────────────────────────────────────────────────────────
@@ -296,16 +304,20 @@ export function removeAllTracks(pc: RTCPeerConnection): void {
  * Wire format:
  *   { scope: "application"|"runtime", data: { type: <command>, data: <payload> } }
  *
- * @param channel     The RTCDataChannel to send on.
- * @param command     Inner command/message type (e.g. "set_prompt", "requestCapabilities").
- * @param data        Payload for the command.
- * @param scope       Outer envelope scope – defaults to "application".
+ * @param channel      The RTCDataChannel to send on.
+ * @param command      Inner command/message type (e.g. "set_prompt", "requestCapabilities").
+ * @param data         Payload for the command.
+ * @param scope        Outer envelope scope – defaults to "application".
+ * @param maxBytes     Max allowed serialized message size in bytes.
+ *                     Defaults to {@link DEFAULT_MAX_MESSAGE_BYTES} (256 KiB).
+ *                     Pass the negotiated SCTP limit when available.
  */
 export function sendMessage(
   channel: RTCDataChannel,
   command: string,
   data: any,
-  scope: MessageScope = "application"
+  scope: MessageScope = "application",
+  maxBytes: number = DEFAULT_MAX_MESSAGE_BYTES
 ): void {
   if (channel.readyState !== "open") {
     throw new Error(`Data channel not open: ${channel.readyState}`);
@@ -313,7 +325,17 @@ export function sendMessage(
   const jsonData = typeof data === "string" ? JSON.parse(data) : data;
   const inner = { type: command, data: jsonData };
   const payload = { scope, data: inner };
-  channel.send(JSON.stringify(payload));
+  const serialized = JSON.stringify(payload);
+
+  const byteLength = new TextEncoder().encode(serialized).byteLength;
+  if (byteLength > maxBytes) {
+    throw new Error(
+      `Data channel message too large: ${byteLength} bytes exceeds ` +
+        `limit of ${maxBytes} bytes (command: "${command}")`
+    );
+  }
+
+  channel.send(serialized);
 }
 
 /**


### PR DESCRIPTION
Why
---
Sending an oversized message over the WebRTC data channel crashes the
channel and kills the connection. There was no size guard anywhere in
the send path.

What Changed
---
- `webrtc.sendMessage()` now computes the UTF-8 byte length of the
  serialized payload and throws a descriptive error if it exceeds a
  configurable limit (defaults to 256 KiB, the safe cross-browser
  SCTP default).
- `GPUMachineClient` reads the negotiated SCTP max from
  `peerConnection.sctp.maxMessageSize` and passes it through, so the
  check uses the real peer-negotiated limit when available.
- Oversized messages are now caught and logged as warnings instead of
  crashing the data channel.

Note
---
This doesn't allow to resize images, because the SDK doesn't have a concept of uploading an _image_, but instead,
just uploading base64 strings. So we cannot resize an image for the dev (yet)
This fix enforces a limit so that the data channel cannot crash.

topic: REA-897-enforce-limit-on-data-channel-size
reviewers: bryce, ahmed