### PR TITLE
fix use `Reactor-Api-Key` header in `tokens.ts`

### DIFF
--- a/packages/js-sdk/__tests__/unit/tokens.test.ts
+++ b/packages/js-sdk/__tests__/unit/tokens.test.ts
@@ -49,7 +49,7 @@ describe("fetchInsecureToken", () => {
     );
   });
 
-  it("sends API key in X-API-Key header", async () => {
+  it("sends API key in Reactor-API-Key header", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({ jwt: "token" }),
@@ -60,7 +60,7 @@ describe("fetchInsecureToken", () => {
       expect.any(String),
       expect.objectContaining({
         method: "GET",
-        headers: { "X-API-Key": "rk_my_secret_key" },
+        headers: { "Reactor-API-Key": "rk_my_secret_key" },
       })
     );
   });

--- a/packages/js-sdk/src/utils/tokens.ts
+++ b/packages/js-sdk/src/utils/tokens.ts
@@ -24,7 +24,7 @@ export async function fetchInsecureToken(
   const response = await fetch(`${apiUrl}/tokens`, {
     method: "GET",
     headers: {
-      "X-API-Key": apiKey,
+      "Reactor-API-Key": apiKey,
     },
   });
 


### PR DESCRIPTION
topic: fix-use-reactor-api-key-header-in-tokens-ts