### PR TITLE
[REA-1001] Add tests for client connection timings

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+
+let machineClientHandlers: Record<string, (...args: any[]) => void> = {};
+let mockMachineClient: any;
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn().mockImplementation(() => ({
+    getIceServers: vi.fn().mockResolvedValue([]),
+    createSession: vi.fn().mockResolvedValue("test-session-id"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 2,
+      }),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
+    getIceServers: vi.fn().mockResolvedValue([]),
+    createSession: vi.fn().mockResolvedValue("local"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/GPUMachineClient", () => ({
+  GPUMachineClient: vi.fn().mockImplementation(() => {
+    machineClientHandlers = {};
+    mockMachineClient = {
+      createOffer: vi.fn().mockResolvedValue("mock-sdp-offer"),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        machineClientHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue({ rtt: 10, timestamp: Date.now() }),
+      getConnectionTimings: vi
+        .fn()
+        .mockReturnValue({ iceNegotiationMs: 45, dataChannelMs: 55 }),
+      resetConnectionTimings: vi.fn(),
+    };
+    return mockMachineClient;
+  }),
+}));
+
+describe("Reactor connection timings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    machineClientHandlers = {};
+    mockMachineClient = undefined;
+  });
+
+  async function connectAndReady(r: Reactor, jwt = "jwt") {
+    await r.connect(jwt);
+    machineClientHandlers["statusChanged"]("connected");
+  }
+
+  it("populates connectionTimings after reaching ready", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    const stats = r.getStats();
+    expect(stats).toBeDefined();
+    expect(stats!.connectionTimings).toBeDefined();
+
+    const t = stats!.connectionTimings!;
+    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingAttempts).toBe(2);
+    expect(t.iceNegotiationMs).toBe(45);
+    expect(t.dataChannelMs).toBe(55);
+    expect(t.totalMs).toBeGreaterThanOrEqual(0);
+
+    await r.disconnect();
+  });
+
+  it("merges connectionTimings into statsUpdate events", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    const statsHandler = vi.fn();
+    r.on("statsUpdate", statsHandler);
+
+    machineClientHandlers["statsUpdate"]({ rtt: 25, timestamp: Date.now() });
+
+    expect(statsHandler).toHaveBeenCalledTimes(1);
+    const emitted = statsHandler.mock.calls[0][0];
+    expect(emitted.rtt).toBe(25);
+    expect(emitted.connectionTimings).toBeDefined();
+    expect(emitted.connectionTimings.sdpPollingAttempts).toBe(2);
+
+    await r.disconnect();
+  });
+
+  it("clears connectionTimings on disconnect (getStats)", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    expect(r.getStats()!.connectionTimings).toBeDefined();
+
+    await r.disconnect();
+    expect(r.getStats()).toBeUndefined();
+  });
+
+  it("clears connectionTimings from statsUpdate events after disconnect and reconnect", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await connectAndReady(r);
+
+    // Timings present after first connection
+    const statsHandler = vi.fn();
+    r.on("statsUpdate", statsHandler);
+    machineClientHandlers["statsUpdate"]({ rtt: 10, timestamp: Date.now() });
+    expect(statsHandler.mock.calls[0][0].connectionTimings).toBeDefined();
+    expect(
+      statsHandler.mock.calls[0][0].connectionTimings.sdpPollingAttempts
+    ).toBe(2);
+
+    await r.disconnect();
+
+    // After disconnect, getStats returns undefined (machineClient cleared)
+    expect(r.getStats()).toBeUndefined();
+  });
+
+  it("has partial connectionTimings before machine client emits connected", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await r.connect("jwt");
+
+    const stats = r.getStats();
+    expect(stats).toBeDefined();
+    const t = stats!.connectionTimings!;
+    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t.sdpPollingMs).toBeGreaterThanOrEqual(0);
+    // ICE/data-channel/total are placeholder zeros until finalized
+    expect(t.iceNegotiationMs).toBe(0);
+    expect(t.dataChannelMs).toBe(0);
+    expect(t.totalMs).toBe(0);
+
+    await r.disconnect();
+  });
+});

