### PR TITLE
[REA-1451] fix: make cluster field optional in SessionInfoResponseSchema

### DIFF
--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -103,7 +103,7 @@ export const CapabilitiesSchema = z.object({
 export const SessionInfoResponseSchema = z.object({
   session_id: z.string(),
   state: z.string(),
-  cluster: z.string(),
+  cluster: z.string().optional(),
 });
 
 // POST /sessions — Response (201)


### PR DESCRIPTION
## Summary

- Make `cluster` optional in `SessionInfoResponseSchema` — the local runtime does not return this field
- Fixes ZodError (`expected string, received undefined` at path `cluster`) when connecting to local runtimes via the test frontend

## Root cause

`SessionInfoResponseSchema` defines `cluster: z.string()` (required), but the local runtime's `/start_session` response omits it entirely — `cluster` is only meaningful for coordinated/production deployments.

## Change

```diff
- cluster: z.string(),
+ cluster: z.string().optional(),
```

One line in `packages/js-sdk/src/core/types.ts`.

## Test plan

- [ ] Local connection via test frontend no longer throws ZodError
- [ ] Production/coordinator connections still work (they return `cluster`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)