### PR TITLE
Align JS-SDK response schemas with REST API contract

### DIFF
--- a/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client-extended.test.ts
@@ -5,16 +5,23 @@ import { CoordinatorClient } from "../../src/core/CoordinatorClient";
 
 const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
 
+const MOCK_CLUSTER = "sup.us-west-2.aws.prod.reactor.inc";
+const MOCK_SERVER_INFO = { server_version: "1.5.0" };
+
 const MOCK_INITIAL_RESPONSE = {
   session_id: MOCK_SESSION_ID,
   model: { name: "echo" },
+  server_info: MOCK_SERVER_INFO,
   state: "CREATED",
+  cluster: MOCK_CLUSTER,
 };
 
 const MOCK_FULL_SESSION_RESPONSE = {
   session_id: MOCK_SESSION_ID,
   model: { name: "echo" },
+  server_info: MOCK_SERVER_INFO,
   state: "ACTIVE",
+  cluster: MOCK_CLUSTER,
   selected_transport: { protocol: "webrtc", version: "1.0" },
   capabilities: {
     protocol_version: "1.0",
@@ -90,7 +97,9 @@ describe("CoordinatorClient (extended)", () => {
           Promise.resolve({
             session_id: MOCK_SESSION_ID,
             model: { name: "echo" },
+            server_info: MOCK_SERVER_INFO,
             state: "PENDING",
+            cluster: MOCK_CLUSTER,
           }),
       });
 
@@ -129,7 +138,9 @@ describe("CoordinatorClient (extended)", () => {
             Promise.resolve({
               session_id: MOCK_SESSION_ID,
               model: { name: "echo" },
+              server_info: MOCK_SERVER_INFO,
               state: "PENDING",
+              cluster: MOCK_CLUSTER,
             }),
         });
 
@@ -140,7 +151,9 @@ describe("CoordinatorClient (extended)", () => {
             Promise.resolve({
               session_id: MOCK_SESSION_ID,
               model: { name: "echo" },
+              server_info: MOCK_SERVER_INFO,
               state: "WAITING",
+              cluster: MOCK_CLUSTER,
             }),
         });
 

--- a/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
@@ -17,6 +17,7 @@ const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
 const MOCK_INITIAL_RESPONSE = {
   session_id: MOCK_SESSION_ID,
   model: { name: "echo" },
+  server_info: { server_version: "1.5.0" },
   state: "CREATED",
   cluster: "sup.us-west-2.aws.prod.reactor.inc",
 };
@@ -24,7 +25,9 @@ const MOCK_INITIAL_RESPONSE = {
 const MOCK_FULL_SESSION_RESPONSE = {
   session_id: MOCK_SESSION_ID,
   model: { name: "echo" },
+  server_info: { server_version: "1.5.0" },
   state: "ACTIVE",
+  cluster: "sup.us-west-2.aws.prod.reactor.inc",
   selected_transport: { protocol: "webrtc", version: "1.0" },
   capabilities: {
     protocol_version: "1.0",
@@ -54,7 +57,7 @@ describe("CoordinatorClient", () => {
   // ── createSession() ────────────────────────────────────────────────────
 
   describe("createSession()", () => {
-    it("sends correct request body and returns InitialSessionResponse", async () => {
+    it("sends correct request body and returns CreateSessionResponse", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 201,
@@ -179,7 +182,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({
             session_id: MOCK_SESSION_ID,
             model: { name: "echo" },
+            server_info: { server_version: "1.5.0" },
             state: "PENDING",
+            cluster: "sup.us-west-2.aws.prod.reactor.inc",
           }),
       });
 
@@ -208,7 +213,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({
             session_id: MOCK_SESSION_ID,
             model: { name: "echo" },
+            server_info: { server_version: "1.5.0" },
             state: SessionState.CLOSED,
+            cluster: "sup.us-west-2.aws.prod.reactor.inc",
           }),
       });
 
@@ -228,7 +235,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({
             session_id: MOCK_SESSION_ID,
             model: { name: "echo" },
+            server_info: { server_version: "1.5.0" },
             state: SessionState.INACTIVE,
+            cluster: "sup.us-west-2.aws.prod.reactor.inc",
           }),
       });
 
@@ -248,7 +257,9 @@ describe("CoordinatorClient", () => {
           Promise.resolve({
             session_id: MOCK_SESSION_ID,
             model: { name: "echo" },
+            server_info: { server_version: "1.5.0" },
             state: "PENDING",
+            cluster: "sup.us-west-2.aws.prod.reactor.inc",
           }),
       });
 
@@ -279,7 +290,7 @@ describe("CoordinatorClient", () => {
 
       const result = await client.getSession();
       expect(result.session_id).toBe(MOCK_SESSION_ID);
-      expect(result.capabilities.tracks).toHaveLength(1);
+      expect(result.capabilities?.tracks).toHaveLength(1);
     });
 
     it("throws on non-OK response", async () => {

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -11,7 +11,9 @@ import {
 const MOCK_LOCAL_SESSION_RESPONSE = {
   session_id: "local",
   model: { name: "echo" },
+  server_info: { server_version: "1.0.0" },
   state: "ACTIVE",
+  cluster: "local",
   selected_transport: { protocol: "webrtc", version: "1.0" },
   capabilities: {
     protocol_version: "1.0",
@@ -36,7 +38,7 @@ describe("LocalCoordinatorClient", () => {
   // ── createSession() ────────────────────────────────────────────────────
 
   describe("createSession()", () => {
-    it("posts to /start_session and returns InitialSessionResponse", async () => {
+    it("posts to /start_session and returns CreateSessionResponse", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(MOCK_LOCAL_SESSION_RESPONSE),

--- a/packages/js-sdk/__tests__/unit/schemas.test.ts
+++ b/packages/js-sdk/__tests__/unit/schemas.test.ts
@@ -3,7 +3,6 @@
 import { describe, it, expect } from "vitest";
 import {
   CreateSessionRequestSchema,
-  InitialSessionResponseSchema,
   CreateSessionResponseSchema,
   SessionResponseSchema,
   CapabilitiesSchema,
@@ -63,28 +62,19 @@ describe("CreateSessionRequestSchema", () => {
   });
 });
 
-describe("InitialSessionResponseSchema", () => {
-  it("validates a slim session creation response", () => {
+describe("CreateSessionResponseSchema", () => {
+  it("validates a session creation response", () => {
     const data = {
       session_id: "85ded560-014c-42df-8902-89dfbca8fa00",
-      model: { name: "echo" },
-      state: "CREATED",
-    };
-    const result = InitialSessionResponseSchema.parse(data);
-    expect(result.session_id).toBe("85ded560-014c-42df-8902-89dfbca8fa00");
-    expect(result.state).toBe("CREATED");
-  });
-
-  it("accepts optional server_info and cluster", () => {
-    const data = {
-      session_id: "test-id",
       model: { name: "echo" },
       server_info: { server_version: "1.5.0" },
       state: "CREATED",
       cluster: "sup.us-west-2.aws.prod.reactor.inc",
     };
-    const result = InitialSessionResponseSchema.parse(data);
-    expect(result.server_info?.server_version).toBe("1.5.0");
+    const result = CreateSessionResponseSchema.parse(data);
+    expect(result.session_id).toBe("85ded560-014c-42df-8902-89dfbca8fa00");
+    expect(result.state).toBe("CREATED");
+    expect(result.server_info.server_version).toBe("1.5.0");
     expect(result.cluster).toBe("sup.us-west-2.aws.prod.reactor.inc");
   });
 
@@ -92,61 +82,22 @@ describe("InitialSessionResponseSchema", () => {
     const data = {
       session_id: "local",
       model: { name: "echo" },
+      server_info: { server_version: "1.0.0" },
       state: "CREATED",
+      cluster: "local",
     };
-    expect(() => InitialSessionResponseSchema.parse(data)).not.toThrow();
+    expect(() => CreateSessionResponseSchema.parse(data)).not.toThrow();
   });
 });
 
-describe("CreateSessionResponseSchema (full)", () => {
-  it("validates a full response with capabilities and transport", () => {
-    const data = {
-      session_id: "85ded560-014c-42df-8902-89dfbca8fa00",
-      model: { name: "echo" },
-      state: "ACTIVE",
-      selected_transport: { protocol: "webrtc", version: "1.0" },
-      capabilities: {
-        protocol_version: "1.0",
-        tracks: [{ name: "main_video", kind: "video", direction: "recvonly" }],
-      },
-    };
-    const result = CreateSessionResponseSchema.parse(data);
-    expect(result.selected_transport.protocol).toBe("webrtc");
-    expect(result.capabilities.tracks).toHaveLength(1);
-  });
-
-  it("rejects when selected_transport is missing", () => {
-    expect(() =>
-      CreateSessionResponseSchema.parse({
-        session_id: "test-id",
-        model: { name: "echo" },
-        state: "ACTIVE",
-        capabilities: {
-          protocol_version: "1.0",
-          tracks: [],
-        },
-      })
-    ).toThrow();
-  });
-
-  it("rejects when capabilities is missing", () => {
-    expect(() =>
-      CreateSessionResponseSchema.parse({
-        session_id: "test-id",
-        model: { name: "echo" },
-        state: "ACTIVE",
-        selected_transport: { protocol: "webrtc", version: "1.0" },
-      })
-    ).toThrow();
-  });
-});
-
-describe("SessionResponseSchema (partial)", () => {
+describe("SessionResponseSchema", () => {
   it("validates with optional capabilities and transport", () => {
     const data = {
       session_id: "test-id",
       model: { name: "echo" },
+      server_info: { server_version: "1.5.0" },
       state: "CREATED",
+      cluster: "sup.us-west-2.aws.prod.reactor.inc",
     };
     expect(() => SessionResponseSchema.parse(data)).not.toThrow();
   });
@@ -157,12 +108,12 @@ describe("SessionResponseSchema (partial)", () => {
       model: { name: "echo", version: "1.0.0" },
       state: "ACTIVE",
       server_info: { server_version: "1.5.0" },
+      cluster: "sup.us-west-2.aws.prod.reactor.inc",
       selected_transport: { protocol: "webrtc", version: "1.0" },
       capabilities: {
         protocol_version: "1.0",
         tracks: [],
       },
-      cluster: "sup.us-west-2.aws.prod.reactor.inc",
     };
     const result = SessionResponseSchema.parse(data);
     expect(result.model.version).toBe("1.0.0");

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -10,11 +10,10 @@
 import {
   type CreateSessionRequest,
   type CreateSessionResponse,
-  type InitialSessionResponse,
+  type SessionResponse,
   type SessionInfoResponse,
   type TerminateSessionRequest,
   CreateSessionResponseSchema,
-  InitialSessionResponseSchema,
   SessionResponseSchema,
   SessionInfoResponseSchema,
   SessionState,
@@ -132,7 +131,7 @@ export class CoordinatorClient {
    */
   async createSession(
     extraArgs?: Record<string, any>
-  ): Promise<InitialSessionResponse> {
+  ): Promise<CreateSessionResponse> {
     console.debug("[CoordinatorClient] Creating session...");
 
     const requestBody: CreateSessionRequest = {
@@ -167,7 +166,7 @@ export class CoordinatorClient {
     }
 
     const data = await response.json();
-    const parsed = InitialSessionResponseSchema.parse(data);
+    const parsed = CreateSessionResponseSchema.parse(data);
     this.currentSessionId = parsed.session_id;
 
     console.debug(
@@ -186,7 +185,7 @@ export class CoordinatorClient {
    */
   async pollSessionReady(opts?: {
     maxAttempts?: number;
-  }): Promise<CreateSessionResponse> {
+  }): Promise<SessionResponse> {
     if (!this.currentSessionId) {
       throw new Error("No active session. Call createSession() first.");
     }
@@ -245,13 +244,12 @@ export class CoordinatorClient {
       }
 
       if (partial.capabilities && partial.selected_transport) {
-        const full = CreateSessionResponseSchema.parse(data);
         console.debug(
           `[CoordinatorClient] Session ready after ${attempt} poll(s), ` +
-            `transport: ${full.selected_transport.protocol}, ` +
-            `tracks: ${full.capabilities.tracks.length}`
+            `transport: ${partial.selected_transport.protocol}, ` +
+            `tracks: ${partial.capabilities.tracks.length}`
         );
-        return full;
+        return partial;
       }
 
       console.debug(
@@ -268,10 +266,11 @@ export class CoordinatorClient {
   }
 
   /**
-   * Gets full session details from the coordinator.
-   * Returns the same shape as the creation response but with updated state.
+   * Gets session details from the coordinator.
+   * Fields like selected_transport and capabilities are only present
+   * after the Runtime accepts the session.
    */
-  async getSession(): Promise<CreateSessionResponse> {
+  async getSession(): Promise<SessionResponse> {
     if (!this.currentSessionId) {
       throw new Error("No active session. Call createSession() first.");
     }
@@ -293,7 +292,7 @@ export class CoordinatorClient {
     }
 
     const data = await response.json();
-    return CreateSessionResponseSchema.parse(data);
+    return SessionResponseSchema.parse(data);
   }
 
   /**

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -15,16 +15,16 @@
 import { CoordinatorClient } from "./CoordinatorClient";
 import {
   type CreateSessionResponse,
-  type InitialSessionResponse,
+  type SessionResponse,
   CreateSessionResponseSchema,
-  InitialSessionResponseSchema,
+  SessionResponseSchema,
   API_VERSION_HEADER,
   API_ACCEPT_VERSION_HEADER,
   REACTOR_API_VERSION,
 } from "./types";
 
 export class LocalCoordinatorClient extends CoordinatorClient {
-  private cachedSessionResponse?: CreateSessionResponse;
+  private cachedSessionResponse?: SessionResponse;
 
   constructor(baseUrl: string, model: string) {
     super({
@@ -49,7 +49,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
    */
   override async createSession(
     extraArgs?: Record<string, any>
-  ): Promise<InitialSessionResponse> {
+  ): Promise<CreateSessionResponse> {
     console.debug("[LocalCoordinatorClient] Starting session...");
 
     const response = await fetch(`${this.baseUrl}/start_session`, {
@@ -73,26 +73,27 @@ export class LocalCoordinatorClient extends CoordinatorClient {
 
     const data = await response.json();
 
-    this.cachedSessionResponse = CreateSessionResponseSchema.parse(data);
-    this.currentSessionId = this.cachedSessionResponse.session_id;
+    const session = SessionResponseSchema.parse(data);
+    this.cachedSessionResponse = session;
+    this.currentSessionId = session.session_id;
 
     console.debug(
       "[LocalCoordinatorClient] Session started:",
       this.currentSessionId,
       "transport:",
-      this.cachedSessionResponse.selected_transport.protocol,
+      session.selected_transport?.protocol,
       "tracks:",
-      this.cachedSessionResponse.capabilities.tracks.length
+      session.capabilities?.tracks.length
     );
 
-    return InitialSessionResponseSchema.parse(data);
+    return CreateSessionResponseSchema.parse(data);
   }
 
   /**
    * Returns the cached full session response immediately.
    * The local runtime already provided everything in start_session.
    */
-  override async pollSessionReady(): Promise<CreateSessionResponse> {
+  override async pollSessionReady(): Promise<SessionResponse> {
     if (!this.cachedSessionResponse) {
       throw new Error(
         "No cached session response. Call createSession() first."

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -17,7 +17,7 @@ import { type TransportClient, type TransportStatus } from "./TransportClient";
 import { WebRTCTransportClient } from "./WebRTCTransportClient";
 import {
   type Capabilities,
-  type CreateSessionResponse,
+  type SessionResponse,
   type TrackCapability,
   REACTOR_WEBRTC_VERSION,
 } from "./types";
@@ -50,7 +50,7 @@ export class Reactor {
 
   private capabilities?: Capabilities;
   private tracks: TrackCapability[] = [];
-  private sessionResponse?: CreateSessionResponse;
+  private sessionResponse?: SessionResponse;
 
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
@@ -244,19 +244,19 @@ export class Reactor {
       this.sessionResponse = sessionResponse;
 
       // 3. Store capabilities and tracks
-      this.capabilities = sessionResponse.capabilities;
-      this.tracks = sessionResponse.capabilities.tracks;
+      this.capabilities = sessionResponse.capabilities!;
+      this.tracks = sessionResponse.capabilities!.tracks;
       this.emit("capabilitiesReceived", this.capabilities);
 
       console.debug(
         "[Reactor] Session ready, transport:",
-        sessionResponse.selected_transport.protocol,
+        sessionResponse.selected_transport!.protocol,
         "tracks:",
         this.tracks.length
       );
 
       // 4. Instantiate transport based on selected_transport
-      const protocol = sessionResponse.selected_transport.protocol;
+      const protocol = sessionResponse.selected_transport!.protocol;
       if (protocol !== "webrtc") {
         throw new Error(`Unsupported transport protocol: ${protocol}`);
       }
@@ -266,7 +266,7 @@ export class Reactor {
         sessionId: sessionResponse.session_id,
         jwtToken: this.local ? "local" : jwtToken!,
         webrtcVersion:
-          sessionResponse.selected_transport.version ?? REACTOR_WEBRTC_VERSION,
+          sessionResponse.selected_transport?.version ?? REACTOR_WEBRTC_VERSION,
         maxPollAttempts: options?.maxAttempts,
       });
       this.setupTransportHandlers();
@@ -429,7 +429,7 @@ export class Reactor {
     return this.capabilities;
   }
 
-  getSessionInfo(): CreateSessionResponse | undefined {
+  getSessionInfo(): SessionResponse | undefined {
     return this.sessionResponse;
   }
 

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -84,15 +84,6 @@ export const CreateSessionRequestSchema = z.object({
   extra_args: z.record(z.string(), z.any()).optional(),
 });
 
-// POST /sessions — Response (201): slim initial response before Runtime accepts
-export const InitialSessionResponseSchema = z.object({
-  session_id: z.string(),
-  model: z.object({ name: z.string() }),
-  server_info: z.object({ server_version: z.string() }).optional(),
-  state: z.string(),
-  cluster: z.string().optional(),
-});
-
 // Mirrors the proto Command message.
 export const CommandCapabilitySchema = z.object({
   name: z.string(),
@@ -100,7 +91,6 @@ export const CommandCapabilitySchema = z.object({
   schema: z.record(z.string(), z.any()).optional(),
 });
 
-// GET /sessions/{id} — Full response with capabilities (populated after Runtime accepts).
 // Mirrors the proto TransportCapabilities message.
 export const CapabilitiesSchema = z.object({
   protocol_version: z.string(),
@@ -109,27 +99,23 @@ export const CapabilitiesSchema = z.object({
   emission_fps: z.number().nullable().optional(),
 });
 
-export const SessionResponseSchema = z.object({
-  session_id: z.string(),
-  server_info: z.object({ server_version: z.string() }).optional(),
-  selected_transport: TransportDeclarationSchema.optional(),
-  model: z.object({ name: z.string(), version: z.string().optional() }),
-  capabilities: CapabilitiesSchema.optional(),
-  state: z.string(),
-  cluster: z.string().optional(),
-});
-
-// Full session response: selected_transport and capabilities are guaranteed present
-export const CreateSessionResponseSchema = SessionResponseSchema.extend({
-  selected_transport: TransportDeclarationSchema,
-  capabilities: CapabilitiesSchema,
-});
-
 // GET /sessions/{id}/info — Response (200)
 export const SessionInfoResponseSchema = z.object({
   session_id: z.string(),
-  cluster: z.string().optional(),
   state: z.string(),
+  cluster: z.string(),
+});
+
+// POST /sessions — Response (201)
+export const CreateSessionResponseSchema = SessionInfoResponseSchema.extend({
+  model: z.object({ name: z.string(), version: z.string().optional() }),
+  server_info: z.object({ server_version: z.string() }),
+});
+
+// GET /sessions/{id} — Response (200)
+export const SessionResponseSchema = CreateSessionResponseSchema.extend({
+  selected_transport: TransportDeclarationSchema.optional(),
+  capabilities: CapabilitiesSchema.optional(),
 });
 
 // DELETE /sessions/{id} — Request
@@ -179,11 +165,8 @@ export type CommandCapability = z.infer<typeof CommandCapabilitySchema>;
 export type TrackMappingEntry = z.infer<typeof TrackMappingEntrySchema>;
 
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
-export type InitialSessionResponse = z.infer<
-  typeof InitialSessionResponseSchema
->;
-export type SessionResponse = z.infer<typeof SessionResponseSchema>;
 export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>;
+export type SessionResponse = z.infer<typeof SessionResponseSchema>;
 export type Capabilities = z.infer<typeof CapabilitiesSchema>;
 
 export type SessionInfoResponse = z.infer<typeof SessionInfoResponseSchema>;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -19,7 +19,7 @@ export type {
   CommandCapability,
   Capabilities,
   TransportDeclaration,
-  CreateSessionResponse as SessionInfo,
+  SessionResponse as SessionInfo,
 } from "./core/types";
 
 export interface ReactorError {


### PR DESCRIPTION
Why
---
The SDK type names didn't match the HTTP endpoints they represent.
`InitialSessionResponseSchema` was a made-up name, `CreateSessionResponseSchema`
was used for the "full/ready" variant instead of the actual POST /sessions
response, and `cluster`/`server_info` were incorrectly marked optional.

What Changed
---
- Restructured schemas as an inheritance chain:
  `SessionInfoResponseSchema` -> `CreateSessionResponseSchema` -> `SessionResponseSchema`,
  matching GET /sessions/{id}/info, POST /sessions, and GET /sessions/{id}
- Removed `InitialSessionResponseSchema` (renamed to `CreateSessionResponseSchema`)
- Removed the old `CreateSessionResponseSchema` that required `selected_transport`
  and `capabilities` -- those belong on `SessionResponseSchema` as optional fields
- Made `cluster` and `server_info` required (they are always returned by the API)
- Fixed `getSession()` to use `SessionResponseSchema` instead of the strict schema
  that caused flaky integration tests when the Runtime hadn't accepted yet
- Updated all unit test fixtures to include required `cluster` and `server_info`

API Changes
---
`CoordinatorClient.getSession()` now returns `SessionResponse` (with optional
`capabilities` and `selected_transport`) instead of requiring those fields.
`CoordinatorClient.pollSessionReady()` also returns `SessionResponse` instead
of the removed strict schema.

topic: align-js-sdk-with-coordinator-behaviour