### PR TITLE
[REA-1075][1/5] Add Versioning, Update Types for new Protocol

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "3.0.0",
+  "version": "2.7.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -32,6 +32,10 @@
     "sdk"
   ],
   "author": "Reactor Technologies, Inc.",
+  "reactor": {
+    "apiVersion": 1,
+    "webrtcVersion": "1.0"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -89,7 +89,7 @@ export const InitialSessionResponseSchema = z.object({
   session_id: z.string(),
   model: z.object({ name: z.string() }),
   server_info: z.object({ server_version: z.string() }).optional(),
-  status: z.string(),
+  state: z.string(),
   cluster: z.string().optional(),
 });
 
@@ -115,7 +115,7 @@ export const SessionResponseSchema = z.object({
   selected_transport: TransportDeclarationSchema.optional(),
   model: z.object({ name: z.string(), version: z.string().optional() }),
   capabilities: CapabilitiesSchema.optional(),
-  status: z.string(),
+  state: z.string(),
   cluster: z.string().optional(),
 });
 
@@ -129,7 +129,7 @@ export const CreateSessionResponseSchema = SessionResponseSchema.extend({
 export const SessionInfoResponseSchema = z.object({
   session_id: z.string(),
   cluster: z.string().optional(),
-  status: z.string(),
+  state: z.string(),
 });
 
 // DELETE /sessions/{id} — Request

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -93,11 +93,19 @@ export const InitialSessionResponseSchema = z.object({
   cluster: z.string().optional(),
 });
 
-// GET /sessions/{id} — Full response with capabilities (populated after Runtime accepts)
+// Mirrors the proto Command message.
+export const CommandCapabilitySchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  schema: z.record(z.string(), z.any()).optional(),
+});
+
+// GET /sessions/{id} — Full response with capabilities (populated after Runtime accepts).
+// Mirrors the proto TransportCapabilities message.
 export const CapabilitiesSchema = z.object({
   version: z.string(),
   tracks: z.array(TrackCapabilitySchema),
-  commands: z.record(z.string(), z.any()).optional(),
+  commands: z.array(CommandCapabilitySchema).optional(),
   emission_fps: z.number().nullable().optional(),
 });
 
@@ -168,6 +176,7 @@ export const WebRTCSdpAnswerResponseSchema = z.object({
 export type ClientInfo = z.infer<typeof ClientInfoSchema>;
 export type TransportDeclaration = z.infer<typeof TransportDeclarationSchema>;
 export type TrackCapability = z.infer<typeof TrackCapabilitySchema>;
+export type CommandCapability = z.infer<typeof CommandCapabilitySchema>;
 export type TrackMappingEntry = z.infer<typeof TrackMappingEntrySchema>;
 
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -69,7 +69,7 @@ export const TrackCapabilitySchema = z.object({
 });
 
 export const TrackMappingEntrySchema = TrackCapabilitySchema.extend({
-  id: z.string(),
+  mid: z.string(),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -166,7 +166,6 @@ export const WebRTCSdpOfferRequestSchema = z.object({
 // GET /sessions/{id}/transport/webrtc/sdp_params — Response (200)
 export const WebRTCSdpAnswerResponseSchema = z.object({
   sdp_answer: z.string(),
-  track_mapping: z.array(TrackMappingEntrySchema).optional(),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -1,91 +1,168 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
 /**
  * Internal types for the Reactor SDK.
+ *
+ * All Zod schemas and derived TypeScript types live here.
+ * Version constants are sourced from package.json via resolveJsonModule.
  */
 
 import { z } from "zod";
+import packageJson from "../../package.json";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Version Constants (single source of truth: package.json)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const REACTOR_SDK_VERSION: string = packageJson.version;
+export const REACTOR_API_VERSION: number = (packageJson as any).reactor
+  .apiVersion;
+export const REACTOR_WEBRTC_VERSION: string = (packageJson as any).reactor
+  .webrtcVersion;
+export const REACTOR_SDK_TYPE = "js" as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Versioning Headers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const API_VERSION_HEADER = "Reactor-API-Version";
+export const API_ACCEPT_VERSION_HEADER = "Reactor-API-Accept-Version";
+export const WEBRTC_VERSION_HEADER = "Reactor-WebRTC-Version";
+
+export const VERSION_ERROR_CODES = {
+  426: "CLIENT_VERSION_TOO_OLD",
+  501: "SERVER_VERSION_TOO_OLD",
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session States
+// ─────────────────────────────────────────────────────────────────────────────
 
 export enum SessionState {
-  CREATED,
-  PENDING,
-  SUSPENDED,
-  WAITING,
-  ACTIVE,
-  INACTIVE,
-  CLOSED,
+  CREATED = "CREATED",
+  PENDING = "PENDING",
+  SUSPENDED = "SUSPENDED",
+  WAITING = "WAITING",
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE",
+  CLOSED = "CLOSED",
 }
 
-export const ModelSchema = z.object({
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ClientInfoSchema = z.object({
+  sdk_version: z.string(),
+  sdk_type: z.literal("js"),
+});
+
+export const TransportDeclarationSchema = z.object({
+  protocol: z.string(),
+  version: z.string(),
+});
+
+export const TrackCapabilitySchema = z.object({
   name: z.string(),
+  kind: z.enum(["video", "audio"]),
+  direction: z.enum(["recvonly", "sendonly"]),
 });
 
-// Schema used for the HTTP POST request to start a session from the CLIENT to the COORDINATOR.
+export const TrackMappingEntrySchema = TrackCapabilitySchema.extend({
+  id: z.union([z.number(), z.string()]),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session API Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+// POST /sessions — Request
 export const CreateSessionRequestSchema = z.object({
-  model: ModelSchema,
-  sdp_offer: z.string(),
-  extra_args: z.record(z.string(), z.any()), // Dictionary
+  model: z.object({ name: z.string() }),
+  client_info: ClientInfoSchema,
+  supported_transports: z.array(TransportDeclarationSchema),
+  extra_args: z.record(z.string(), z.any()).optional(),
 });
 
-// Schema used to return the session ID that was created.
+// POST /sessions — Response (201)
+export const CapabilitiesSchema = z.object({
+  version: z.string(),
+  tracks: z.array(TrackCapabilitySchema),
+  commands: z.record(z.string(), z.any()).optional(),
+  emission_fps: z.number().optional(),
+});
+
 export const CreateSessionResponseSchema = z.object({
-  session_id: z.uuidv4(),
+  session_id: z.string().uuid(),
+  server_info: z.object({ server_version: z.string() }),
+  selected_transport: TransportDeclarationSchema,
+  model: z.object({ name: z.string(), version: z.string().optional() }),
+  capabilities: CapabilitiesSchema.optional(),
+  status: z.string(),
 });
 
-// GET /sessions/{session_id}/info
-export const SessionStatusResponseSchema = z.object({
-  session_id: z.uuidv4(),
-  state: SessionState,
+// GET /sessions/{id}/info — Response (200)
+export const SessionInfoResponseSchema = z.object({
+  session_id: z.string().uuid(),
+  cluster: z.string().optional(),
+  status: z.string(),
 });
 
-// Response to GET /session/{session_id} request
-export const SessionInfoResponseSchema = SessionStatusResponseSchema.extend({
-  session_info: CreateSessionRequestSchema.extend({
-    session_id: z.uuidv4(),
-  }),
+// DELETE /sessions/{id} — Request
+export const TerminateSessionRequestSchema = z.object({
+  reason: z.string().optional(),
 });
 
-// SDPParamsRequest is the request body for PUT /sessions/{session_id}/sdp_params
-export const SDPParamsRequestSchema = z.object({
-  sdp_offer: z.string(),
-  extra_args: z.record(z.string(), z.any()), // Dictionary
+// ─────────────────────────────────────────────────────────────────────────────
+// WebRTC Transport Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+// GET /sessions/{id}/transport/webrtc/ice_servers — Response (200)
+export const IceServerSchema = z.object({
+  urls: z.array(z.string()),
+  username: z.string().optional(),
+  credential: z.string().optional(),
 });
 
-// SDPParamsResponse is the response for GET /sessions/{session_id}/sdp_params
-// and for for PUT /sessions/{session_id}/sdp_params.
-export const SDPParamsResponseSchema = z.object({
-  sdp_answer: z.string(),
-  extra_args: z.record(z.string(), z.any()), // Dictionary
-});
-
-// Response from GET /ice_servers endpoint (coordinator)
 export const IceServersResponseSchema = z.object({
-  ice_servers: z.array(
-    z.object({
-      uris: z.array(z.string()),
-      credentials: z
-        .object({
-          username: z.string(),
-          password: z.string(),
-        })
-        .optional(),
-    })
-  ),
+  ice_servers: z.array(IceServerSchema),
 });
 
-// Internal connection status for individual components
-export type InternalConnectionStatus =
-  | "disconnected"
-  | "connecting"
-  | "connected"
-  | "error";
+// POST/PUT /sessions/{id}/transport/webrtc/sdp_params — Request
+export const WebRTCSdpOfferRequestSchema = z.object({
+  sdp_offer: z.string(),
+  client_info: ClientInfoSchema.optional(),
+  track_mapping: z.array(TrackMappingEntrySchema),
+});
 
-// Inferred types from Zod schemas
+// GET /sessions/{id}/transport/webrtc/sdp_params — Response (200)
+export const WebRTCSdpAnswerResponseSchema = z.object({
+  sdp_answer: z.string(),
+  track_mapping: z.array(TrackMappingEntrySchema).optional(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inferred TypeScript Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ClientInfo = z.infer<typeof ClientInfoSchema>;
+export type TransportDeclaration = z.infer<typeof TransportDeclarationSchema>;
+export type TrackCapability = z.infer<typeof TrackCapabilitySchema>;
+export type TrackMappingEntry = z.infer<typeof TrackMappingEntrySchema>;
+
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
 export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>;
-
-export type SDPParamsResponse = z.infer<typeof SDPParamsResponseSchema>;
-export type SDPParamsRequest = z.infer<typeof SDPParamsRequestSchema>;
+export type Capabilities = z.infer<typeof CapabilitiesSchema>;
 
 export type SessionInfoResponse = z.infer<typeof SessionInfoResponseSchema>;
-export type SessionStatusResponse = z.infer<typeof SessionStatusResponseSchema>;
+export type TerminateSessionRequest = z.infer<
+  typeof TerminateSessionRequestSchema
+>;
 
+export type IceServer = z.infer<typeof IceServerSchema>;
 export type IceServersResponse = z.infer<typeof IceServersResponseSchema>;
+
+export type WebRTCSdpOfferRequest = z.infer<typeof WebRTCSdpOfferRequestSchema>;
+export type WebRTCSdpAnswerResponse = z.infer<
+  typeof WebRTCSdpAnswerResponseSchema
+>;

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -88,7 +88,7 @@ export const CreateSessionRequestSchema = z.object({
 export const InitialSessionResponseSchema = z.object({
   session_id: z.string(),
   model: z.object({ name: z.string() }),
-  server_info: z.object({ server_version: z.string() }),
+  server_info: z.object({ server_version: z.string() }).optional(),
   status: z.string(),
   cluster: z.string().optional(),
 });
@@ -111,7 +111,7 @@ export const CapabilitiesSchema = z.object({
 
 export const SessionResponseSchema = z.object({
   session_id: z.string(),
-  server_info: z.object({ server_version: z.string() }),
+  server_info: z.object({ server_version: z.string() }).optional(),
   selected_transport: TransportDeclarationSchema.optional(),
   model: z.object({ name: z.string(), version: z.string().optional() }),
   capabilities: CapabilitiesSchema.optional(),

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -69,7 +69,7 @@ export const TrackCapabilitySchema = z.object({
 });
 
 export const TrackMappingEntrySchema = TrackCapabilitySchema.extend({
-  id: z.union([z.number(), z.string()]),
+  id: z.string(),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -84,26 +84,42 @@ export const CreateSessionRequestSchema = z.object({
   extra_args: z.record(z.string(), z.any()).optional(),
 });
 
-// POST /sessions — Response (201)
+// POST /sessions — Response (201): slim initial response before Runtime accepts
+export const InitialSessionResponseSchema = z.object({
+  session_id: z.string(),
+  model: z.object({ name: z.string() }),
+  server_info: z.object({ server_version: z.string() }),
+  status: z.string(),
+  cluster: z.string().optional(),
+});
+
+// GET /sessions/{id} — Full response with capabilities (populated after Runtime accepts)
 export const CapabilitiesSchema = z.object({
   version: z.string(),
   tracks: z.array(TrackCapabilitySchema),
   commands: z.record(z.string(), z.any()).optional(),
-  emission_fps: z.number().optional(),
+  emission_fps: z.number().nullable().optional(),
 });
 
-export const CreateSessionResponseSchema = z.object({
-  session_id: z.string().uuid(),
+export const SessionResponseSchema = z.object({
+  session_id: z.string(),
   server_info: z.object({ server_version: z.string() }),
-  selected_transport: TransportDeclarationSchema,
+  selected_transport: TransportDeclarationSchema.optional(),
   model: z.object({ name: z.string(), version: z.string().optional() }),
   capabilities: CapabilitiesSchema.optional(),
   status: z.string(),
+  cluster: z.string().optional(),
+});
+
+// Full session response: selected_transport and capabilities are guaranteed present
+export const CreateSessionResponseSchema = SessionResponseSchema.extend({
+  selected_transport: TransportDeclarationSchema,
+  capabilities: CapabilitiesSchema,
 });
 
 // GET /sessions/{id}/info — Response (200)
 export const SessionInfoResponseSchema = z.object({
-  session_id: z.string().uuid(),
+  session_id: z.string(),
   cluster: z.string().optional(),
   status: z.string(),
 });
@@ -118,10 +134,14 @@ export const TerminateSessionRequestSchema = z.object({
 // ─────────────────────────────────────────────────────────────────────────────
 
 // GET /sessions/{id}/transport/webrtc/ice_servers — Response (200)
+export const IceServerCredentialsSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});
+
 export const IceServerSchema = z.object({
-  urls: z.array(z.string()),
-  username: z.string().optional(),
-  credential: z.string().optional(),
+  uris: z.array(z.string()),
+  credentials: IceServerCredentialsSchema.optional(),
 });
 
 export const IceServersResponseSchema = z.object({
@@ -151,6 +171,10 @@ export type TrackCapability = z.infer<typeof TrackCapabilitySchema>;
 export type TrackMappingEntry = z.infer<typeof TrackMappingEntrySchema>;
 
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
+export type InitialSessionResponse = z.infer<
+  typeof InitialSessionResponseSchema
+>;
+export type SessionResponse = z.infer<typeof SessionResponseSchema>;
 export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>;
 export type Capabilities = z.infer<typeof CapabilitiesSchema>;
 

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -103,7 +103,7 @@ export const CommandCapabilitySchema = z.object({
 // GET /sessions/{id} — Full response with capabilities (populated after Runtime accepts).
 // Mirrors the proto TransportCapabilities message.
 export const CapabilitiesSchema = z.object({
-  version: z.string(),
+  protocol_version: z.string(),
   tracks: z.array(TrackCapabilitySchema),
   commands: z.array(CommandCapabilitySchema).optional(),
   emission_fps: z.number().nullable().optional(),

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./core/Reactor";
+export * from "./core/TransportClient";
+export * from "./core/WebRTCTransportClient";
 export * from "./react/ReactorProvider";
 export * from "./react/ReactorView";
 export * from "./react/ReactorController";

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -13,89 +13,13 @@ export type ReactorStatus =
  */
 export type MessageScope = "application" | "runtime";
 
-/**
- * Describes a single named media track for SDP negotiation.
- *
- * Track names must exactly match the class attribute names defined on the
- * model's Python code.  The name is encoded as the SDP MID so both sides
- * can route media by name rather than by positional index.
- *
- * Use the {@link video} and {@link audio} helper functions to create
- * instances instead of constructing this interface directly.
- */
-export interface TrackConfig {
-  name: string;
-  kind: "audio" | "video";
-}
-
-/**
- * Optional configuration for a video track (reserved for future use).
- */
-export interface VideoTrackOptions {
-  /** Maximum framerate constraint for the video track. */
-  maxFramerate?: number;
-}
-
-/**
- * Optional configuration for an audio track (reserved for future use).
- */
-export interface AudioTrackOptions {
-  /** Sample rate constraint for the audio track. */
-  sampleRate?: number;
-}
-
-/**
- * Creates a **video** {@link TrackConfig}.
- *
- * A track declared in the **`receive`** array means the client will
- * **RECEIVE** video frames **from the model** (model → client).
- *
- * A track declared in the **`send`** array means the client will
- * **SEND** video frames **to the model** (client → model).
- *
- * Track names must be unique across both arrays — the same name cannot
- * appear in `receive` and `send`.
- *
- * @param name    - The track name.  Must match the model's declared track attribute name.
- * @param options - Reserved for future constraints (e.g. `maxFramerate`).
- *
- * When no `receive` array is provided to the Reactor constructor, a single
- * `video("main_video")` track is used by default.
- *
- * @example
- * ```ts
- * receive: [video("main_video")]          // receive video from the model
- * send:    [video("webcam")]              // send webcam video to the model
- * ```
- */
-export function video(name: string, _options?: VideoTrackOptions): TrackConfig {
-  return { name, kind: "video" };
-}
-
-/**
- * Creates an **audio** {@link TrackConfig}.
- *
- * A track declared in the **`receive`** array means the client will
- * **RECEIVE** audio samples **from the model** (model → client).
- *
- * A track declared in the **`send`** array means the client will
- * **SEND** audio samples **to the model** (client → model).
- *
- * Track names must be unique across both arrays — the same name cannot
- * appear in `receive` and `send`.
- *
- * @param name    - The track name.  Must match the model's declared track attribute name.
- * @param options - Reserved for future constraints (e.g. `sampleRate`).
- *
- * @example
- * ```ts
- * receive: [audio("main_audio")]          // receive audio from the model
- * send:    [audio("mic")]                 // send microphone audio to the model
- * ```
- */
-export function audio(name: string, _options?: AudioTrackOptions): TrackConfig {
-  return { name, kind: "audio" };
-}
+// Re-export core types that users may need
+export type {
+  TrackCapability,
+  Capabilities,
+  TransportDeclaration,
+  CreateSessionResponse as SessionInfo,
+} from "./core/types";
 
 export interface ReactorError {
   code: string;
@@ -140,21 +64,18 @@ export interface ConnectOptions {
 }
 
 /**
- * One-shot timing breakdown of the connect() handshake, recorded once per
- * connection and included in every subsequent {@link ConnectionStats} update.
- * All durations are in milliseconds (from `performance.now()`).
+ * Transport-agnostic timing breakdown of the connect() handshake, recorded
+ * once per connection and included in every subsequent {@link ConnectionStats}
+ * update. All durations are in milliseconds (from `performance.now()`).
+ *
+ * For transport-specific timings (e.g. ICE negotiation, data channel open),
+ * see the relevant transport stats type (e.g. {@link WebRTCTransportTimings}).
  */
 export interface ConnectionTimings {
   /** POST /sessions round-trip time */
   sessionCreationMs: number;
-  /** Total time spent polling for the SDP answer */
-  sdpPollingMs: number;
-  /** Number of SDP poll requests made (1 = answered on first try) */
-  sdpPollingAttempts: number;
-  /** setRemoteDescription → RTCPeerConnection connectionState "connected" */
-  iceNegotiationMs: number;
-  /** setRemoteDescription → RTCDataChannel "open" */
-  dataChannelMs: number;
+  /** Total time spent in transport.connect() (signaling, negotiation, etc.) */
+  transportConnectingMs: number;
   /** End-to-end: connect() invocation → status "ready" */
   totalMs: number;
 }
@@ -185,4 +106,5 @@ export type ReactorEvent =
   | "trackReceived" // (name: string, track: MediaStreamTrack, stream: MediaStream)
   | "error" //error events with ReactorError details
   | "sessionExpirationChanged" //session expiration has changed
+  | "capabilitiesReceived" //server capabilities received after session creation
   | "statsUpdate"; //WebRTC stats update (RTT, etc.)

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -16,6 +16,7 @@ export type MessageScope = "application" | "runtime";
 // Re-export core types that users may need
 export type {
   TrackCapability,
+  CommandCapability,
   Capabilities,
   TransportDeclaration,
   CreateSessionResponse as SessionInfo,

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -13,7 +13,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "resolveJsonModule": true
   },
-  "include": ["src", "bin"]
+  "include": ["src", "bin", "package.json"]
 }


### PR DESCRIPTION
Why
---
The session establishment protocol is being redesigned to decouple
session lifecycle from transport signaling. This first PR lays the
foundation: version constants, versioning headers, and all Zod
schemas aligned to the new REST API contract.

What Changed
---
- Bumped package version to 3.0.0 (breaking: new protocol).
- Added `reactor.apiVersion` and `reactor.webrtcVersion` to
  package.json as the single source of truth for version numbers.
- Enabled `resolveJsonModule` in tsconfig so types.ts can import
  version constants directly from package.json at compile time.
- Rewrote `core/types.ts`: replaced old schemas (ModelSchema,
  SDPParamsRequest/Response, SessionStatusResponse, IceServersResponse
  with nested `uris`/`credentials`) with new ones matching the REST
  API v1 contract (CreateSessionRequest/Response, Capabilities,
  TrackCapability, TrackMappingEntry, WebRTCSdpOffer/Answer,
  IceServer with flat `urls`/`username`/`credential`).
- Added version constants (REACTOR_SDK_VERSION, REACTOR_API_VERSION,
  REACTOR_WEBRTC_VERSION), header names, and VERSION_ERROR_CODES.
- SessionState enum now uses string values instead of numeric.
- Removed old client-side track helpers (`video()`, `audio()`,
  TrackConfig) from `src/types.ts` — tracks are now server-declared
  via capabilities. Re-exports new core types (TrackCapability,
  Capabilities, TransportDeclaration, SessionInfo) instead.
- `ConnectionTimings` is now transport-agnostic: `sessionCreationMs`,
  `transportConnectingMs`, `totalMs`. WebRTC-specific timings will
  live in `WebRTCTransportTimings` (next PR).
- Added `capabilitiesReceived` to `ReactorEvent` union.
- Exported `TransportClient` and `WebRTCTransportClient` from index
  (files land in next PRs).

New Protocol
---
- API versioning via `Reactor-API-Version` / `Reactor-API-Accept-Version`
  headers; transport versioning via `Reactor-WebRTC-Version`.
- Session creation no longer carries SDP — it sends `client_info` and
  `supported_transports`, receives `selected_transport` + `capabilities`.
- Capabilities declare tracks as an array of `{ name, kind, direction }`
  using WebRTC terminology (`recvonly`/`sendonly`).
- SDP exchange uses explicit `track_mapping` instead of MID munging.

Upcoming
---
- [2/5] CoordinatorClient + LocalCoordinatorClient rewrite
- [3/5] TransportClient interface + WebRTCTransportClient
- [4/5] Reactor.ts orchestration update
- [5/5] Update tests

topic: REA-1075-add-protocol-versioning-types
reviewers: bryce, massenz