--- a/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
@@ -137,8 +137,9 @@ describe("CoordinatorClient (extended)", () => {
         // Advance through second backoff (1000ms) — triggers third poll (200)
         await vi.advanceTimersByTimeAsync(1000);
 
-        const answer = await promise;
-        expect(answer).toBe("final-answer");
+        const result = await promise;
+        expect(result.sdpAnswer).toBe("final-answer");
+        expect(result.sdpPollingAttempts).toBe(3);
         expect(mockFetch).toHaveBeenCalledTimes(4);
       } finally {
         vi.useRealTimers();

--- a/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
@@ -187,8 +187,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "answer-sdp", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", "offer-sdp");
-      expect(answer).toBe("answer-sdp");
+      const result = await client.connect("session-123", "offer-sdp");
+      expect(result.sdpAnswer).toBe("answer-sdp");
+      expect(result.sdpPollingAttempts).toBe(0);
     });
 
     it("polls when PUT returns 202, then succeeds", async () => {
@@ -204,8 +205,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "polled-answer", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", "offer-sdp", 3);
-      expect(answer).toBe("polled-answer");
+      const result = await client.connect("session-123", "offer-sdp", 3);
+      expect(result.sdpAnswer).toBe("polled-answer");
+      expect(result.sdpPollingAttempts).toBe(2);
     });
 
     it("goes directly to polling when no SDP offer is given", async () => {
@@ -216,8 +218,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({ sdp_answer: "direct-answer", extra_args: {} }),
       });
 
-      const answer = await client.connect("session-123", undefined, 2);
-      expect(answer).toBe("direct-answer");
+      const result = await client.connect("session-123", undefined, 2);
+      expect(result.sdpAnswer).toBe("direct-answer");
+      expect(result.sdpPollingAttempts).toBe(1);
       // Should be a GET, not PUT
       expect(mockFetch.mock.calls[0][1].method).toBe("GET");
     });

