### PR TITLE
[REA-1075][4/5] Update Reactor.ts orchestration

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -13,10 +13,7 @@ import {
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
 import { LocalCoordinatorClient } from "./LocalCoordinatorClient";
-import {
-  type TransportClient,
-  type TransportStatus,
-} from "./TransportClient";
+import { type TransportClient, type TransportStatus } from "./TransportClient";
 import { WebRTCTransportClient } from "./WebRTCTransportClient";
 import {
   type Capabilities,

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -230,8 +230,8 @@ export class Reactor {
       console.debug(
         "[Reactor] Session created:",
         initialResponse.session_id,
-        "status:",
-        initialResponse.status
+        "state:",
+        initialResponse.state
       );
 
       // 2. Poll until the Runtime accepts and capabilities are available

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
 import {
   type ReactorEvent,
   type ReactorStatus,
@@ -5,46 +7,32 @@ import {
   type ReactorError,
   type MessageScope,
   type ConnectOptions,
-  type TrackConfig,
   type ConnectionStats,
   type ConnectionTimings,
   isAbortError,
-  ConflictError,
 } from "../types";
 import { CoordinatorClient } from "./CoordinatorClient";
 import { LocalCoordinatorClient } from "./LocalCoordinatorClient";
-import { GPUMachineClient, GPUMachineStatus } from "./GPUMachineClient";
+import {
+  type TransportClient,
+  type TransportStatus,
+} from "./TransportClient";
+import { WebRTCTransportClient } from "./WebRTCTransportClient";
+import {
+  type Capabilities,
+  type CreateSessionResponse,
+  type TrackCapability,
+  REACTOR_WEBRTC_VERSION,
+} from "./types";
 import { z } from "zod";
 
 const LOCAL_COORDINATOR_URL = "http://localhost:8080";
 export const DEFAULT_BASE_URL = "https://api.reactor.inc";
 
-const TrackConfigSchema = z.object({
-  name: z.string(),
-  kind: z.enum(["audio", "video"]),
-});
-
 const OptionsSchema = z.object({
   apiUrl: z.string().default(DEFAULT_BASE_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
-  /**
-   * Tracks the client **RECEIVES** from the model (model → client).
-   * Each entry produces a `recvonly` transceiver.
-   * Names must be unique across both `receive` and `send`.
-   *
-   * When omitted, defaults to a single video track named `"main_video"`.
-   * Pass an explicit empty array to opt out of the default.
-   */
-  receive: z
-    .array(TrackConfigSchema)
-    .default([{ name: "main_video", kind: "video" }]),
-  /**
-   * Tracks the client **SENDS** to the model (client → model).
-   * Each entry produces a `sendonly` transceiver.
-   * Names must be unique across both `receive` and `send`.
-   */
-  send: z.array(TrackConfigSchema).default([]),
 });
 export type Options = z.input<typeof OptionsSchema>;
 
@@ -52,39 +40,33 @@ type EventHandler = (...args: any[]) => void;
 
 export class Reactor {
   private coordinatorClient: CoordinatorClient | undefined;
-  private machineClient: GPUMachineClient | undefined;
+  private transportClient: TransportClient | undefined;
   private status: ReactorStatus = "disconnected";
   private coordinatorUrl: string;
   private lastError?: ReactorError;
   private model: string;
   private sessionExpiration?: number;
   private local: boolean;
-  /** Tracks the client RECEIVES from the model (model → client). */
-  private receive: TrackConfig[];
-  /** Tracks the client SENDS to the model (client → model). */
-  private send: TrackConfig[];
   private sessionId?: string;
   private connectStartTime?: number;
   private connectionTimings?: ConnectionTimings;
 
+  private capabilities?: Capabilities;
+  private tracks: TrackCapability[] = [];
+  private sessionResponse?: CreateSessionResponse;
+
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
     this.coordinatorUrl = validatedOptions.apiUrl;
-
-    // TODO(REA-146) Properly accept version from parameter.
     this.model = validatedOptions.modelName;
     this.local = validatedOptions.local;
-    this.receive = validatedOptions.receive;
-    this.send = validatedOptions.send;
     if (this.local && options.apiUrl === undefined) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
     }
   }
 
-  // Generic event map
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
 
-  // Event Emitter API
   on(event: ReactorEvent, handler: EventHandler) {
     if (!this.eventListeners.has(event)) {
       this.eventListeners.set(event, new Set());
@@ -102,17 +84,12 @@ export class Reactor {
 
   /**
    * Sends a command to the model via the data channel.
-   *
-   * @param command The command name.
-   * @param data The command payload.
-   * @param scope "application" (default) for model commands, "runtime" for platform messages.
    */
   async sendCommand(
     command: string,
     data: any,
     scope: MessageScope = "application"
   ): Promise<void> {
-    // Synchronous validation - throw immediately
     if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
       const errorMessage = `Cannot send message, status is ${this.status}`;
       console.warn("[Reactor]", errorMessage);
@@ -120,9 +97,8 @@ export class Reactor {
     }
 
     try {
-      this.machineClient?.sendCommand(command, data, scope);
+      this.transportClient?.sendCommand(command, data, scope);
     } catch (error) {
-      // Async operational error - emit event only
       console.error("[Reactor] Failed to send message:", error);
       this.createError(
         "MESSAGE_SEND_FAILED",
@@ -130,15 +106,13 @@ export class Reactor {
         "gpu",
         true
       );
-      // Don't re-throw - let the error event handle it
     }
   }
 
   /**
-   * Publishes a MediaStreamTrack to a named send track.
-   *
-   * @param name The declared send track name (e.g. "webcam").
-   * @param track The MediaStreamTrack to publish.
+   * Publishes a MediaStreamTrack to a named sendonly track.
+   * The transceiver is already set up from capabilities — this just
+   * calls replaceTrack() on the sender.
    */
   async publishTrack(name: string, track: MediaStreamTrack): Promise<void> {
     if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
@@ -149,7 +123,7 @@ export class Reactor {
     }
 
     try {
-      await this.machineClient?.publishTrack(name, track);
+      await this.transportClient?.publishTrack(name, track);
     } catch (error) {
       console.error(`[Reactor] Failed to publish track "${name}":`, error);
       this.createError(
@@ -161,14 +135,9 @@ export class Reactor {
     }
   }
 
-  /**
-   * Unpublishes the track with the given name.
-   *
-   * @param name The declared send track name to unpublish.
-   */
   async unpublishTrack(name: string): Promise<void> {
     try {
-      await this.machineClient?.unpublishTrack(name);
+      await this.transportClient?.unpublishTrack(name);
     } catch (error) {
       console.error(`[Reactor] Failed to unpublish track "${name}":`, error);
       this.createError(
@@ -181,8 +150,7 @@ export class Reactor {
   }
 
   /**
-   * Public method for reconnecting to an existing session, that may have been interrupted but can be recovered.
-   * @param options Optional connect options (e.g. maxAttempts for SDP polling)
+   * Reconnects to an existing session with a fresh transport.
    */
   async reconnect(options?: ConnectOptions): Promise<void> {
     if (!this.sessionId || !this.coordinatorClient) {
@@ -195,42 +163,30 @@ export class Reactor {
       return;
     }
 
-    this.setStatus("connecting");
-
-    if (!this.machineClient) {
-      // Get ICE servers from coordinator
-      const iceServers = await this.coordinatorClient.getIceServers();
-      this.machineClient = new GPUMachineClient({ iceServers });
-      this.setupMachineClientHandlers();
+    if (this.tracks.length === 0) {
+      console.warn("[Reactor] No tracks available for reconnect.");
+      return;
     }
 
-    const sdpOffer = await this.machineClient.createOffer({
-      send: this.send,
-      receive: this.receive,
-    });
+    this.setStatus("connecting");
 
-    // Send offer to coordinator and get answer.
     try {
-      const { sdpAnswer } = await this.coordinatorClient.connect(
-        this.sessionId,
-        sdpOffer,
-        options?.maxAttempts
-      );
-      // Connect to GPU machine with the answer.
-      // Status transitions to "ready" via the statusChanged handler once
-      // the peer connection and data channel are fully open.
-      await this.machineClient.connect(sdpAnswer);
+      if (!this.transportClient) {
+        this.transportClient = new WebRTCTransportClient({
+          baseUrl: this.coordinatorUrl,
+          sessionId: this.sessionId,
+          jwtToken: this.local ? "local" : "",
+          maxPollAttempts: options?.maxAttempts,
+        });
+        this.setupTransportHandlers();
+      }
+
+      await this.transportClient.reconnect(this.tracks);
     } catch (error) {
-      // disconnect() already aborted the polling and cleaned up state — nothing to do.
       if (isAbortError(error)) return;
 
-      let recoverable = false;
-      if (error instanceof ConflictError) {
-        recoverable = true;
-      }
       console.error("[Reactor] Failed to reconnect:", error);
-      // Disconnect without recovery, as the session "connect" call on the coordinator failed
-      this.disconnect(recoverable);
+      this.disconnect(true);
       this.createError(
         "RECONNECTION_FAILED",
         `Failed to reconnect: ${error}`,
@@ -241,11 +197,8 @@ export class Reactor {
   }
 
   /**
-   * Connects to the coordinator and waits for a GPU to be assigned.
-   * Once a GPU is assigned, the Reactor will connect to the gpu machine via WebRTC.
-   * If no authentication is provided and not in local mode, an error is thrown.
-   * @param jwtToken Optional JWT token for authentication
-   * @param options Optional connect options (e.g. maxAttempts for SDP polling)
+   * Connects to the coordinator, creates a session, then establishes
+   * the transport using server-declared capabilities.
    */
   async connect(jwtToken?: string, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);
@@ -262,60 +215,65 @@ export class Reactor {
     this.connectStartTime = performance.now();
 
     try {
-      console.debug(
-        "[Reactor] Connecting to coordinator with authenticated URL"
-      );
-
       this.coordinatorClient = this.local
-        ? new LocalCoordinatorClient(this.coordinatorUrl)
+        ? new LocalCoordinatorClient(this.coordinatorUrl, this.model)
         : new CoordinatorClient({
             baseUrl: this.coordinatorUrl,
-            jwtToken: jwtToken!, // Safe: validated above
+            jwtToken: jwtToken!,
             model: this.model,
           });
 
-      // Get ICE servers from coordinator
-      const iceServers = await this.coordinatorClient.getIceServers();
-
-      // Create GPUMachineClient and generate SDP offer
-      this.machineClient = new GPUMachineClient({ iceServers });
-      this.setupMachineClientHandlers();
-
-      const sdpOffer = await this.machineClient.createOffer({
-        send: this.send,
-        receive: this.receive,
-      });
-
-      // Create session passing SDP offer. We will get the answer polling the sdp_offer endpoint.
+      // 1. Create session — no SDP, just model + client info + transports
       const tSession = performance.now();
-      const sessionId = await this.coordinatorClient.createSession(sdpOffer);
+      const sessionResponse = await this.coordinatorClient.createSession();
       const sessionCreationMs = performance.now() - tSession;
-      this.setSessionId(sessionId);
 
-      // Connect to coordinator and get SDP Answer.
-      // We don't pass the sdp offer here because we passed it already when creating the session.
-      const tSdp = performance.now();
-      const { sdpAnswer, sdpPollingAttempts } =
-        await this.coordinatorClient.connect(
-          sessionId,
-          undefined,
-          options?.maxAttempts
-        );
-      const sdpPollingMs = performance.now() - tSdp;
+      this.sessionResponse = sessionResponse;
+      this.setSessionId(sessionResponse.session_id);
+
+      // 2. Store capabilities and tracks
+      if (sessionResponse.capabilities) {
+        this.capabilities = sessionResponse.capabilities;
+        this.tracks = sessionResponse.capabilities.tracks;
+        this.emit("capabilitiesReceived", this.capabilities);
+      } else {
+        this.tracks = [];
+      }
+
+      console.debug(
+        "[Reactor] Session created, transport:",
+        sessionResponse.selected_transport.protocol,
+        "tracks:",
+        this.tracks.length
+      );
+
+      // 3. Instantiate transport based on selected_transport
+      const protocol = sessionResponse.selected_transport.protocol;
+      if (protocol !== "webrtc") {
+        throw new Error(`Unsupported transport protocol: ${protocol}`);
+      }
+
+      this.transportClient = new WebRTCTransportClient({
+        baseUrl: this.coordinatorUrl,
+        sessionId: sessionResponse.session_id,
+        jwtToken: this.local ? "local" : jwtToken!,
+        webrtcVersion:
+          sessionResponse.selected_transport.version ?? REACTOR_WEBRTC_VERSION,
+        maxPollAttempts: options?.maxAttempts,
+      });
+      this.setupTransportHandlers();
+
+      // 4. Connect transport using capabilities tracks
+      const tTransport = performance.now();
+      await this.transportClient.connect(this.tracks);
+      const transportConnectingMs = performance.now() - tTransport;
 
       this.connectionTimings = {
         sessionCreationMs,
-        sdpPollingMs,
-        sdpPollingAttempts,
-        iceNegotiationMs: 0,
-        dataChannelMs: 0,
+        transportConnectingMs,
         totalMs: 0,
       };
-
-      // Connect to GPU machine with the answer
-      await this.machineClient.connect(sdpAnswer);
     } catch (error) {
-      // disconnect() already aborted the polling and cleaned up state — nothing to do.
       if (isAbortError(error)) return;
 
       console.error("[Reactor] Connection failed:", error);
@@ -325,8 +283,6 @@ export class Reactor {
         "api",
         true
       );
-      // Non-recoverable disconnect: terminates the server-side session (DELETE)
-      // and cleans up all local state (machine client, session ID, etc.)
       try {
         await this.disconnect(false);
       } catch (disconnectError) {
@@ -340,19 +296,15 @@ export class Reactor {
   }
 
   /**
-   * Sets up event handlers for the machine client.
-   *
-   * Each handler captures the client reference at registration time and
-   * ignores events if this.machineClient has since changed (e.g. after
-   * disconnect + reconnect), preventing stale WebRTC teardown events from
-   * interfering with a new connection.
+   * Sets up event handlers for the transport client.
+   * Each handler captures the client reference to ignore stale events.
    */
-  private setupMachineClientHandlers(): void {
-    if (!this.machineClient) return;
-    const client = this.machineClient;
+  private setupTransportHandlers(): void {
+    if (!this.transportClient) return;
+    const client = this.transportClient;
 
     client.on("message", (message: any, scope: MessageScope) => {
-      if (this.machineClient !== client) return;
+      if (this.transportClient !== client) return;
       if (scope === "application") {
         this.emit("message", message);
       } else if (scope === "runtime") {
@@ -360,11 +312,11 @@ export class Reactor {
       }
     });
 
-    client.on("statusChanged", (status: GPUMachineStatus) => {
-      if (this.machineClient !== client) return;
+    client.on("statusChanged", (status: TransportStatus) => {
+      if (this.transportClient !== client) return;
       switch (status) {
         case "connected":
-          this.finalizeConnectionTimings(client);
+          this.finalizeConnectionTimings();
           this.setStatus("ready");
           break;
         case "disconnected":
@@ -373,7 +325,7 @@ export class Reactor {
         case "error":
           this.createError(
             "GPU_CONNECTION_ERROR",
-            "GPU machine connection failed",
+            "Transport connection failed",
             "gpu",
             true
           );
@@ -385,13 +337,13 @@ export class Reactor {
     client.on(
       "trackReceived",
       (name: string, track: MediaStreamTrack, stream: MediaStream) => {
-        if (this.machineClient !== client) return;
+        if (this.transportClient !== client) return;
         this.emit("trackReceived", name, track, stream);
       }
     );
 
     client.on("statsUpdate", (stats: ConnectionStats) => {
-      if (this.machineClient !== client) return;
+      if (this.transportClient !== client) return;
       this.emit("statsUpdate", {
         ...stats,
         connectionTimings: this.connectionTimings,
@@ -400,8 +352,7 @@ export class Reactor {
   }
 
   /**
-   * Disconnects from the coordinator and the gpu machine.
-   * Ensures cleanup completes even if individual disconnections fail.
+   * Disconnects from both the transport and the coordinator.
    */
   async disconnect(recoverable: boolean = false) {
     if (this.status === "disconnected" && !this.sessionId) {
@@ -409,10 +360,8 @@ export class Reactor {
       return;
     }
 
-    // Abort any in-flight coordinator requests (SDP polling, pending fetches)
-    // before tearing down. abort() resets the controller so terminateSession()
-    // below can still make its own HTTP call.
     this.coordinatorClient?.abort();
+    this.transportClient?.abort();
 
     if (this.coordinatorClient && !recoverable) {
       try {
@@ -423,16 +372,14 @@ export class Reactor {
       this.coordinatorClient = undefined;
     }
 
-    // Disconnect machine client with error handling
-    if (this.machineClient) {
+    if (this.transportClient) {
       try {
-        await this.machineClient.disconnect();
+        await this.transportClient.disconnect();
       } catch (error) {
-        console.error("[Reactor] Error disconnecting from GPU machine:", error);
-        // Continue with cleanup even if machine disconnect fails
+        console.error("[Reactor] Error disconnecting transport:", error);
       }
       if (!recoverable) {
-        this.machineClient = undefined;
+        this.transportClient = undefined;
       }
     }
 
@@ -441,8 +388,52 @@ export class Reactor {
     if (!recoverable) {
       this.setSessionExpiration(undefined);
       this.setSessionId(undefined);
+      this.capabilities = undefined;
+      this.tracks = [];
+      this.sessionResponse = undefined;
     }
   }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Getters
+  // ─────────────────────────────────────────────────────────────────────────
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
+  getStatus(): ReactorStatus {
+    return this.status;
+  }
+
+  getState(): ReactorState {
+    return {
+      status: this.status,
+      lastError: this.lastError,
+    };
+  }
+
+  getLastError(): ReactorError | undefined {
+    return this.lastError;
+  }
+
+  getCapabilities(): Capabilities | undefined {
+    return this.capabilities;
+  }
+
+  getSessionInfo(): CreateSessionResponse | undefined {
+    return this.sessionResponse;
+  }
+
+  getStats(): ConnectionStats | undefined {
+    const stats = this.transportClient?.getStats();
+    if (!stats) return undefined;
+    return { ...stats, connectionTimings: this.connectionTimings };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private State Management
+  // ─────────────────────────────────────────────────────────────────────────
 
   private setSessionId(newSessionId: string | undefined) {
     console.debug(
@@ -457,10 +448,6 @@ export class Reactor {
     }
   }
 
-  getSessionId(): string | undefined {
-    return this.sessionId;
-  }
-
   private setStatus(newStatus: ReactorStatus) {
     console.debug("[Reactor] Setting status:", newStatus, "from", this.status);
     if (this.status !== newStatus) {
@@ -469,14 +456,6 @@ export class Reactor {
     }
   }
 
-  getStatus(): ReactorStatus {
-    return this.status;
-  }
-
-  /**
-   * Set the session expiration time.
-   * @param newSessionExpiration The new session expiration time in seconds.
-   */
   private setSessionExpiration(newSessionExpiration: number | undefined) {
     console.debug(
       "[Reactor] Setting session expiration:",
@@ -488,50 +467,20 @@ export class Reactor {
     }
   }
 
-  /**
-   * Get the current state including status, error, and waiting info
-   */
-  getState(): ReactorState {
-    return {
-      status: this.status,
-      lastError: this.lastError,
-    };
-  }
-
-  /**
-   * Get the last error that occurred
-   */
-  getLastError(): ReactorError | undefined {
-    return this.lastError;
-  }
-
-  getStats(): ConnectionStats | undefined {
-    const stats = this.machineClient?.getStats();
-    if (!stats) return undefined;
-    return { ...stats, connectionTimings: this.connectionTimings };
-  }
-
   private resetConnectionTimings(): void {
     this.connectStartTime = undefined;
     this.connectionTimings = undefined;
   }
 
-  private finalizeConnectionTimings(client: GPUMachineClient): void {
+  private finalizeConnectionTimings(): void {
     if (!this.connectionTimings || this.connectStartTime == null) return;
 
-    const webrtcTimings = client.getConnectionTimings();
-    this.connectionTimings.iceNegotiationMs =
-      webrtcTimings?.iceNegotiationMs ?? 0;
-    this.connectionTimings.dataChannelMs = webrtcTimings?.dataChannelMs ?? 0;
     this.connectionTimings.totalMs = performance.now() - this.connectStartTime;
     this.connectStartTime = undefined;
 
     console.debug("[Reactor] Connection timings:", this.connectionTimings);
   }
 
-  /**
-   * Create and store an error
-   */
   private createError(
     code: string,
     message: string,
@@ -547,8 +496,6 @@ export class Reactor {
       component,
       retryAfter,
     };
-
-    // Emit error event
     this.emit("error", this.lastError);
   }
 }

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -220,31 +220,43 @@ export class Reactor {
             model: this.model,
           });
 
-      // 1. Create session — no SDP, just model + client info + transports
+      // 1. Create session — slim response with session_id and status
       const tSession = performance.now();
-      const sessionResponse = await this.coordinatorClient.createSession();
+      const initialResponse = await this.coordinatorClient.createSession();
       const sessionCreationMs = performance.now() - tSession;
 
-      this.sessionResponse = sessionResponse;
-      this.setSessionId(sessionResponse.session_id);
-
-      // 2. Store capabilities and tracks
-      if (sessionResponse.capabilities) {
-        this.capabilities = sessionResponse.capabilities;
-        this.tracks = sessionResponse.capabilities.tracks;
-        this.emit("capabilitiesReceived", this.capabilities);
-      } else {
-        this.tracks = [];
-      }
+      this.setSessionId(initialResponse.session_id);
 
       console.debug(
-        "[Reactor] Session created, transport:",
+        "[Reactor] Session created:",
+        initialResponse.session_id,
+        "status:",
+        initialResponse.status
+      );
+
+      // 2. Poll until the Runtime accepts and capabilities are available
+      this.setStatus("waiting");
+
+      const tPoll = performance.now();
+      const sessionResponse =
+        await this.coordinatorClient.pollSessionReady();
+      const sessionPollingMs = performance.now() - tPoll;
+
+      this.sessionResponse = sessionResponse;
+
+      // 3. Store capabilities and tracks
+      this.capabilities = sessionResponse.capabilities;
+      this.tracks = sessionResponse.capabilities.tracks;
+      this.emit("capabilitiesReceived", this.capabilities);
+
+      console.debug(
+        "[Reactor] Session ready, transport:",
         sessionResponse.selected_transport.protocol,
         "tracks:",
         this.tracks.length
       );
 
-      // 3. Instantiate transport based on selected_transport
+      // 4. Instantiate transport based on selected_transport
       const protocol = sessionResponse.selected_transport.protocol;
       if (protocol !== "webrtc") {
         throw new Error(`Unsupported transport protocol: ${protocol}`);
@@ -260,13 +272,13 @@ export class Reactor {
       });
       this.setupTransportHandlers();
 
-      // 4. Connect transport using capabilities tracks
+      // 5. Connect transport using capabilities tracks
       const tTransport = performance.now();
       await this.transportClient.connect(this.tracks);
       const transportConnectingMs = performance.now() - tTransport;
 
       this.connectionTimings = {
-        sessionCreationMs,
+        sessionCreationMs: sessionCreationMs + sessionPollingMs,
         transportConnectingMs,
         totalMs: 0,
       };

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -238,8 +238,7 @@ export class Reactor {
       this.setStatus("waiting");
 
       const tPoll = performance.now();
-      const sessionResponse =
-        await this.coordinatorClient.pollSessionReady();
+      const sessionResponse = await this.coordinatorClient.pollSessionReady();
       const sessionPollingMs = performance.now() - tPoll;
 
       this.sessionResponse = sessionResponse;


### PR DESCRIPTION
Why
---
The Reactor orchestrator was tightly coupled to GPUMachineClient and
the old flow where the SDP offer was sent during session creation.
It now needs to use the new CoordinatorClient (session-only) and
TransportClient (signaling-only) in a two-phase connect sequence.

What Changed
---
Constructor:
- Removed `receive` and `send` track arrays from Options — tracks
  are now server-declared via capabilities, not client-specified.
- Removed TrackConfigSchema and the default "main_video" track.

connect():
- Phase 1: coordinatorClient.createSession() returns session_id,
  selected_transport, and capabilities (no SDP involved).
- Stores capabilities and emits "capabilitiesReceived" event.
- Phase 2: instantiates the appropriate TransportClient based on
  selected_transport.protocol (currently only "webrtc").
- Calls transportClient.connect(tracks) which handles the full
  signaling lifecycle internally.

reconnect():
- No longer manually fetches ICE servers or creates SDP offers.
- Delegates entirely to transportClient.reconnect(tracks).
- Guards against reconnect when no tracks are available.

disconnect():
- Now aborts both coordinatorClient and transportClient.
- Clears capabilities, tracks, and sessionResponse on
  non-recoverable disconnect.

New public getters:
- getCapabilities() — returns server-declared capabilities.
- getSessionInfo() — returns the full session creation response.

ConnectionTimings:
- Now transport-agnostic: only sessionCreationMs,
  transportConnectingMs, and totalMs.
- finalizeConnectionTimings() no longer pulls WebRTC-specific
  fields — those live in WebRTCTransportTimings on the transport.

Renamed throughout:
- machineClient → transportClient
- GPUMachineClient → TransportClient / WebRTCTransportClient
- GPUMachineStatus → TransportStatus
- setupMachineClientHandlers → setupTransportHandlers

Orchestration Flow
---
```
  connect(jwt)
    |
    v
  CoordinatorClient.createSession()
    |--- session_id, selected_transport, capabilities
    v
  new WebRTCTransportClient(session_id, ...)
    |
    v
  transportClient.connect(capabilities.tracks)
    |--- ICE servers, SDP offer/answer, peer connection
    v
  "connected" --> Reactor status = "ready"
```

Upcoming
---
- [5/5] Test updates

topic: REA-1075-update-reactor-orchestration
relative: REA-1075-update-transport-client-interface
reviewers: bryce, massenz