### PR TITLE
[REA-1075][5/5] Update React SDK to match new protocol

### DIFF
--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -16,7 +16,7 @@ export interface ReactorState {
   /**
    * Media tracks received from the model, keyed by track name.
    *
-   * Each entry maps a declared **receive** track name (e.g. `"main_video"`,
+   * Each entry maps a recvonly track name (e.g. `"main_video"`,
    * `"main_audio"`) to the live `MediaStreamTrack` delivered by the model.
    */
   tracks: Record<string, MediaStreamTrack>;

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -8,23 +8,30 @@ export interface ReactorControllerProps {
   style?: React.CSSProperties;
 }
 
+interface CommandParamSchema {
+  description?: string;
+  type: string;
+  minimum?: number;
+  maximum?: number;
+  required?: boolean;
+  enum?: string[];
+}
+
 interface CommandSchema {
   description: string;
-  schema: Record<
-    string,
-    {
-      description?: string;
-      type: string;
-      minimum?: number;
-      maximum?: number;
-      required?: boolean;
-      enum?: string[];
-    }
-  >;
+  schema: Record<string, CommandParamSchema>;
+}
+
+// The runtime sends commands as a list of {name, description, schema}
+// matching the proto Command message.
+interface CommandCapabilityMessage {
+  name: string;
+  description: string;
+  schema?: Record<string, CommandParamSchema>;
 }
 
 interface CommandsMessage {
-  commands: Record<string, CommandSchema>;
+  commands: CommandCapabilityMessage[];
 }
 
 export function ReactorController({
@@ -89,16 +96,26 @@ export function ReactorController({
       "commands" in message.data
     ) {
       const commandsMessage = message.data as CommandsMessage;
-      setCommands(commandsMessage.commands);
+
+      // Convert the list of command descriptors (proto Command shape)
+      // into a Record keyed by name for the controller's internal state.
+      const commandsRecord: Record<string, CommandSchema> = {};
+      for (const cmd of commandsMessage.commands) {
+        commandsRecord[cmd.name] = {
+          description: cmd.description,
+          schema: cmd.schema ?? {},
+        };
+      }
+      setCommands(commandsRecord);
 
       // Initialize form values for each command
       const initialValues: Record<string, Record<string, any>> = {};
       const initialExpanded: Record<string, boolean> = {};
 
-      Object.entries(commandsMessage.commands).forEach(
+      Object.entries(commandsRecord).forEach(
         ([commandName, commandSchema]) => {
           initialValues[commandName] = {};
-          initialExpanded[commandName] = false; // Start collapsed by default
+          initialExpanded[commandName] = false;
 
           Object.entries(commandSchema.schema).forEach(
             ([paramName, paramSchema]) => {

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -112,28 +112,24 @@ export function ReactorController({
       const initialValues: Record<string, Record<string, any>> = {};
       const initialExpanded: Record<string, boolean> = {};
 
-      Object.entries(commandsRecord).forEach(
-        ([commandName, commandSchema]) => {
-          initialValues[commandName] = {};
-          initialExpanded[commandName] = false;
+      Object.entries(commandsRecord).forEach(([commandName, commandSchema]) => {
+        initialValues[commandName] = {};
+        initialExpanded[commandName] = false;
 
-          Object.entries(commandSchema.schema).forEach(
-            ([paramName, paramSchema]) => {
-              if (paramSchema.type === "number") {
-                initialValues[commandName][paramName] =
-                  paramSchema.minimum ?? 0;
-              } else if (paramSchema.type === "string") {
-                initialValues[commandName][paramName] = "";
-              } else if (paramSchema.type === "boolean") {
-                initialValues[commandName][paramName] = false;
-              } else if (paramSchema.type === "integer") {
-                initialValues[commandName][paramName] =
-                  paramSchema.minimum ?? 0;
-              }
+        Object.entries(commandSchema.schema).forEach(
+          ([paramName, paramSchema]) => {
+            if (paramSchema.type === "number") {
+              initialValues[commandName][paramName] = paramSchema.minimum ?? 0;
+            } else if (paramSchema.type === "string") {
+              initialValues[commandName][paramName] = "";
+            } else if (paramSchema.type === "boolean") {
+              initialValues[commandName][paramName] = false;
+            } else if (paramSchema.type === "integer") {
+              initialValues[commandName][paramName] = paramSchema.minimum ?? 0;
             }
-          );
-        }
-      );
+          }
+        );
+      });
       setFormValues(initialValues);
       setExpandedCommands(initialExpanded);
     }

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -57,7 +57,7 @@ export function ReactorProvider({
   // Destructure connectOptions with defaults
   const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
-  const { apiUrl, modelName, local, receive, send } = props;
+  const { apiUrl, modelName, local } = props;
   const maxAttempts = pollingOptions.maxAttempts;
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
@@ -134,8 +134,6 @@ export function ReactorProvider({
         apiUrl,
         modelName,
         local,
-        receive,
-        send,
         jwtToken,
       } satisfies ReactorInitializationProps)
     );
@@ -185,8 +183,6 @@ export function ReactorProvider({
     modelName,
     autoConnect,
     local,
-    receive,
-    send,
     jwtToken,
     maxAttempts,
   ]);

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -178,14 +178,7 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-  }, [
-    apiUrl,
-    modelName,
-    autoConnect,
-    local,
-    jwtToken,
-    maxAttempts,
-  ]);
+  }, [apiUrl, modelName, autoConnect, local, jwtToken, maxAttempts]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -6,14 +6,16 @@ import React from "react";
 
 export interface ReactorViewProps {
   /**
-   * The name of the **receive** track to render.
-   * Must match a track name declared in the `receive` array (model → client).
+   * The name of the recvonly track to render.
+   * Must match a track name declared in the server capabilities.
+   * Check the model's documentation for available track names.
    * Defaults to `"main_video"`.
    */
   track?: string;
   /**
-   * Optional name of a **receive** audio track to play alongside the video
-   * (e.g. `"main_audio"`).  The audio is mixed into the same `<video>` element.
+   * Optional name of a recvonly audio track to play alongside the video
+   * (e.g. `"main_audio"`). The audio is mixed into the same `<video>` element.
+   * Check the model's documentation for available track names.
    */
   audioTrack?: string;
   width?: number;

--- a/packages/js-sdk/src/react/WebcamStream.tsx
+++ b/packages/js-sdk/src/react/WebcamStream.tsx
@@ -6,8 +6,9 @@ import React from "react";
 
 export interface WebcamStreamProps {
   /**
-   * The name of the **send** track to publish the webcam to.
-   * Must match a track name declared in the `send` array (client → model).
+   * The name of the sendonly track to publish the webcam to.
+   * Must match a track name declared in the server capabilities.
+   * Check the model's documentation for available track names.
    */
   track: string;
   className?: string;


### PR DESCRIPTION
Why
---
The React layer referenced the old `receive`/`send` track arrays that
no longer exist in the Reactor Options. Tracks are now server-declared
via capabilities, so the React components just need to stop passing
those removed props and update their documentation accordingly.

What Changed
---
ReactorProvider:
- Removed `receive` and `send` from the props destructuring,
  the store re-initialization call, and the useEffect dependency
  array. These fields no longer exist on ReactorOptions.

ReactorView:
- Updated JSDoc: track props now reference "server capabilities"
  instead of the old "receive array". Added note to check the
  model's documentation for available track names.

WebcamStream:
- Updated JSDoc: track prop now references "server capabilities"
  instead of the old "send array". Added note to check the
  model's documentation for available track names.

store.ts:
- Updated ReactorState.tracks JSDoc to use "recvonly" terminology
  instead of "declared receive track".

New React API
---
Before (v2):
  <ReactorProvider modelName="morpheus" receive={[video("main_video")]} send={[video("webcam")]}>

After (v3):
  <ReactorProvider modelName="morpheus">

Tracks are discovered automatically from server capabilities after
session creation. Users call publishTrack() for sendonly tracks and
receive recvonly tracks via the "trackReceived" event (unchanged).

topic: REA-1075-update-react-sdk-to-match-new-protocol
relative: REA-1075-update-reactor-orchestration
reviewers: bryce, massenz