### PR TITLE
Cleanup exported values from JS-SDK

### DIFF
--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,6 +1,4 @@
 export * from "./core/Reactor";
-export * from "./core/TransportClient";
-export * from "./core/WebRTCTransportClient";
 export * from "./react/ReactorProvider";
 export * from "./react/ReactorView";
 export * from "./react/ReactorController";

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -18,8 +18,7 @@ export type {
   TrackCapability,
   CommandCapability,
   Capabilities,
-  TransportDeclaration,
-  SessionResponse as SessionInfo,
+  SessionResponse,
 } from "./core/types";
 
 export interface ReactorError {


### PR DESCRIPTION
Why
---
The barrel export re-exported internal transport classes and a
confusingly aliased session type that no consumer actually uses.
This leaks implementation details and inflates the public API surface.

What Changed
---
- Removed `TransportClient` and `WebRTCTransportClient` re-exports from
  the barrel (internal plumbing, never used by consumers)
- Removed the `SessionResponse as SessionInfo` alias and the
  `TransportDeclaration` re-export from `types.ts`
- Added `SessionResponse` re-export under its real name so consumers
  can type `getSessionInfo()` return values
- Added `ReactorStore` type export so consumers can annotate
  `useReactor` / `useReactorStore` selectors

topic: cleanup-js-sdk-public-exports
reviewers: bryce, ahmed