### PR TITLE
rename fetchInsecureJwtToken to fetchInsecureToken

### DIFF
--- a/examples/dynamic/components/Settings.tsx
+++ b/examples/dynamic/components/Settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { fetchInsecureJwtToken } from "@reactor-team/js-sdk";
+import { fetchInsecureToken } from "@reactor-team/js-sdk";
 import {
   Tooltip,
   TooltipContent,
@@ -59,7 +59,7 @@ export function Settings({
       setIsFetchingToken(true);
       setTokenError(null);
       try {
-        const token = await fetchInsecureJwtToken(apiKey, coordinatorUrl);
+        const token = await fetchInsecureToken(apiKey, coordinatorUrl);
         onJwtTokenChange(token);
       } catch (err) {
         setTokenError(

--- a/examples/film-director/components/ApiKeyInput.tsx
+++ b/examples/film-director/components/ApiKeyInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { fetchInsecureJwtToken } from "@reactor-team/js-sdk";
+import { fetchInsecureToken } from "@reactor-team/js-sdk";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
@@ -50,7 +50,7 @@ export function ApiKeyInput({
       setIsFetching(true);
       setError(null);
       try {
-        const token = await fetchInsecureJwtToken(apiKey);
+        const token = await fetchInsecureToken(apiKey);
         handleJwtChange(token);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to fetch token");

--- a/examples/film-director/components/ConnectionPanel.tsx
+++ b/examples/film-director/components/ConnectionPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useReactor, fetchInsecureJwtToken } from "@reactor-team/js-sdk";
+import { useReactor, fetchInsecureToken } from "@reactor-team/js-sdk";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -59,7 +59,7 @@ export function ConnectionPanel({
       setIsFetching(true);
       setError(null);
       try {
-        const token = await fetchInsecureJwtToken(apiKey);
+        const token = await fetchInsecureToken(apiKey);
         handleJwtChange(token);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to fetch token");

--- a/examples/livecore/components/ApiKeyInput.tsx
+++ b/examples/livecore/components/ApiKeyInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { fetchInsecureJwtToken } from "@reactor-team/js-sdk";
+import { fetchInsecureToken } from "@reactor-team/js-sdk";
 
 interface ApiKeyInputProps {
   onJwtTokenChange: (token: string | undefined) => void;
@@ -41,7 +41,7 @@ export function ApiKeyInput({
       setIsFetching(true);
       setError(null);
       try {
-        const token = await fetchInsecureJwtToken(apiKey);
+        const token = await fetchInsecureToken(apiKey);
         onJwtTokenChange(token);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to fetch token");

--- a/examples/livecore/components/ConnectionPanel.tsx
+++ b/examples/livecore/components/ConnectionPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useReactor, fetchInsecureJwtToken } from "@reactor-team/js-sdk";
+import { useReactor, fetchInsecureToken } from "@reactor-team/js-sdk";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -59,7 +59,7 @@ export function ConnectionPanel({
       setIsFetching(true);
       setError(null);
       try {
-        const token = await fetchInsecureJwtToken(apiKey);
+        const token = await fetchInsecureToken(apiKey);
         handleJwtChange(token);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to fetch token");

--- a/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { CoordinatorClient } from "../../src/core/CoordinatorClient";
-import { fetchInsecureJwtToken } from "../../src/utils/tokens";
+import { fetchInsecureToken } from "../../src/utils/tokens";
 import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
@@ -15,7 +15,7 @@ describe.skipIf(!API_KEY)("CoordinatorClient — integration", () => {
   let cachedJwt: string | undefined;
   async function getJwt(): Promise<string> {
     if (!cachedJwt)
-      cachedJwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+      cachedJwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     return cachedJwt;
   }
 

--- a/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
+++ b/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
 import { video } from "../../src/types";
-import { fetchInsecureJwtToken } from "../../src/utils/tokens";
+import { fetchInsecureToken } from "../../src/utils/tokens";
 import type { ReactorStatus } from "../../src/types";
 
 const API_KEY = process.env.REACTOR_API_KEY;
@@ -63,7 +63,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Connection lifecycle ───────────────────────────────────────────────
 
   it("connects and reaches the ready state", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -82,7 +82,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   }, 90_000);
 
   it("emits sessionIdChanged on connect", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -104,7 +104,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Commands ───────────────────────────────────────────────────────────
 
   it("sends commands (set_effect, set_intensity) without error", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -126,7 +126,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Disconnect ─────────────────────────────────────────────────────────
 
   it("disconnects cleanly after reaching ready", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -144,7 +144,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Full status lifecycle ──────────────────────────────────────────────
 
   it("status transitions: connecting → ready → disconnected", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -166,7 +166,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Stats ──────────────────────────────────────────────────────────────
 
   it("receives stats updates when connected", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -199,7 +199,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Multiple receive tracks ────────────────────────────────────────────
 
   it("negotiates multiple receive tracks", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -218,7 +218,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Send + receive tracks ──────────────────────────────────────────────
 
   it("connects with both send and receive tracks", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     reactor = new Reactor({
       modelName: MODEL,
       apiUrl: COORDINATOR_URL,
@@ -236,7 +236,7 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
   // ── Error path ─────────────────────────────────────────────────────────
 
   it("rejects with an error for a non-existent model", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     const bad = new Reactor({
       modelName: "nonexistent-model-xyz-12345",
       apiUrl: COORDINATOR_URL,

--- a/packages/js-sdk/__tests__/integration/tokens.test.ts
+++ b/packages/js-sdk/__tests__/integration/tokens.test.ts
@@ -1,22 +1,22 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 import { describe, it, expect } from "vitest";
-import { fetchInsecureJwtToken } from "../../src/utils/tokens";
+import { fetchInsecureToken } from "../../src/utils/tokens";
 import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
 const API_KEY = process.env.REACTOR_API_KEY;
 const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 
-describe.skipIf(!API_KEY)("fetchInsecureJwtToken — integration", () => {
+describe.skipIf(!API_KEY)("fetchInsecureToken — integration", () => {
   it("returns a valid JWT (3-segment base64 string)", async () => {
-    const jwt = await fetchInsecureJwtToken(API_KEY!, COORDINATOR_URL);
+    const jwt = await fetchInsecureToken(API_KEY!, COORDINATOR_URL);
     expect(typeof jwt).toBe("string");
     expect(jwt.split(".")).toHaveLength(3);
   }, 15_000);
 
   it("rejects an invalid API key", async () => {
     await expect(
-      fetchInsecureJwtToken("rk_invalid_key_12345", COORDINATOR_URL)
+      fetchInsecureToken("rk_invalid_key_12345", COORDINATOR_URL)
     ).rejects.toThrow();
   }, 15_000);
 });

--- a/packages/js-sdk/__tests__/unit/tokens.test.ts
+++ b/packages/js-sdk/__tests__/unit/tokens.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchInsecureJwtToken } from "../../src/utils/tokens";
+import { fetchInsecureToken } from "../../src/utils/tokens";
 import { DEFAULT_BASE_URL } from "../../src/core/Reactor";
 
-describe("fetchInsecureJwtToken", () => {
+describe("fetchInsecureToken", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe("fetchInsecureJwtToken", () => {
       json: async () => ({ jwt: "test-jwt" }),
     });
 
-    const token = await fetchInsecureJwtToken("rk_test_key");
+    const token = await fetchInsecureToken("rk_test_key");
     expect(token).toBe("test-jwt");
   });
 
@@ -29,7 +29,7 @@ describe("fetchInsecureJwtToken", () => {
       json: async () => ({ jwt: "token" }),
     });
 
-    await fetchInsecureJwtToken("rk_test_key");
+    await fetchInsecureToken("rk_test_key");
     expect(mockFetch).toHaveBeenCalledWith(
       `${DEFAULT_BASE_URL}/tokens`,
       expect.any(Object)
@@ -42,7 +42,7 @@ describe("fetchInsecureJwtToken", () => {
       json: async () => ({ jwt: "token" }),
     });
 
-    await fetchInsecureJwtToken("rk_test_key", "https://custom.api.example");
+    await fetchInsecureToken("rk_test_key", "https://custom.api.example");
     expect(mockFetch).toHaveBeenCalledWith(
       "https://custom.api.example/tokens",
       expect.any(Object)
@@ -55,7 +55,7 @@ describe("fetchInsecureJwtToken", () => {
       json: async () => ({ jwt: "token" }),
     });
 
-    await fetchInsecureJwtToken("rk_my_secret_key");
+    await fetchInsecureToken("rk_my_secret_key");
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -71,7 +71,7 @@ describe("fetchInsecureJwtToken", () => {
       json: async () => ({ jwt: "token" }),
     });
 
-    await fetchInsecureJwtToken("rk_test_key");
+    await fetchInsecureToken("rk_test_key");
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("SECURITY WARNING")
     );
@@ -84,7 +84,7 @@ describe("fetchInsecureJwtToken", () => {
       text: async () => "Unauthorized",
     });
 
-    await expect(fetchInsecureJwtToken("rk_bad_key")).rejects.toThrow(
+    await expect(fetchInsecureToken("rk_bad_key")).rejects.toThrow(
       "Failed to create token: 401 Unauthorized"
     );
   });
@@ -96,7 +96,7 @@ describe("fetchInsecureJwtToken", () => {
       text: async () => "Internal Server Error",
     });
 
-    await expect(fetchInsecureJwtToken("rk_test_key")).rejects.toThrow(
+    await expect(fetchInsecureToken("rk_test_key")).rejects.toThrow(
       "Failed to create token: 500 Internal Server Error"
     );
   });

--- a/packages/js-sdk/src/utils/tokens.ts
+++ b/packages/js-sdk/src/utils/tokens.ts
@@ -11,12 +11,12 @@ import { DEFAULT_BASE_URL } from "../core/Reactor";
  * @param apiUrl - Optional API URL, defaults to production
  * @returns string containing the JWT token
  */
-export async function fetchInsecureJwtToken(
+export async function fetchInsecureToken(
   apiKey: string,
   apiUrl: string = DEFAULT_BASE_URL
 ): Promise<string> {
   console.warn(
-    "[Reactor] ⚠️ SECURITY WARNING: fetchInsecureJwtToken() exposes your API key in client-side code. " +
+    "[Reactor] ⚠️ SECURITY WARNING: fetchInsecureToken() exposes your API key in client-side code. " +
       "This should ONLY be used for local development or testing. " +
       "In production, fetch tokens from your server instead."
   );


### PR DESCRIPTION
Devs don't need to know the token is a JWT. That's an implementation detail that leaks through the API name and makes it feel more complicated than it is.