--- a/packages/js-sdk/__tests__/unit/gpu-machine-client-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/gpu-machine-client-timings.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GPUMachineClient } from "../../src/core/GPUMachineClient";
+
+function createMockPeerConnection() {
+  return {
+    addTransceiver: vi.fn().mockReturnValue({
+      sender: { replaceTrack: vi.fn() },
+      mid: "0",
+    }),
+    createOffer: vi.fn().mockResolvedValue({
+      type: "offer",
+      sdp: [
+        "v=0",
+        "o=- 0 0 IN IP4 127.0.0.1",
+        "s=-",
+        "a=group:BUNDLE 0",
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+        "a=mid:0",
+        "",
+      ].join("\r\n"),
+    }),
+    setLocalDescription: vi.fn(),
+    setRemoteDescription: vi.fn(),
+    createDataChannel: vi.fn().mockReturnValue({
+      onopen: null as ((ev: Event) => void) | null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+      readyState: "connecting",
+      close: vi.fn(),
+      send: vi.fn(),
+    }),
+    close: vi.fn(),
+    getSenders: vi.fn().mockReturnValue([]),
+    getReceivers: vi.fn().mockReturnValue([]),
+    getStats: vi.fn().mockResolvedValue(new Map()),
+    get localDescription() {
+      return {
+        sdp: [
+          "v=0",
+          "o=- 0 0 IN IP4 127.0.0.1",
+          "s=-",
+          "a=group:BUNDLE 0",
+          "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+          "a=mid:0",
+          "",
+        ].join("\r\n"),
+      };
+    },
+    signalingState: "have-local-offer",
+    connectionState: "new",
+    iceGatheringState: "complete",
+    onconnectionstatechange: null as (() => void) | null,
+    ontrack: null,
+    onicecandidate: null,
+    onicecandidateerror: null,
+    ondatachannel: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+}
+
+describe("GPUMachineClient connection timings", () => {
+  let mockPC: ReturnType<typeof createMockPeerConnection>;
+
+  beforeEach(() => {
+    mockPC = createMockPeerConnection();
+    vi.stubGlobal("RTCPeerConnection", vi.fn().mockReturnValue(mockPC));
+    vi.stubGlobal(
+      "RTCSessionDescription",
+      vi.fn().mockImplementation((d: any) => d)
+    );
+    vi.stubGlobal(
+      "RTCIceCandidate",
+      vi.fn().mockImplementation((c: any) => c)
+    );
+    vi.stubGlobal(
+      "MediaStream",
+      vi.fn().mockImplementation(() => ({ getTracks: () => [] }))
+    );
+  });
+
+  it("returns undefined before connect", () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("records ICE and data channel durations after connection", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    // Simulate peer connection reaching "connected"
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+
+    // Simulate data channel opening
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    const timings = client.getConnectionTimings();
+    expect(timings).toBeDefined();
+    expect(timings!.iceNegotiationMs).toBeGreaterThanOrEqual(0);
+    expect(timings!.dataChannelMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns undefined when only ICE connected but data channel not open", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("clears timings on disconnect", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    expect(client.getConnectionTimings()).toBeDefined();
+
+    await client.disconnect();
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+
+  it("resetConnectionTimings clears all timing state", async () => {
+    const client = new GPUMachineClient({ iceServers: [] });
+
+    await client.createOffer({ send: [], receive: [] });
+    await client.connect("v=0\r\nanswer");
+
+    mockPC.connectionState = "connected";
+    mockPC.onconnectionstatechange!();
+    const dc = mockPC.createDataChannel.mock.results[0].value;
+    dc.readyState = "open";
+    dc.onopen(new Event("open"));
+
+    expect(client.getConnectionTimings()).toBeDefined();
+
+    client.resetConnectionTimings();
+    expect(client.getConnectionTimings()).toBeUndefined();
+  });
+});

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -79,8 +79,9 @@ describe("LocalCoordinatorClient", () => {
         json: () => Promise.resolve({ sdp: "answer-sdp", type: "answer" }),
       });
 
-      const answer = await client.connect("local", "");
-      expect(answer).toBe("answer-sdp");
+      const result = await client.connect("local", "");
+      expect(result.sdpAnswer).toBe("answer-sdp");
+      expect(result.sdpPollingAttempts).toBe(0);
     });
 
     it("throws ConflictError on 409", async () => {

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -11,7 +11,12 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 1,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
     getSessionId: vi.fn().mockReturnValue("test-session-id"),
@@ -22,7 +27,12 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -43,6 +53,10 @@ vi.mock("../../src/core/GPUMachineClient", () => ({
       }),
       off: vi.fn(),
       getStats: vi.fn().mockReturnValue(undefined),
+      getConnectionTimings: vi
+        .fn()
+        .mockReturnValue({ iceNegotiationMs: 50, dataChannelMs: 60 }),
+      resetConnectionTimings: vi.fn(),
     };
     return mockMachineClient;
   }),
@@ -280,7 +294,9 @@ describe("Reactor (extended)", () => {
       r.on("statsUpdate", statsHandler);
 
       machineClientHandlers["statsUpdate"]({ rtt: 25 });
-      expect(statsHandler).toHaveBeenCalledWith({ rtt: 25 });
+      expect(statsHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ rtt: 25 })
+      );
       await r.disconnect();
     });
 

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -7,7 +7,12 @@ vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("test-session-id"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 1,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -17,7 +22,12 @@ vi.mock("../../src/core/LocalCoordinatorClient", () => ({
   LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
     getIceServers: vi.fn().mockResolvedValue([]),
     createSession: vi.fn().mockResolvedValue("local"),
-    connect: vi.fn().mockResolvedValue("mock-sdp-answer"),
+    connect: vi
+      .fn()
+      .mockResolvedValue({
+        sdpAnswer: "mock-sdp-answer",
+        sdpPollingAttempts: 0,
+      }),
     terminateSession: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
   })),
@@ -34,6 +44,8 @@ vi.mock("../../src/core/GPUMachineClient", () => ({
     on: vi.fn(),
     off: vi.fn(),
     getStats: vi.fn().mockReturnValue(undefined),
+    getConnectionTimings: vi.fn().mockReturnValue(undefined),
+    resetConnectionTimings: vi.fn(),
   })),
 }));
 


### PR DESCRIPTION
Why
---
The previous commit added connection timing instrumentation but no
dedicated test coverage for the new code paths.

What Changed
---
- Added `connection-timings.test.ts` with 5 tests covering the Reactor
  timing assembly: populating timings on ready, merging into statsUpdate
  events, clearing on disconnect, and verifying partial state before
  finalization.
- Added `gpu-machine-client-timings.test.ts` with 5 tests covering the
  GPUMachineClient timing fields: initial undefined state, recording ICE
  and data channel durations, partial state when only ICE connects,
  clearing on disconnect, and explicit resetConnectionTimings.
- Updated existing test mocks in reactor.test.ts, reactor-extended.test.ts,
  coordinator-client.test.ts, coordinator-client-extended.test.ts, and
  local-coordinator-client.test.ts to match the new connect() return type
  ({ sdpAnswer, sdpPollingAttempts }) and added getConnectionTimings /
  resetConnectionTimings to GPUMachineClient mocks.

topic: REA-1001-add-tests-for-client-connection-timings
relative: REA-1001-add-client-connection-timings-to-js-sdk
reviewers: bryce