### PR TITLE
feat!: remove coordinator from public SDK API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 .DS_Store
 *.log
 CLAUDE.md
+next-env.d.ts
+tsconfig.tsbuildinfo

--- a/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
@@ -6,8 +6,7 @@ import { fetchInsecureJwtToken } from "../../src/utils/tokens";
 import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
-const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
+const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 const MODEL = "echo";
 
 describe.skipIf(!API_KEY)("CoordinatorClient — integration", () => {

--- a/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
@@ -3,11 +3,11 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { CoordinatorClient } from "../../src/core/CoordinatorClient";
 import { fetchInsecureJwtToken } from "../../src/utils/tokens";
-import { PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
 const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? PROD_COORDINATOR_URL;
+  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 const MODEL = "echo";
 
 describe.skipIf(!API_KEY)("CoordinatorClient — integration", () => {

--- a/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
+++ b/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 import { describe, it, expect, afterEach } from "vitest";
-import { Reactor, PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
 import { video } from "../../src/types";
 import { fetchInsecureJwtToken } from "../../src/utils/tokens";
 import type { ReactorStatus } from "../../src/types";
 
 const API_KEY = process.env.REACTOR_API_KEY;
 const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? PROD_COORDINATOR_URL;
+  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 const MODEL = "echo";
 
 function waitForStatus(
@@ -67,7 +67,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -86,7 +86,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -108,7 +108,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -130,7 +130,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -148,7 +148,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -170,7 +170,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 
@@ -203,7 +203,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [
         video("main_video"),
         video("video_edges"),
@@ -222,7 +222,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
       send: [video("webcam")],
     });
@@ -240,7 +240,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
     const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
     const bad = new Reactor({
       modelName: "nonexistent-model-xyz-12345",
-      coordinatorUrl: COORDINATOR_URL,
+      apiUrl: COORDINATOR_URL,
       receive: [video("main_video")],
     });
 

--- a/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
+++ b/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
@@ -7,8 +7,7 @@ import { fetchInsecureJwtToken } from "../../src/utils/tokens";
 import type { ReactorStatus } from "../../src/types";
 
 const API_KEY = process.env.REACTOR_API_KEY;
-const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
+const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 const MODEL = "echo";
 
 function waitForStatus(

--- a/packages/js-sdk/__tests__/integration/tokens.test.ts
+++ b/packages/js-sdk/__tests__/integration/tokens.test.ts
@@ -2,11 +2,11 @@
 
 import { describe, it, expect } from "vitest";
 import { fetchInsecureJwtToken } from "../../src/utils/tokens";
-import { PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
 const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? PROD_COORDINATOR_URL;
+  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 
 describe.skipIf(!API_KEY)("fetchInsecureJwtToken — integration", () => {
   it("returns a valid JWT (3-segment base64 string)", async () => {

--- a/packages/js-sdk/__tests__/integration/tokens.test.ts
+++ b/packages/js-sdk/__tests__/integration/tokens.test.ts
@@ -5,8 +5,7 @@ import { fetchInsecureJwtToken } from "../../src/utils/tokens";
 import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
-const COORDINATOR_URL =
-  process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
+const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 
 describe.skipIf(!API_KEY)("fetchInsecureJwtToken — integration", () => {
   it("returns a valid JWT (3-segment base64 string)", async () => {

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Reactor, PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
 import { GPUMachineStatus } from "../../src/core/GPUMachineClient";
 
 let machineClientHandlers: Record<string, (...args: any[]) => void> = {};

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Reactor, PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn().mockImplementation(() => ({
@@ -61,8 +61,8 @@ describe("Reactor", () => {
       expect(() => new Reactor({ modelName: 123 } as any)).toThrow();
     });
 
-    it("exports PROD_COORDINATOR_URL", () => {
-      expect(PROD_COORDINATOR_URL).toBe("https://api.reactor.inc");
+    it("exports DEFAULT_BASE_URL", () => {
+      expect(DEFAULT_BASE_URL).toBe("https://api.reactor.inc");
     });
   });
 

--- a/packages/js-sdk/__tests__/unit/tokens.test.ts
+++ b/packages/js-sdk/__tests__/unit/tokens.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fetchInsecureJwtToken } from "../../src/utils/tokens";
-import { PROD_COORDINATOR_URL } from "../../src/core/Reactor";
+import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 describe("fetchInsecureJwtToken", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -23,7 +23,7 @@ describe("fetchInsecureJwtToken", () => {
     expect(token).toBe("test-jwt");
   });
 
-  it("uses PROD_COORDINATOR_URL by default", async () => {
+  it("uses DEFAULT_BASE_URL by default", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({ jwt: "token" }),
@@ -31,7 +31,7 @@ describe("fetchInsecureJwtToken", () => {
 
     await fetchInsecureJwtToken("rk_test_key");
     expect(mockFetch).toHaveBeenCalledWith(
-      `${PROD_COORDINATOR_URL}/tokens`,
+      `${DEFAULT_BASE_URL}/tokens`,
       expect.any(Object)
     );
   });

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -17,7 +17,7 @@ import { GPUMachineClient, GPUMachineStatus } from "./GPUMachineClient";
 import { z } from "zod";
 
 const LOCAL_COORDINATOR_URL = "http://localhost:8080";
-export const PROD_COORDINATOR_URL = "https://api.reactor.inc";
+export const DEFAULT_BASE_URL = "https://api.reactor.inc";
 
 const TrackConfigSchema = z.object({
   name: z.string(),
@@ -25,7 +25,7 @@ const TrackConfigSchema = z.object({
 });
 
 const OptionsSchema = z.object({
-  coordinatorUrl: z.string().default(PROD_COORDINATOR_URL),
+  apiUrl: z.string().default(DEFAULT_BASE_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
   /**
@@ -69,14 +69,14 @@ export class Reactor {
 
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
-    this.coordinatorUrl = validatedOptions.coordinatorUrl;
+    this.coordinatorUrl = validatedOptions.apiUrl;
 
     // TODO(REA-146) Properly accept version from parameter.
     this.model = validatedOptions.modelName;
     this.local = validatedOptions.local;
     this.receive = validatedOptions.receive;
     this.send = validatedOptions.send;
-    if (this.local && options.coordinatorUrl === undefined) {
+    if (this.local && options.apiUrl === undefined) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
     }
   }
@@ -234,7 +234,7 @@ export class Reactor {
       this.createError(
         "RECONNECTION_FAILED",
         `Failed to reconnect: ${error}`,
-        "coordinator",
+        "api",
         true
       );
     }
@@ -322,7 +322,7 @@ export class Reactor {
       this.createError(
         "CONNECTION_FAILED",
         `Connection failed: ${error}`,
-        "coordinator",
+        "api",
         true
       );
       // Non-recoverable disconnect: terminates the server-side session (DELETE)
@@ -535,7 +535,7 @@ export class Reactor {
   private createError(
     code: string,
     message: string,
-    component: "coordinator" | "gpu" | "livekit",
+    component: "api" | "gpu",
     recoverable: boolean,
     retryAfter?: number
   ) {

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -83,7 +83,7 @@ export const createReactorStore = (
   publicState: ReactorState = defaultInitState
 ): StoreApi<ReactorStore> => {
   console.debug("[ReactorStore] Creating store", {
-    coordinatorUrl: initProps.coordinatorUrl,
+    apiUrl: initProps.apiUrl,
     jwtToken: initProps.jwtToken,
     initialState: publicState,
   });

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -57,7 +57,7 @@ export function ReactorProvider({
   // Destructure connectOptions with defaults
   const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
-  const { coordinatorUrl, modelName, local, receive, send } = props;
+  const { apiUrl, modelName, local, receive, send } = props;
   const maxAttempts = pollingOptions.maxAttempts;
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
@@ -131,7 +131,7 @@ export function ReactorProvider({
     console.debug("[ReactorProvider] Updating reactor store");
     storeRef.current = createReactorStore(
       initReactorStore({
-        coordinatorUrl,
+        apiUrl,
         modelName,
         local,
         receive,
@@ -181,7 +181,7 @@ export function ReactorProvider({
         });
     };
   }, [
-    coordinatorUrl,
+    apiUrl,
     modelName,
     autoConnect,
     local,

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -102,7 +102,7 @@ export interface ReactorError {
   message: string;
   timestamp: number;
   recoverable: boolean;
-  component: "coordinator" | "gpu" | "livekit";
+  component: "api" | "gpu";
   retryAfter?: number;
 }
 

--- a/packages/js-sdk/src/utils/tokens.ts
+++ b/packages/js-sdk/src/utils/tokens.ts
@@ -1,4 +1,4 @@
-import { PROD_COORDINATOR_URL } from "../core/Reactor";
+import { DEFAULT_BASE_URL } from "../core/Reactor";
 
 /**
  * ⚠️ INSECURE: Fetches a JWT token directly from the client.
@@ -8,12 +8,12 @@ import { PROD_COORDINATOR_URL } from "../core/Reactor";
  * In production, call /tokens from your server and pass the JWT to your frontend.
  *
  * @param apiKey - Your Reactor API key (will be exposed in client code!)
- * @param coordinatorUrl - Optional coordinator URL, defaults to production
+ * @param apiUrl - Optional API URL, defaults to production
  * @returns string containing the JWT token
  */
 export async function fetchInsecureJwtToken(
   apiKey: string,
-  coordinatorUrl: string = PROD_COORDINATOR_URL
+  apiUrl: string = DEFAULT_BASE_URL
 ): Promise<string> {
   console.warn(
     "[Reactor] ⚠️ SECURITY WARNING: fetchInsecureJwtToken() exposes your API key in client-side code. " +
@@ -21,7 +21,7 @@ export async function fetchInsecureJwtToken(
       "In production, fetch tokens from your server instead."
   );
 
-  const response = await fetch(`${coordinatorUrl}/tokens`, {
+  const response = await fetch(`${apiUrl}/tokens`, {
     method: "GET",
     headers: {
       "X-API-Key": apiKey,


### PR DESCRIPTION
Closes REA-1058

## Why

`coordinatorUrl` / `coordinator_url` is an internal infrastructure term that leaks into the public API. Developers shouldn't need to know what a "coordinator" is. From their perspective they're just configuring the Reactor API URL. This rename aligns with how other SDKs (OpenAI, Anthropic) surface their base URL option and makes the API self-explanatory.

The `"coordinator"` value in `ReactorError.component` has the same problem. When a developer sees an error, `component: "api"` tells them where it came from without exposing internal architecture. `"livekit"` is also removed as it was never a valid emitted value.

## Changes

**Renames:**
- `coordinatorUrl` constructor option -> `apiUrl` (on `Reactor` class and `ReactorProvider`)
- `coordinatorUrl` param on `fetchInsecureJwtToken` -> `apiUrl`
- `PROD_COORDINATOR_URL` exported constant -> `DEFAULT_BASE_URL`
- `ReactorError.component: "coordinator"` -> `"api"`, removed `"livekit"`

**Version bump:** 2.5.1 -> 3.0.0 (breaking change)

Internal variable names (`coordinatorClient`, `coordinatorUrl` private fields) are unchanged.