### PR TITLE
[REA-1001] Add client connection timings to JS-SDK

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -10,12 +10,10 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 2,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 2,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -25,12 +23,10 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 0,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 0,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),

--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+
+let machineClientHandlers: Record<string, (...args: any[]) => void> = {};
+let mockMachineClient: any;
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn().mockImplementation(() => ({
+    getIceServers: vi.fn().mockResolvedValue([]),
+    createSession: vi.fn().mockResolvedValue("test-session-id"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 2,
+      }),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
+    getIceServers: vi.fn().mockResolvedValue([]),
+    createSession: vi.fn().mockResolvedValue("local"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/GPUMachineClient", () => ({
+  GPUMachineClient: vi.fn().mockImplementation(() => {
+    machineClientHandlers = {};
+    mockMachineClient = {
+      createOffer: vi.fn().mockResolvedValue("mock-sdp-offer"),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        machineClientHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue({ rtt: 10, timestamp: Date.now() }),
+      getConnectionTimings: vi
+        .fn()
+        .mockReturnValue({ iceNegotiationMs: 45, dataChannelMs: 55 }),
+      resetConnectionTimings: vi.fn(),
+    };
+    return mockMachineClient;
+  }),
+}));
+
+describe("Reactor connection timings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    machineClientHandlers = {};
+    mockMachineClient = undefined;
+  });
+
+  async function connectAndReady(r: Reactor, jwt = "jwt") {
+    await r.connect(jwt);
+    machineClientHandlers["statusChanged"]("connected");
+  }
+
+  it("populates connectionTimings after reaching ready", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    const stats = r.getStats();
+    expect(stats).toBeDefined();
+    expect(stats!.connectionTimings).toBeDefined();
+
+    const t = stats!.connectionTimings!;
+    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingAttempts).toBe(2);
+    expect(t.iceNegotiationMs).toBe(45);
+    expect(t.dataChannelMs).toBe(55);
+    expect(t.totalMs).toBeGreaterThanOrEqual(0);
+
+    await r.disconnect();
+  });
+
+  it("merges connectionTimings into statsUpdate events", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    const statsHandler = vi.fn();
+    r.on("statsUpdate", statsHandler);
+
+    machineClientHandlers["statsUpdate"]({ rtt: 25, timestamp: Date.now() });
+
+    expect(statsHandler).toHaveBeenCalledTimes(1);
+    const emitted = statsHandler.mock.calls[0][0];
+    expect(emitted.rtt).toBe(25);
+    expect(emitted.connectionTimings).toBeDefined();
+    expect(emitted.connectionTimings.sdpPollingAttempts).toBe(2);
+
+    await r.disconnect();
+  });
+
+  it("clears connectionTimings on disconnect (getStats)", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    expect(r.getStats()!.connectionTimings).toBeDefined();
+
+    await r.disconnect();
+    expect(r.getStats()).toBeUndefined();
+  });
+
+  it("clears connectionTimings from statsUpdate events after disconnect and reconnect", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    // Timings present after first connection
+    const statsHandler = vi.fn();
+    r.on("statsUpdate", statsHandler);
+    machineClientHandlers["statsUpdate"]({ rtt: 10, timestamp: Date.now() });
+    expect(statsHandler.mock.calls[0][0].connectionTimings).toBeDefined();
+    expect(
+      statsHandler.mock.calls[0][0].connectionTimings.sdpPollingAttempts
+    ).toBe(2);
+
+    await r.disconnect();
+
+    // After disconnect, getStats returns undefined (machineClient cleared)
+    expect(r.getStats()).toBeUndefined();
+  });
+
+  it("has partial connectionTimings before machine client emits connected", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await r.connect("jwt");
+
+    const stats = r.getStats();
+    expect(stats).toBeDefined();
+    const t = stats!.connectionTimings!;
+    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingMs).toBeGreaterThanOrEqual(0);
+    // ICE/data-channel/total are placeholder zeros until finalized
+    expect(t.iceNegotiationMs).toBe(0);
+    expect(t.dataChannelMs).toBe(0);
+    expect(t.totalMs).toBe(0);
+
+    await r.disconnect();
+  });
+});

