### PR TITLE
[REA-1075][2/5] Update CoordinatorClient and LocalCoordinatorClient flow

### DIFF
--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -40,10 +40,10 @@ export interface CoordinatorClientOptions {
 }
 
 export class CoordinatorClient {
-  private baseUrl: string;
+  protected readonly baseUrl: string;
   private jwtToken: string;
-  private model: string;
-  private currentSessionId?: string;
+  protected readonly model: string;
+  protected currentSessionId?: string;
   private abortController: AbortController;
 
   constructor(options: CoordinatorClientOptions) {

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -28,7 +28,7 @@ import {
 } from "./types";
 import { AbortError } from "../types";
 
-const SESSION_POLL_INITIAL_BACKOFF_MS = 500;
+const SESSION_POLL_INITIAL_BACKOFF_MS = 200;
 const SESSION_POLL_MAX_BACKOFF_MS = 10_000;
 const SESSION_POLL_BACKOFF_MULTIPLIER = 2;
 const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 20;

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -173,8 +173,8 @@ export class CoordinatorClient {
     console.debug(
       "[CoordinatorClient] Session created:",
       this.currentSessionId,
-      "status:",
-      parsed.status
+      "state:",
+      parsed.state
     );
 
     return parsed;
@@ -238,9 +238,9 @@ export class CoordinatorClient {
         SessionState.CLOSED,
         SessionState.INACTIVE,
       ];
-      if (terminalStates.includes(partial.status)) {
+      if (terminalStates.includes(partial.state)) {
         throw new Error(
-          `Session entered terminal state "${partial.status}" while waiting for capabilities`
+          `Session entered terminal state "${partial.state}" while waiting for capabilities`
         );
       }
 
@@ -256,7 +256,7 @@ export class CoordinatorClient {
 
       console.debug(
         `[CoordinatorClient] Session poll ${attempt}/${maxAttempts} — ` +
-          `status: ${partial.status}, waiting ${backoffMs}ms...`
+          `state: ${partial.state}, waiting ${backoffMs}ms...`
       );
 
       await this.sleep(backoffMs);

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -1,30 +1,34 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
 /**
- * The CoordinatorClient is responsible for handling the connection to the coordinator
- * via HTTP requests and WebRTC signaling.
+ * The CoordinatorClient handles session lifecycle via HTTP requests.
+ *
+ * Transport signaling (ICE servers, SDP exchange) is NOT handled here —
+ * that responsibility belongs to the TransportClient implementations.
  */
 
 import {
-  CreateSessionRequest,
-  CreateSessionResponse,
-  IceServersResponseSchema,
-  SDPParamsRequest,
-  SDPParamsResponse,
-  SessionInfoResponse,
+  type CreateSessionRequest,
+  type CreateSessionResponse,
+  type SessionInfoResponse,
+  type TerminateSessionRequest,
+  CreateSessionResponseSchema,
+  SessionInfoResponseSchema,
+  REACTOR_API_VERSION,
+  REACTOR_SDK_VERSION,
+  REACTOR_SDK_TYPE,
+  REACTOR_WEBRTC_VERSION,
+  API_VERSION_HEADER,
+  API_ACCEPT_VERSION_HEADER,
+  VERSION_ERROR_CODES,
 } from "./types";
 import { AbortError } from "../types";
-import { transformIceServers } from "../utils/webrtc";
 
 export interface CoordinatorClientOptions {
   baseUrl: string;
   jwtToken: string;
   model: string;
 }
-
-// Polling configuration
-const INITIAL_BACKOFF_MS = 500;
-const MAX_BACKOFF_MS = 15000;
-const BACKOFF_MULTIPLIER = 2;
-const DEFAULT_MAX_ATTEMPTS = 6;
 
 export class CoordinatorClient {
   private baseUrl: string;
@@ -41,7 +45,7 @@ export class CoordinatorClient {
   }
 
   /**
-   * Aborts any in-flight HTTP requests and polling loops.
+   * Aborts any in-flight HTTP requests.
    * A fresh AbortController is created so the client remains reusable.
    */
   abort(): void {
@@ -50,7 +54,7 @@ export class CoordinatorClient {
   }
 
   /**
-   * The current abort signal, passed to every fetch() and sleep() call.
+   * The current abort signal, passed to every fetch() call.
    * Protected so subclasses can forward it to their own fetch calls.
    */
   protected get signal(): AbortSignal {
@@ -58,68 +62,71 @@ export class CoordinatorClient {
   }
 
   /**
-   * Returns the authorization header with JWT Bearer token
+   * Returns authorization + versioning headers for all coordinator requests.
    */
-  private getAuthHeaders(): HeadersInit {
+  protected getHeaders(): HeadersInit {
     return {
       Authorization: `Bearer ${this.jwtToken}`,
+      [API_VERSION_HEADER]: String(REACTOR_API_VERSION),
+      [API_ACCEPT_VERSION_HEADER]: String(REACTOR_API_VERSION),
     };
   }
 
   /**
-   * Fetches ICE servers from the coordinator.
-   * @returns Array of RTCIceServer objects for WebRTC peer connection configuration
+   * Checks an HTTP response for version mismatch errors (426, 501).
+   * Logs a clear message and throws with a descriptive error code.
    */
-  async getIceServers(): Promise<RTCIceServer[]> {
-    console.debug("[CoordinatorClient] Fetching ICE servers...");
-
-    const response = await fetch(
-      `${this.baseUrl}/ice_servers?model=${this.model}`,
-      {
-        method: "GET",
-        headers: this.getAuthHeaders(),
-        signal: this.signal,
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ICE servers: ${response.status}`);
+  protected async checkVersionMismatch(response: Response): Promise<void> {
+    if (response.status === 426) {
+      const msg =
+        `Client API version (${REACTOR_API_VERSION}) is too old. ` +
+        `Server requires a newer version. Please upgrade @reactor-team/js-sdk.`;
+      console.error(`[Reactor]`, msg);
+      throw new Error(`${VERSION_ERROR_CODES[426]}: ${msg}`);
     }
 
-    const data = await response.json();
-    const parsed = IceServersResponseSchema.parse(data);
-    const iceServers = transformIceServers(parsed);
-
-    console.debug(
-      "[CoordinatorClient] Received ICE servers:",
-      iceServers.length
-    );
-    return iceServers;
+    if (response.status === 501) {
+      const msg =
+        `Server does not support API version ${REACTOR_API_VERSION}. ` +
+        `The server may need to be updated.`;
+      console.error(`[Reactor]`, msg);
+      throw new Error(`${VERSION_ERROR_CODES[501]}: ${msg}`);
+    }
   }
 
   /**
    * Creates a new session with the coordinator.
-   * Expects a 200 response and stores the session ID.
-   * @returns The session ID
+   * No SDP is sent — transport signaling is decoupled from session creation.
+   * @returns The full session creation response (session_id, selected_transport, capabilities, etc.)
    */
-  async createSession(sdp_offer: string): Promise<string> {
+  async createSession(
+    extraArgs?: Record<string, any>
+  ): Promise<CreateSessionResponse> {
     console.debug("[CoordinatorClient] Creating session...");
 
     const requestBody: CreateSessionRequest = {
       model: { name: this.model },
-      sdp_offer: sdp_offer,
-      extra_args: {},
+      client_info: {
+        sdk_version: REACTOR_SDK_VERSION,
+        sdk_type: REACTOR_SDK_TYPE,
+      },
+      supported_transports: [
+        { protocol: "webrtc", version: REACTOR_WEBRTC_VERSION },
+      ],
+      ...(extraArgs ? { extra_args: extraArgs } : {}),
     };
 
     const response = await fetch(`${this.baseUrl}/sessions`, {
       method: "POST",
       headers: {
-        ...this.getAuthHeaders(),
+        ...this.getHeaders(),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
       signal: this.signal,
     });
+
+    await this.checkVersionMismatch(response);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -128,56 +135,118 @@ export class CoordinatorClient {
       );
     }
 
-    const data: CreateSessionResponse = await response.json();
-    this.currentSessionId = data.session_id;
+    const data = await response.json();
+    const parsed = CreateSessionResponseSchema.parse(data);
+    this.currentSessionId = parsed.session_id;
 
     console.debug(
-      "[CoordinatorClient] Session created with ID:",
-      this.currentSessionId
+      "[CoordinatorClient] Session created:",
+      this.currentSessionId,
+      "transport:",
+      parsed.selected_transport.protocol
     );
 
-    return data.session_id;
+    return parsed;
   }
 
   /**
-   * Gets the current session information from the coordinator.
-   * @returns The session data (untyped for now)
+   * Gets full session details from the coordinator.
+   * Returns the same shape as the creation response but with updated state.
    */
-  async getSession(): Promise<SessionInfoResponse> {
+  async getSession(): Promise<CreateSessionResponse> {
     if (!this.currentSessionId) {
       throw new Error("No active session. Call createSession() first.");
     }
-
-    console.debug(
-      "[CoordinatorClient] Getting session info for:",
-      this.currentSessionId
-    );
 
     const response = await fetch(
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "GET",
-        headers: this.getAuthHeaders(),
+        headers: this.getHeaders(),
         signal: this.signal,
       }
     );
+
+    await this.checkVersionMismatch(response);
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(`Failed to get session: ${response.status} ${errorText}`);
     }
 
-    const data: SessionInfoResponse = await response.json();
-
-    return data;
+    const data = await response.json();
+    return CreateSessionResponseSchema.parse(data);
   }
 
   /**
-   * Terminates the current session by sending a DELETE request to the coordinator.
-   * No-op if no session has been created yet.
-   * @throws Error if the request fails (except for 404, which clears local state)
+   * Gets lightweight session status (session_id, cluster, status).
    */
-  async terminateSession(): Promise<void> {
+  async getSessionInfo(): Promise<SessionInfoResponse> {
+    if (!this.currentSessionId) {
+      throw new Error("No active session. Call createSession() first.");
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/sessions/${this.currentSessionId}/info`,
+      {
+        method: "GET",
+        headers: this.getHeaders(),
+        signal: this.signal,
+      }
+    );
+
+    await this.checkVersionMismatch(response);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to get session info: ${response.status} ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+    return SessionInfoResponseSchema.parse(data);
+  }
+
+  /**
+   * Restarts an inactive session with a different compute unit.
+   * The session ID is preserved but a new transport must be established.
+   */
+  async restartSession(): Promise<void> {
+    if (!this.currentSessionId) {
+      throw new Error("No active session. Call createSession() first.");
+    }
+
+    console.debug(
+      "[CoordinatorClient] Restarting session:",
+      this.currentSessionId
+    );
+
+    const response = await fetch(
+      `${this.baseUrl}/sessions/${this.currentSessionId}`,
+      {
+        method: "PUT",
+        headers: this.getHeaders(),
+        signal: this.signal,
+      }
+    );
+
+    await this.checkVersionMismatch(response);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to restart session: ${response.status} ${errorText}`
+      );
+    }
+  }
+
+  /**
+   * Terminates the current session by sending a DELETE request.
+   * No-op if no session has been created yet.
+   * @param reason Optional termination reason
+   */
+  async terminateSession(reason?: string): Promise<void> {
     if (!this.currentSessionId) {
       return;
     }
@@ -187,11 +256,19 @@ export class CoordinatorClient {
       this.currentSessionId
     );
 
+    const body: TerminateSessionRequest | undefined = reason
+      ? { reason }
+      : undefined;
+
     const response = await fetch(
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "DELETE",
-        headers: this.getAuthHeaders(),
+        headers: {
+          ...this.getHeaders(),
+          ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
         signal: this.signal,
       }
     );
@@ -202,7 +279,6 @@ export class CoordinatorClient {
     }
 
     if (response.status === 404) {
-      // Session doesn't exist on server, clear local state to stay consistent
       console.debug(
         "[CoordinatorClient] Session not found on server, clearing local state:",
         this.currentSessionId
@@ -211,196 +287,13 @@ export class CoordinatorClient {
       return;
     }
 
-    // For other error codes, throw without clearing state (might warrant retry)
     const errorText = await response.text();
     throw new Error(
       `Failed to terminate session: ${response.status} ${errorText}`
     );
   }
 
-  /**
-   * Get the current session ID
-   */
   getSessionId(): string | undefined {
     return this.currentSessionId;
-  }
-
-  /**
-   * Sends an SDP offer to the server for reconnection.
-   * @param sessionId - The session ID to connect to
-   * @param sdpOffer - The SDP offer from the local WebRTC peer connection
-   * @returns The SDP answer if ready (200), or null if pending (202)
-   */
-  private async sendSdpOffer(
-    sessionId: string,
-    sdpOffer: string
-  ): Promise<string | null> {
-    console.debug(
-      "[CoordinatorClient] Sending SDP offer for session:",
-      sessionId
-    );
-
-    const requestBody: SDPParamsRequest = {
-      sdp_offer: sdpOffer,
-      extra_args: {},
-    };
-
-    const response = await fetch(
-      `${this.baseUrl}/sessions/${sessionId}/sdp_params`,
-      {
-        method: "PUT",
-        headers: {
-          ...this.getAuthHeaders(),
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-        signal: this.signal,
-      }
-    );
-
-    if (response.status === 200) {
-      const answerData: SDPParamsResponse = await response.json();
-      console.debug("[CoordinatorClient] Received SDP answer immediately");
-      return answerData.sdp_answer;
-    }
-
-    if (response.status === 202) {
-      console.debug(
-        "[CoordinatorClient] SDP offer accepted, answer pending (202)"
-      );
-      return null;
-    }
-
-    const errorText = await response.text();
-    throw new Error(
-      `Failed to send SDP offer: ${response.status} ${errorText}`
-    );
-  }
-
-  /**
-   * Polls for the SDP answer with exponential backoff.
-   * Used for async reconnection when the answer is not immediately available.
-   * @param sessionId - The session ID to poll for
-   * @param maxAttempts - Optional maximum number of polling attempts before giving up
-   * @returns The SDP answer from the server
-   */
-  private async pollSdpAnswer(
-    sessionId: string,
-    maxAttempts: number = DEFAULT_MAX_ATTEMPTS
-  ): Promise<{ sdpAnswer: string; attempts: number }> {
-    console.debug(
-      "[CoordinatorClient] Polling for SDP answer for session:",
-      sessionId
-    );
-
-    let backoffMs = INITIAL_BACKOFF_MS;
-    let attempt = 0;
-
-    while (true) {
-      if (this.signal.aborted) {
-        throw new AbortError("SDP polling aborted");
-      }
-
-      if (attempt >= maxAttempts) {
-        throw new Error(
-          `SDP polling exceeded maximum attempts (${maxAttempts}) for session ${sessionId}`
-        );
-      }
-
-      attempt++;
-      console.debug(
-        `[CoordinatorClient] SDP poll attempt ${attempt}/${maxAttempts} for session ${sessionId}`
-      );
-
-      const response = await fetch(
-        `${this.baseUrl}/sessions/${sessionId}/sdp_params`,
-        {
-          method: "GET",
-          headers: {
-            ...this.getAuthHeaders(),
-            "Content-Type": "application/json",
-          },
-          signal: this.signal,
-        }
-      );
-
-      if (response.status === 200) {
-        const answerData: SDPParamsResponse = await response.json();
-        console.debug("[CoordinatorClient] Received SDP answer via polling");
-        return { sdpAnswer: answerData.sdp_answer, attempts: attempt };
-      }
-
-      if (response.status === 202) {
-        console.warn(
-          `[CoordinatorClient] SDP answer pending (202), retrying in ${backoffMs}ms...`
-        );
-
-        await this.sleep(backoffMs);
-
-        // Exponential backoff capped at MAX_BACKOFF_MS (15s)
-        backoffMs = Math.min(backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
-        continue;
-      }
-
-      // For other error codes, throw immediately
-      const errorText = await response.text();
-      throw new Error(
-        `Failed to poll SDP answer: ${response.status} ${errorText}`
-      );
-    }
-  }
-
-  /**
-   * Connects to the session by sending an SDP offer and receiving an SDP answer.
-   * If sdpOffer is provided, sends it first. If the answer is pending (202),
-   * falls back to polling. If no sdpOffer is provided, goes directly to polling.
-   * @param sessionId - The session ID to connect to
-   * @param sdpOffer - Optional SDP offer from the local WebRTC peer connection
-   * @param maxAttempts - Optional maximum number of polling attempts before giving up
-   * @returns The SDP answer and the number of polling attempts made (0 if answered immediately via PUT)
-   */
-  async connect(
-    sessionId: string,
-    sdpOffer?: string,
-    maxAttempts?: number
-  ): Promise<{ sdpAnswer: string; sdpPollingAttempts: number }> {
-    console.debug("[CoordinatorClient] Connecting to session:", sessionId);
-
-    if (sdpOffer) {
-      // Reconnection: we have a new SDP offer (recalculated after ICE restart)
-      // Try to send it and get an immediate answer
-      const answer = await this.sendSdpOffer(sessionId, sdpOffer);
-      if (answer !== null) {
-        return { sdpAnswer: answer, sdpPollingAttempts: 0 };
-      }
-      // Server accepted but answer not ready yet (202), fall back to polling
-    }
-
-    // No SDP offer = async reconnection, poll until server has the answer
-    const result = await this.pollSdpAnswer(sessionId, maxAttempts);
-    return { sdpAnswer: result.sdpAnswer, sdpPollingAttempts: result.attempts };
-  }
-
-  /**
-   * Abort-aware sleep. Resolves after `ms` milliseconds unless the
-   * abort signal fires first, in which case it rejects with AbortError.
-   */
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const { signal } = this;
-      if (signal.aborted) {
-        reject(new AbortError("Sleep aborted"));
-        return;
-      }
-      const timer = setTimeout(() => {
-        signal.removeEventListener("abort", onAbort);
-        resolve();
-      }, ms);
-      const onAbort = () => {
-        clearTimeout(timer);
-        reject(new AbortError("Sleep aborted"));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
   }
 }

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -10,10 +10,14 @@
 import {
   type CreateSessionRequest,
   type CreateSessionResponse,
+  type InitialSessionResponse,
   type SessionInfoResponse,
   type TerminateSessionRequest,
   CreateSessionResponseSchema,
+  InitialSessionResponseSchema,
+  SessionResponseSchema,
   SessionInfoResponseSchema,
+  SessionState,
   REACTOR_API_VERSION,
   REACTOR_SDK_VERSION,
   REACTOR_SDK_TYPE,
@@ -23,6 +27,11 @@ import {
   VERSION_ERROR_CODES,
 } from "./types";
 import { AbortError } from "../types";
+
+const SESSION_POLL_INITIAL_BACKOFF_MS = 500;
+const SESSION_POLL_MAX_BACKOFF_MS = 10_000;
+const SESSION_POLL_BACKOFF_MULTIPLIER = 2;
+const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 20;
 
 export interface CoordinatorClientOptions {
   baseUrl: string;
@@ -94,14 +103,36 @@ export class CoordinatorClient {
     }
   }
 
+  protected sleep(ms: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const { signal } = this;
+      if (signal.aborted) {
+        reject(new AbortError("Sleep aborted"));
+        return;
+      }
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new AbortError("Sleep aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
   /**
    * Creates a new session with the coordinator.
    * No SDP is sent — transport signaling is decoupled from session creation.
-   * @returns The full session creation response (session_id, selected_transport, capabilities, etc.)
+   *
+   * The POST response is a slim acknowledgment (session_id, model name, status).
+   * Capabilities and transport details are populated later once the Runtime
+   * accepts the session — use {@link pollSessionReady} to wait for them.
    */
   async createSession(
     extraArgs?: Record<string, any>
-  ): Promise<CreateSessionResponse> {
+  ): Promise<InitialSessionResponse> {
     console.debug("[CoordinatorClient] Creating session...");
 
     const requestBody: CreateSessionRequest = {
@@ -136,17 +167,105 @@ export class CoordinatorClient {
     }
 
     const data = await response.json();
-    const parsed = CreateSessionResponseSchema.parse(data);
+    const parsed = InitialSessionResponseSchema.parse(data);
     this.currentSessionId = parsed.session_id;
 
     console.debug(
       "[CoordinatorClient] Session created:",
       this.currentSessionId,
-      "transport:",
-      parsed.selected_transport.protocol
+      "status:",
+      parsed.status
     );
 
     return parsed;
+  }
+
+  /**
+   * Polls GET /sessions/{id} until the Runtime has accepted the session
+   * and populated capabilities and selected_transport.
+   */
+  async pollSessionReady(opts?: {
+    maxAttempts?: number;
+  }): Promise<CreateSessionResponse> {
+    if (!this.currentSessionId) {
+      throw new Error("No active session. Call createSession() first.");
+    }
+
+    const maxAttempts =
+      opts?.maxAttempts ?? SESSION_POLL_DEFAULT_MAX_ATTEMPTS;
+    let backoffMs = SESSION_POLL_INITIAL_BACKOFF_MS;
+    let attempt = 0;
+
+    console.debug(
+      "[CoordinatorClient] Polling session until capabilities are available..."
+    );
+
+    while (true) {
+      if (this.signal.aborted) {
+        throw new AbortError("Session polling aborted");
+      }
+
+      if (attempt >= maxAttempts) {
+        throw new Error(
+          `Session polling exceeded maximum attempts (${maxAttempts}). ` +
+            `The model may be unavailable or overloaded.`
+        );
+      }
+
+      attempt++;
+
+      const response = await fetch(
+        `${this.baseUrl}/sessions/${this.currentSessionId}`,
+        {
+          method: "GET",
+          headers: this.getHeaders(),
+          signal: this.signal,
+        }
+      );
+
+      await this.checkVersionMismatch(response);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Failed to poll session: ${response.status} ${errorText}`
+        );
+      }
+
+      const data = await response.json();
+      const partial = SessionResponseSchema.parse(data);
+
+      const terminalStates: string[] = [
+        SessionState.CLOSED,
+        SessionState.INACTIVE,
+      ];
+      if (terminalStates.includes(partial.status)) {
+        throw new Error(
+          `Session entered terminal state "${partial.status}" while waiting for capabilities`
+        );
+      }
+
+      if (partial.capabilities && partial.selected_transport) {
+        const full = CreateSessionResponseSchema.parse(data);
+        console.debug(
+          `[CoordinatorClient] Session ready after ${attempt} poll(s), ` +
+            `transport: ${full.selected_transport.protocol}, ` +
+            `tracks: ${full.capabilities.tracks.length}`
+        );
+        return full;
+      }
+
+      console.debug(
+        `[CoordinatorClient] Session poll ${attempt}/${maxAttempts} — ` +
+          `status: ${partial.status}, waiting ${backoffMs}ms...`
+      );
+
+      await this.sleep(backoffMs);
+      backoffMs = Math.min(
+        backoffMs * SESSION_POLL_BACKOFF_MULTIPLIER,
+        SESSION_POLL_MAX_BACKOFF_MS
+      );
+    }
   }
 
   /**

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -191,8 +191,7 @@ export class CoordinatorClient {
       throw new Error("No active session. Call createSession() first.");
     }
 
-    const maxAttempts =
-      opts?.maxAttempts ?? SESSION_POLL_DEFAULT_MAX_ATTEMPTS;
+    const maxAttempts = opts?.maxAttempts ?? SESSION_POLL_DEFAULT_MAX_ATTEMPTS;
     let backoffMs = SESSION_POLL_INITIAL_BACKOFF_MS;
     let attempt = 0;
 

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -1,116 +1,33 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
 /**
- * LocalCoordinatorClient is a client for connecting to a local coordinator.
- * It extends CoordinatorClient and overrides methods for local development.
+ * LocalCoordinatorClient connects to a local runtime instance.
+ *
+ * The local runtime exposes the same REST API as the production coordinator
+ * but requires no authentication. This subclass overrides only the auth
+ * headers — all endpoint paths and request/response shapes are inherited.
  */
 
-import { ConflictError } from "../types";
-import { transformIceServers } from "../utils/webrtc";
 import { CoordinatorClient } from "./CoordinatorClient";
-import { IceServersResponseSchema } from "./types";
+import { API_VERSION_HEADER, API_ACCEPT_VERSION_HEADER, REACTOR_API_VERSION } from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
-  private localBaseUrl: string;
-  private sdpOffer: string | undefined;
-
-  constructor(baseUrl: string) {
-    // Pass dummy values to parent - they won't be used for local
+  constructor(baseUrl: string, model: string) {
     super({
-      baseUrl: baseUrl,
+      baseUrl,
       jwtToken: "local",
-      model: "local",
+      model,
     });
-    this.localBaseUrl = baseUrl;
   }
 
   /**
-   * Gets ICE servers from the local HTTP runtime.
-   * @returns The ICE server configuration
+   * Override: local runtime requires no authentication.
+   * Only versioning headers are sent.
    */
-  async getIceServers(): Promise<RTCIceServer[]> {
-    console.debug("[LocalCoordinatorClient] Fetching ICE servers...");
-    const response = await fetch(`${this.localBaseUrl}/ice_servers`, {
-      method: "GET",
-      signal: this.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error("Failed to get ICE servers from local coordinator.");
-    }
-
-    const data = await response.json();
-    const parsed = IceServersResponseSchema.parse(data);
-    const iceServers = transformIceServers(parsed);
-
-    console.debug(
-      "[LocalCoordinatorClient] Received ICE servers:",
-      iceServers.length
-    );
-    return iceServers;
-  }
-
-  /**
-   * Creates a local session by posting to /start_session.
-   * @returns always "local"
-   */
-  async createSession(sdpOffer: string): Promise<string> {
-    console.debug("[LocalCoordinatorClient] Creating local session...");
-    this.sdpOffer = sdpOffer;
-    const response = await fetch(`${this.localBaseUrl}/start_session`, {
-      method: "POST",
-      signal: this.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error("Failed to send local start session command.");
-    }
-
-    console.debug("[LocalCoordinatorClient] Local session created");
-    return "local";
-  }
-
-  /**
-   * Connects to the local session by posting SDP params to /sdp_params.
-   * Local connections are always immediate (no polling).
-   * @param sessionId - The session ID (ignored for local)
-   * @param sdpMessage - The SDP offer from the local WebRTC peer connection
-   * @returns The SDP answer and polling attempts (always 0 for local)
-   */
-  async connect(
-    sessionId: string,
-    sdpMessage?: string
-  ): Promise<{ sdpAnswer: string; sdpPollingAttempts: number }> {
-    this.sdpOffer = sdpMessage || this.sdpOffer;
-    console.debug("[LocalCoordinatorClient] Connecting to local session...");
-    const sdpBody = {
-      sdp: this.sdpOffer,
-      type: "offer",
+  protected override getHeaders(): HeadersInit {
+    return {
+      [API_VERSION_HEADER]: String(REACTOR_API_VERSION),
+      [API_ACCEPT_VERSION_HEADER]: String(REACTOR_API_VERSION),
     };
-    const response = await fetch(`${this.localBaseUrl}/sdp_params`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(sdpBody),
-      signal: this.signal,
-    });
-
-    if (!response.ok) {
-      if (response.status === 409) {
-        throw new ConflictError("Connection superseded by newer request");
-      }
-      throw new Error("Failed to get SDP answer from local coordinator.");
-    }
-
-    const sdpAnswer: { sdp: string; type: "answer" } = await response.json();
-    console.debug("[LocalCoordinatorClient] Received SDP answer");
-    return { sdpAnswer: sdpAnswer.sdp, sdpPollingAttempts: 0 };
-  }
-
-  async terminateSession(): Promise<void> {
-    console.debug("[LocalCoordinatorClient] Stopping local session...");
-    await fetch(`${this.localBaseUrl}/stop_session`, {
-      method: "POST",
-      signal: this.signal,
-    });
   }
 }

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -9,7 +9,11 @@
  */
 
 import { CoordinatorClient } from "./CoordinatorClient";
-import { API_VERSION_HEADER, API_ACCEPT_VERSION_HEADER, REACTOR_API_VERSION } from "./types";
+import {
+  API_VERSION_HEADER,
+  API_ACCEPT_VERSION_HEADER,
+  REACTOR_API_VERSION,
+} from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
   constructor(baseUrl: string, model: string) {

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -3,19 +3,29 @@
 /**
  * LocalCoordinatorClient connects to a local runtime instance.
  *
- * The local runtime exposes the same REST API as the production coordinator
- * but requires no authentication. This subclass overrides only the auth
- * headers — all endpoint paths and request/response shapes are inherited.
+ * The local runtime uses a simpler protocol than the production coordinator:
+ *   - POST /start_session  → starts session, returns full capabilities immediately
+ *   - POST /stop_session   → stops session
+ *   - Transport signaling via /sessions/{id}/transport/webrtc/* (unchanged)
+ *
+ * No session polling is needed because the local runtime IS the model host —
+ * capabilities are known the moment the session is created.
  */
 
 import { CoordinatorClient } from "./CoordinatorClient";
 import {
+  type CreateSessionResponse,
+  type InitialSessionResponse,
+  CreateSessionResponseSchema,
+  InitialSessionResponseSchema,
   API_VERSION_HEADER,
   API_ACCEPT_VERSION_HEADER,
   REACTOR_API_VERSION,
 } from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
+  private cachedSessionResponse?: CreateSessionResponse;
+
   constructor(baseUrl: string, model: string) {
     super({
       baseUrl,
@@ -24,14 +34,97 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     });
   }
 
-  /**
-   * Override: local runtime requires no authentication.
-   * Only versioning headers are sent.
-   */
   protected override getHeaders(): HeadersInit {
     return {
       [API_VERSION_HEADER]: String(REACTOR_API_VERSION),
       [API_ACCEPT_VERSION_HEADER]: String(REACTOR_API_VERSION),
     };
+  }
+
+  /**
+   * Starts a session on the local runtime.
+   *
+   * Unlike the production coordinator, the local runtime returns the full
+   * response (capabilities, selected_transport) immediately — no polling needed.
+   */
+  override async createSession(
+    extraArgs?: Record<string, any>
+  ): Promise<InitialSessionResponse> {
+    console.debug("[LocalCoordinatorClient] Starting session...");
+
+    const response = await fetch(`${this.baseUrl}/start_session`, {
+      method: "POST",
+      headers: {
+        ...this.getHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ...(extraArgs ? { extra_args: extraArgs } : {}),
+      }),
+      signal: this.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to start session: ${response.status} ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+
+    this.cachedSessionResponse = CreateSessionResponseSchema.parse(data);
+    this.currentSessionId = this.cachedSessionResponse.session_id;
+
+    console.debug(
+      "[LocalCoordinatorClient] Session started:",
+      this.currentSessionId,
+      "transport:",
+      this.cachedSessionResponse.selected_transport.protocol,
+      "tracks:",
+      this.cachedSessionResponse.capabilities.tracks.length
+    );
+
+    return InitialSessionResponseSchema.parse(data);
+  }
+
+  /**
+   * Returns the cached full session response immediately.
+   * The local runtime already provided everything in start_session.
+   */
+  override async pollSessionReady(): Promise<CreateSessionResponse> {
+    if (!this.cachedSessionResponse) {
+      throw new Error(
+        "No cached session response. Call createSession() first."
+      );
+    }
+    return this.cachedSessionResponse;
+  }
+
+  /**
+   * Stops the session on the local runtime.
+   */
+  override async terminateSession(): Promise<void> {
+    if (!this.currentSessionId) {
+      return;
+    }
+
+    console.debug(
+      "[LocalCoordinatorClient] Stopping session:",
+      this.currentSessionId
+    );
+
+    try {
+      await fetch(`${this.baseUrl}/stop_session`, {
+        method: "POST",
+        headers: this.getHeaders(),
+        signal: this.signal,
+      });
+    } catch (error) {
+      console.error("[LocalCoordinatorClient] Error stopping session:", error);
+    }
+
+    this.currentSessionId = undefined;
+    this.cachedSessionResponse = undefined;
   }
 }


### PR DESCRIPTION
Why
---
With session and transport now decoupled, the CoordinatorClient should
only manage session lifecycle (create, get, restart, terminate) and
no longer handle any transport signaling (ICE servers, SDP exchange,
polling). That responsibility moves to TransportClient in a later PR.

What Changed
---
CoordinatorClient:
- Removed all transport-related methods: getIceServers(), sendSdpOffer(),
  pollSdpAnswer(), connect(), and the abort-aware sleep() helper.
- Removed polling configuration constants (INITIAL_BACKOFF_MS, etc.).
- createSession() no longer takes an sdp_offer — it sends client_info
  and supported_transports, and returns the full CreateSessionResponse
  (session_id, selected_transport, capabilities, server_info, status).
- Responses are now validated through Zod schemas instead of raw casts.
- Added getSessionInfo() for lightweight status checks (GET /sessions/{id}/info).
- Added restartSession() for reconnecting to a different compute unit
  (PUT /sessions/{id}).
- terminateSession() now accepts an optional reason string in the body.
- Renamed getAuthHeaders() → getHeaders() (now protected, includes
  versioning headers alongside Authorization).
- Added checkVersionMismatch() to handle 426/501 responses with clear
  console error messages.

LocalCoordinatorClient:
- Reduced from ~115 lines to ~30 lines. No longer overrides
  createSession(), connect(), terminateSession(), or getIceServers().
- Constructor now takes (baseUrl, model) instead of just (baseUrl).
- Only overrides getHeaders() to strip the Authorization header —
  the local runtime needs no auth, just versioning headers.
- Inherits the full parent API: all endpoint paths and request/response
  shapes are the same (the local runtime will implement the new REST API).

New Flow
---
1. Reactor calls coordinatorClient.createSession() → gets session_id,
   selected_transport, capabilities (no SDP involved).
2. Transport signaling (ICE servers, SDP offer/answer) is handled
   entirely by the TransportClient (next PR).
3. coordinatorClient.terminateSession() cleans up when disconnecting.

Upcoming
---
- [3/5] TransportClient interface + WebRTCTransportClient + webrtc.ts simplification
- [4/5] Reactor.ts orchestration
- [5/5] Test updates

topic: REA-1075-update-coordinatorclient-and-localcoordinatorclient-flow
relative: REA-1075-add-protocol-versioning-types
reviewers: bryce, massenz