--- a/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
@@ -137,8 +137,9 @@ describe("CoordinatorClient (extended)", () => {
         // Advance through second backoff (1000ms) — triggers third poll (200)
         await vi.advanceTimersByTimeAsync(1000);
 
-        const answer = await promise;
-        expect(answer).toBe("final-answer");
+        const result = await promise;
+        expect(result.sdpAnswer).toBe("final-answer");
+        expect(result.sdpPollingAttempts).toBe(3);
         expect(mockFetch).toHaveBeenCalledTimes(4);
       } finally {
         vi.useRealTimers();

--- a/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
@@ -187,8 +187,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "answer-sdp", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", "offer-sdp");
-      expect(answer).toBe("answer-sdp");
+      const result = await client.connect("session-123", "offer-sdp");
+      expect(result.sdpAnswer).toBe("answer-sdp");
+      expect(result.sdpPollingAttempts).toBe(0);
     });
 
     it("polls when PUT returns 202, then succeeds", async () => {
@@ -204,8 +205,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "polled-answer", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", "offer-sdp", 3);
-      expect(answer).toBe("polled-answer");
+      const result = await client.connect("session-123", "offer-sdp", 3);
+      expect(result.sdpAnswer).toBe("polled-answer");
+      expect(result.sdpPollingAttempts).toBe(2);
     });
 
     it("goes directly to polling when no SDP offer is given", async () => {
@@ -216,8 +218,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "direct-answer", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", undefined, 2);
-      expect(answer).toBe("direct-answer");
+      const result = await client.connect("session-123", undefined, 2);
+      expect(result.sdpAnswer).toBe("direct-answer");
+      expect(result.sdpPollingAttempts).toBe(1);
       // Should be a GET, not PUT
       expect(mockFetch.mock.calls[0][1].method).toBe("GET");
     });

--- a/packages/js-sdk/__tests__/unit/gpu-machine-client-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/gpu-machine-client-timings.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GPUMachineClient } from "../../src/core/GPUMachineClient";
+
+function createMockPeerConnection() {
+  return {
+    addTransceiver: vi.fn().mockReturnValue({
+      sender: { replaceTrack: vi.fn() },
+      mid: "0",
+    }),
+    createOffer: vi.fn().mockResolvedValue({
+      type: "offer",
+      sdp: [
+        "v=0",
+        "o=- 0 0 IN IP4 127.0.0.1",
+        "s=-",
+        "a=group:BUNDLE 0",
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+        "a=mid:0",
+        "",
+      ].join("\r\n"),
+    }),
+    setLocalDescription: vi.fn(),
+    setRemoteDescription: vi.fn(),
+    createDataChannel: vi.fn().mockReturnValue({
+      onopen: null as ((ev: Event) => void) | null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+      readyState: "connecting",
+      close: vi.fn(),
+      send: vi.fn(),
+    }),
+    close: vi.fn(),
+    getSenders: vi.fn().mockReturnValue([]),
+    getReceivers: vi.fn().mockReturnValue([]),
+    getStats: vi.fn().mockResolvedValue(new Map()),
+    get localDescription() {
+      return {
+        sdp: [
+          "v=0",
+          "o=- 0 0 IN IP4 127.0.0.1",
+          "s=-",
+          "a=group:BUNDLE 0",
+          "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+          "a=mid:0",
+          "",
+        ].join("\r\n"),
+      };
+    },
+    signalingState: "have-local-offer",
+    connectionState: "new",
+    iceGatheringState: "complete",
+    onconnectionstatechange: null as (() => void) | null,
+    ontrack: null,
+    onicecandidate: null,
+    onicecandidateerror: null,
+    ondatachannel: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
+
+describe("GPUMachineClient connection timings", () => {
+  let mockPC: ReturnType<typeof createMockPeerConnection>;
+
+  beforeEach(() => {
+    mockPC = createMockPeerConnection();
+    vi.stubGlobal("RTCPeerConnection", vi.fn().mockReturnValue(mockPC));
+    vi.stubGlobal(
+      "RTCSessionDescription",
+      vi.fn().mockImplementation((d: any) => d)
+    );
+    vi.stubGlobal(
+      "RTCIceCandidate",
+      vi.fn().mockImplementation((c: any) => c)
+    );
+    vi.stubGlobal(
+      "MediaStream",
+      vi.fn().mockImplementation(() => ({ getTracks: () => [] }))
+    );
+  });
+
+  it("returns undefined before connect", () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("records ICE and data channel durations after connection", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    // Simulate peer connection reaching "connected"
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+
+    // Simulate data channel opening
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    const timings = client.getConnectionTimings();
+    expect(timings).toBeDefined();
+    expect(timings!.iceNegotiationMs).toBeGreaterThanOrEqual(0);
+    expect(timings!.dataChannelMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns undefined when only ICE connected but data channel not open", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("clears timings on disconnect", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    expect(client.getConnectionTimings()).toBeDefined();
+
+    await client.disconnect();
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("resetConnectionTimings clears all timing state", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    expect(client.getConnectionTimings()).toBeDefined();
+
+    client.resetConnectionTimings();
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+});

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -79,8 +79,9 @@ describe("LocalCoordinatorClient", () => {
         json: () => Promise.resolve({ sdp: "answer-sdp", type: "answer" }),
       });
 
-      const answer = await client.connect("local", "");
-      expect(answer).toBe("answer-sdp");
+      const result = await client.connect("local", "");
+      expect(result.sdpAnswer).toBe("answer-sdp");
+      expect(result.sdpPollingAttempts).toBe(0);
     });
 
     it("throws ConflictError on 409", async () => {

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -11,7 +11,12 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 1,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
     getSessionId: vi.fn().mockReturnValue("test-session-id"),
@@ -22,7 +27,12 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -43,6 +53,10 @@ vi.mock("../../src/core/GPUMachineClient", () => ({
       }),
       off: vi.fn(),
       getStats: vi.fn().mockReturnValue(undefined),
+      getConnectionTimings: vi
+        .fn()
+        .mockReturnValue({ iceNegotiationMs: 50, dataChannelMs: 60 }),
+      resetConnectionTimings: vi.fn(),
     };
     return mockMachineClient;
   }),
@@ -280,7 +294,9 @@ describe("Reactor (extended)", () => {
       r.on("statsUpdate", statsHandler);
 
       machineClientHandlers["statsUpdate"]({ rtt: 25 });
-      expect(statsHandler).toHaveBeenCalledWith({ rtt: 25 });
+      expect(statsHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ rtt: 25 })
+      );
       await r.disconnect();
     });
 

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -11,12 +11,10 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 1,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 1,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
     getSessionId: vi.fn().mockReturnValue("test-session-id"),
@@ -27,12 +25,10 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 0,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 0,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -7,12 +7,10 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 1,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 1,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -22,12 +20,10 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi
-      .fn()
-      .mockResolvedValue({
-        sdpAnswer: "mock-sdp-answer",
-        sdpPollingAttempts: 0,
-      }),
+    connect: vi.fn().mockResolvedValue({
+      sdpAnswer: "mock-sdp-answer",
+      sdpPollingAttempts: 0,
+    }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -7,7 +7,12 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 1,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -17,7 +22,12 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -34,6 +44,8 @@ vi.mock("../../src/core/GPUMachineClient", () => ({
     on: vi.fn(),
     off: vi.fn(),
     getStats: vi.fn().mockReturnValue(undefined),
+    getConnectionTimings: vi.fn().mockReturnValue(undefined),
+    resetConnectionTimings: vi.fn(),
   })),
 }));
 

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -287,7 +287,7 @@ export class CoordinatorClient {
   private async pollSdpAnswer(
     sessionId: string,
     maxAttempts: number = DEFAULT_MAX_ATTEMPTS
-  ): Promise<string> {
+  ): Promise<{ sdpAnswer: string; attempts: number }> {
     console.debug(
       "[CoordinatorClient] Polling for SDP answer for session:",
       sessionId
@@ -327,7 +327,7 @@ export class CoordinatorClient {
       if (response.status === 200) {
         const answerData: SDPParamsResponse = await response.json();
         console.debug("[CoordinatorClient] Received SDP answer via polling");
-        return answerData.sdp_answer;
+        return { sdpAnswer: answerData.sdp_answer, attempts: attempt };
       }
 
       if (response.status === 202) {
@@ -357,13 +357,13 @@ export class CoordinatorClient {
    * @param sessionId - The session ID to connect to
    * @param sdpOffer - Optional SDP offer from the local WebRTC peer connection
    * @param maxAttempts - Optional maximum number of polling attempts before giving up
-   * @returns The SDP answer from the server
+   * @returns The SDP answer and the number of polling attempts made (0 if answered immediately via PUT)
    */
   async connect(
     sessionId: string,
     sdpOffer?: string,
     maxAttempts?: number
-  ): Promise<string> {
+  ): Promise<{ sdpAnswer: string; sdpPollingAttempts: number }> {
     console.debug("[CoordinatorClient] Connecting to session:", sessionId);
 
     if (sdpOffer) {
@@ -371,13 +371,14 @@ export class CoordinatorClient {
       // Try to send it and get an immediate answer
       const answer = await this.sendSdpOffer(sessionId, sdpOffer);
       if (answer !== null) {
-        return answer;
+        return { sdpAnswer: answer, sdpPollingAttempts: 0 };
       }
       // Server accepted but answer not ready yet (202), fall back to polling
     }
 
     // No SDP offer = async reconnection, poll until server has the answer
-    return this.pollSdpAnswer(sessionId, maxAttempts);
+    const result = await this.pollSdpAnswer(sessionId, maxAttempts);
+    return { sdpAnswer: result.sdpAnswer, sdpPollingAttempts: result.attempts };
   }
 
   /**

--- a/packages/js-sdk/src/core/GPUMachineClient.ts
+++ b/packages/js-sdk/src/core/GPUMachineClient.ts
@@ -53,6 +53,10 @@ export class GPUMachineClient {
   private peerConnected = false;
   private dataChannelOpen = false;
 
+  private iceStartTime?: number;
+  private iceNegotiationMs?: number;
+  private dataChannelMs?: number;
+
   /**
    * Browser-assigned MID ↔ track-name translation tables.
    * Populated after {@link createOffer} so that:
@@ -208,6 +212,9 @@ export class GPUMachineClient {
     }
 
     this.setStatus("connecting");
+    this.iceStartTime = performance.now();
+    this.iceNegotiationMs = undefined;
+    this.dataChannelMs = undefined;
 
     try {
       let answer = sdpAnswer;
@@ -251,6 +258,7 @@ export class GPUMachineClient {
     this.midMapping = undefined;
     this.peerConnected = false;
     this.dataChannelOpen = false;
+    this.resetConnectionTimings();
     this.setStatus("disconnected");
     console.debug("[GPUMachineClient] Disconnected");
   }
@@ -457,6 +465,28 @@ export class GPUMachineClient {
     return this.stats;
   }
 
+  /**
+   * Returns the ICE/data-channel durations recorded during the last connect(),
+   * or undefined if no connection has completed yet.
+   */
+  getConnectionTimings():
+    | { iceNegotiationMs: number; dataChannelMs: number }
+    | undefined {
+    if (this.iceNegotiationMs == null || this.dataChannelMs == null) {
+      return undefined;
+    }
+    return {
+      iceNegotiationMs: this.iceNegotiationMs,
+      dataChannelMs: this.dataChannelMs,
+    };
+  }
+
+  resetConnectionTimings(): void {
+    this.iceStartTime = undefined;
+    this.iceNegotiationMs = undefined;
+    this.dataChannelMs = undefined;
+  }
+
   private startStatsPolling(): void {
     this.stopStatsPolling();
     this.statsInterval = setInterval(async () => {
@@ -507,6 +537,9 @@ export class GPUMachineClient {
       if (state) {
         switch (state) {
           case "connected":
+            if (this.iceStartTime != null && this.iceNegotiationMs == null) {
+              this.iceNegotiationMs = performance.now() - this.iceStartTime;
+            }
             this.peerConnected = true;
             this.checkFullyConnected();
             break;
@@ -565,6 +598,9 @@ export class GPUMachineClient {
 
     this.dataChannel.onopen = () => {
       console.debug("[GPUMachineClient] Data channel open");
+      if (this.iceStartTime != null && this.dataChannelMs == null) {
+        this.dataChannelMs = performance.now() - this.iceStartTime;
+      }
       this.dataChannelOpen = true;
       this.startPing();
       this.checkFullyConnected();

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -70,11 +70,15 @@ export class LocalCoordinatorClient extends CoordinatorClient {
 
   /**
    * Connects to the local session by posting SDP params to /sdp_params.
+   * Local connections are always immediate (no polling).
    * @param sessionId - The session ID (ignored for local)
    * @param sdpMessage - The SDP offer from the local WebRTC peer connection
-   * @returns The SDP answer from the server
+   * @returns The SDP answer and polling attempts (always 0 for local)
    */
-  async connect(sessionId: string, sdpMessage: string): Promise<string> {
+  async connect(
+    sessionId: string,
+    sdpMessage?: string
+  ): Promise<{ sdpAnswer: string; sdpPollingAttempts: number }> {
     this.sdpOffer = sdpMessage || this.sdpOffer;
     console.debug("[LocalCoordinatorClient] Connecting to local session...");
     const sdpBody = {
@@ -99,7 +103,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
 
     const sdpAnswer: { sdp: string; type: "answer" } = await response.json();
     console.debug("[LocalCoordinatorClient] Received SDP answer");
-    return sdpAnswer.sdp;
+    return { sdpAnswer: sdpAnswer.sdp, sdpPollingAttempts: 0 };
   }
 
   async terminateSession(): Promise<void> {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -7,6 +7,7 @@ import {
   type ConnectOptions,
   type TrackConfig,
   type ConnectionStats,
+  type ConnectionTimings,
   isAbortError,
   ConflictError,
 } from "../types";
@@ -63,6 +64,8 @@ export class Reactor {
   /** Tracks the client SENDS to the model (client → model). */
   private send: TrackConfig[];
   private sessionId?: string;
+  private connectStartTime?: number;
+  private connectionTimings?: ConnectionTimings;
 
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
@@ -208,7 +211,7 @@ export class Reactor {
 
     // Send offer to coordinator and get answer.
     try {
-      const sdpAnswer = await this.coordinatorClient.connect(
+      const { sdpAnswer } = await this.coordinatorClient.connect(
         this.sessionId,
         sdpOffer,
         options?.maxAttempts
@@ -256,6 +259,8 @@ export class Reactor {
     }
     this.setStatus("connecting");
 
+    this.connectStartTime = performance.now();
+
     try {
       console.debug(
         "[Reactor] Connecting to coordinator with authenticated URL"
@@ -282,16 +287,30 @@ export class Reactor {
       });
 
       // Create session passing SDP offer. We will get the answer polling the sdp_offer endpoint.
+      const tSession = performance.now();
       const sessionId = await this.coordinatorClient.createSession(sdpOffer);
+      const sessionCreationMs = performance.now() - tSession;
       this.setSessionId(sessionId);
 
       // Connect to coordinator and get SDP Answer.
       // We don't pass the sdp offer here because we passed it already when creating the session.
-      const sdpAnswer = await this.coordinatorClient.connect(
-        sessionId,
-        undefined,
-        options?.maxAttempts
-      );
+      const tSdp = performance.now();
+      const { sdpAnswer, sdpPollingAttempts } =
+        await this.coordinatorClient.connect(
+          sessionId,
+          undefined,
+          options?.maxAttempts
+        );
+      const sdpPollingMs = performance.now() - tSdp;
+
+      this.connectionTimings = {
+        sessionCreationMs,
+        sdpPollingMs,
+        sdpPollingAttempts,
+        iceNegotiationMs: 0,
+        dataChannelMs: 0,
+        totalMs: 0,
+      };
 
       // Connect to GPU machine with the answer
       await this.machineClient.connect(sdpAnswer);
@@ -345,6 +364,7 @@ export class Reactor {
       if (this.machineClient !== client) return;
       switch (status) {
         case "connected":
+          this.finalizeConnectionTimings(client);
           this.setStatus("ready");
           break;
         case "disconnected":
@@ -372,7 +392,10 @@ export class Reactor {
 
     client.on("statsUpdate", (stats: ConnectionStats) => {
       if (this.machineClient !== client) return;
-      this.emit("statsUpdate", stats);
+      this.emit("statsUpdate", {
+        ...stats,
+        connectionTimings: this.connectionTimings,
+      });
     });
   }
 
@@ -414,6 +437,7 @@ export class Reactor {
     }
 
     this.setStatus("disconnected");
+    this.resetConnectionTimings();
     if (!recoverable) {
       this.setSessionExpiration(undefined);
       this.setSessionId(undefined);
@@ -482,7 +506,27 @@ export class Reactor {
   }
 
   getStats(): ConnectionStats | undefined {
-    return this.machineClient?.getStats();
+    const stats = this.machineClient?.getStats();
+    if (!stats) return undefined;
+    return { ...stats, connectionTimings: this.connectionTimings };
+  }
+
+  private resetConnectionTimings(): void {
+    this.connectStartTime = undefined;
+    this.connectionTimings = undefined;
+  }
+
+  private finalizeConnectionTimings(client: GPUMachineClient): void {
+    if (!this.connectionTimings || this.connectStartTime == null) return;
+
+    const webrtcTimings = client.getConnectionTimings();
+    this.connectionTimings.iceNegotiationMs =
+      webrtcTimings?.iceNegotiationMs ?? 0;
+    this.connectionTimings.dataChannelMs = webrtcTimings?.dataChannelMs ?? 0;
+    this.connectionTimings.totalMs = performance.now() - this.connectStartTime;
+    this.connectStartTime = undefined;
+
+    console.debug("[Reactor] Connection timings:", this.connectionTimings);
   }
 
   /**

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -139,6 +139,26 @@ export interface ConnectOptions {
   maxAttempts?: number;
 }
 
+/**
+ * One-shot timing breakdown of the connect() handshake, recorded once per
+ * connection and included in every subsequent {@link ConnectionStats} update.
+ * All durations are in milliseconds (from `performance.now()`).
+ */
+export interface ConnectionTimings {
+  /** POST /sessions round-trip time */
+  sessionCreationMs: number;
+  /** Total time spent polling for the SDP answer */
+  sdpPollingMs: number;
+  /** Number of SDP poll requests made (1 = answered on first try) */
+  sdpPollingAttempts: number;
+  /** setRemoteDescription → RTCPeerConnection connectionState "connected" */
+  iceNegotiationMs: number;
+  /** setRemoteDescription → RTCDataChannel "open" */
+  dataChannelMs: number;
+  /** End-to-end: connect() invocation → status "ready" */
+  totalMs: number;
+}
+
 export interface ConnectionStats {
   /** ICE candidate-pair round-trip time in milliseconds */
   rtt?: number;
@@ -152,6 +172,8 @@ export interface ConnectionStats {
   packetLossRatio?: number;
   /** Network jitter in seconds (from inbound-rtp) */
   jitter?: number;
+  /** Timing breakdown of the initial connection handshake (set once, persisted until disconnect) */
+  connectionTimings?: ConnectionTimings;
   timestamp: number;
 }
 


### PR DESCRIPTION
Why
---
The JS SDK tracks zero timing metrics during the connection handshake,
making it difficult to diagnose slow connects or identify which phase
(session creation, GPU assignment, ICE negotiation) is the bottleneck.

What Changed
---
- Added `ConnectionTimings` interface with six metrics: `sessionCreationMs`,
  `sdpPollingMs`, `sdpPollingAttempts`, `iceNegotiationMs`, `dataChannelMs`,
  and `totalMs` (end-to-end connect-to-ready).
- Added optional `connectionTimings` field to the existing `ConnectionStats`
  type, so timings flow through `useStats()` and `getStats()` with no new
  events or hooks.
- Instrumented `Reactor.connect()` with `performance.now()` markers around
  each phase; async phases (ICE, data channel) are recorded inside
  `GPUMachineClient` and finalized when the connection reaches "ready".
- Changed `CoordinatorClient.connect()` return type from `string` to
  `{ sdpAnswer, sdpPollingAttempts }` (internal-only, not public API).
- Updated `LocalCoordinatorClient.connect()` to match the new return shape
  (always returns `sdpPollingAttempts: 0`).
- Updated existing test mocks in `reactor.test.ts`, `reactor-extended.test.ts`,
  `coordinator-client.test.ts`, `coordinator-client-extended.test.ts`, and
  `local-coordinator-client.test.ts` to match the new `connect()` return
  type and added `getConnectionTimings`/`resetConnectionTimings` to the
  `GPUMachineClient` mock.

topic: REA-1001-add-client-connection-timings-to-js-sdk
relative: add-integration-and-unit-tests-to-imperative-sdk
reviewers: bryce