### PR TITLE
Reduce session connect latency with faster polling and ICE gathering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:unit": "pnpm --filter @reactor-team/js-sdk test:unit",
     "test:integration": "pnpm --filter @reactor-team/js-sdk test:integration",
     "format:check": "prettier --check .",
+    "format": "prettier --write .",
     "local-build": "pnpm --filter @reactor-team/js-sdk build && echo '\n@reactor-team/js-sdk built. Link with:\n  pnpm link '$(realpath packages/js-sdk)",
     "install:create-app": "pnpm --filter create-reactor-app install-cli"
   },

--- a/packages/js-sdk/__tests__/unit/webrtc-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-extended.test.ts
@@ -252,31 +252,30 @@ describe("addIceCandidate()", () => {
 // ---------------------------------------------------------------------------
 
 describe("waitForIceGathering()", () => {
-  it('resolves immediately when state is "complete"', async () => {
-    const pc = {
-      iceGatheringState: "complete",
-      addEventListener: vi.fn(),
+  function mockPc(initialState: string = "gathering") {
+    const handlers: Record<string, Function> = {};
+    return {
+      iceGatheringState: initialState,
+      addEventListener: vi.fn((event: string, cb: Function) => {
+        handlers[event] = cb;
+      }),
       removeEventListener: vi.fn(),
+      _handlers: handlers,
     } as any;
+  }
 
+  it('resolves immediately when state is "complete"', async () => {
+    const pc = mockPc("complete");
     await waitForIceGathering(pc);
     expect(pc.addEventListener).not.toHaveBeenCalled();
   });
 
   it('resolves when state changes to "complete" via event', async () => {
-    let handler: (() => void) | undefined;
-    const pc = {
-      iceGatheringState: "gathering",
-      addEventListener: vi.fn((_event: string, cb: () => void) => {
-        handler = cb;
-      }),
-      removeEventListener: vi.fn(),
-    } as any;
-
+    const pc = mockPc();
     const promise = waitForIceGathering(pc, 10_000);
 
     pc.iceGatheringState = "complete";
-    handler!();
+    pc._handlers["icegatheringstatechange"]();
 
     await promise;
     expect(pc.removeEventListener).toHaveBeenCalledWith(
@@ -285,13 +284,43 @@ describe("waitForIceGathering()", () => {
     );
   });
 
-  it("resolves on timeout without error", async () => {
-    const pc = {
-      iceGatheringState: "gathering",
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    } as any;
+  it("resolves early when srflx candidate arrives", async () => {
+    const pc = mockPc();
+    const promise = waitForIceGathering(pc, 10_000);
 
+    pc._handlers["icecandidate"]({ candidate: { type: "srflx" } });
+
+    await promise;
+    expect(pc.removeEventListener).toHaveBeenCalledWith(
+      "icecandidate",
+      expect.any(Function)
+    );
+  });
+
+  it("resolves early when relay candidate arrives", async () => {
+    const pc = mockPc();
+    const promise = waitForIceGathering(pc, 10_000);
+
+    pc._handlers["icecandidate"]({ candidate: { type: "relay" } });
+
+    await promise;
+    expect(pc.removeEventListener).toHaveBeenCalledWith(
+      "icecandidate",
+      expect.any(Function)
+    );
+  });
+
+  it("does not resolve early for host candidates", async () => {
+    const pc = mockPc();
+    const promise = waitForIceGathering(pc, 100);
+
+    pc._handlers["icecandidate"]({ candidate: { type: "host" } });
+
+    await promise;
+  });
+
+  it("resolves on timeout without error", async () => {
+    const pc = mockPc();
     await waitForIceGathering(pc, 50);
     expect(pc.removeEventListener).toHaveBeenCalled();
   });

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -27,10 +27,10 @@ import {
 } from "./types";
 import { AbortError } from "../types";
 
-const SESSION_POLL_INITIAL_BACKOFF_MS = 200;
+const SESSION_POLL_INITIAL_BACKOFF_MS = 50;
 const SESSION_POLL_MAX_BACKOFF_MS = 10_000;
-const SESSION_POLL_BACKOFF_MULTIPLIER = 2;
-const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 20;
+const SESSION_POLL_BACKOFF_MULTIPLIER = 1.5;
+const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 30;
 
 export interface CoordinatorClientOptions {
   baseUrl: string;

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -220,7 +220,7 @@ export class Reactor {
             model: this.model,
           });
 
-      // 1. Create session — slim response with session_id and status
+      // 1. Create session — may return enriched response with capabilities + ICE servers
       const tSession = performance.now();
       const initialResponse = await this.coordinatorClient.createSession();
       const sessionCreationMs = performance.now() - tSession;
@@ -234,46 +234,82 @@ export class Reactor {
         initialResponse.state
       );
 
-      // 2. Poll until the Runtime accepts and capabilities are available
-      this.setStatus("waiting");
+      // 2. Check if the POST response already contains capabilities (enriched response).
+      //    If so, skip the polling loop entirely.
+      let sessionPollingMs = 0;
+      let prefetchedIceServers: RTCIceServer[] | undefined;
 
-      const tPoll = performance.now();
-      const sessionResponse = await this.coordinatorClient.pollSessionReady();
-      const sessionPollingMs = performance.now() - tPoll;
+      if (
+        initialResponse.capabilities &&
+        initialResponse.selected_transport &&
+        initialResponse.ice_servers
+      ) {
+        console.debug(
+          "[Reactor] Enriched POST response — skipping capability polling",
+          "tracks:",
+          initialResponse.capabilities.tracks.length
+        );
 
-      this.sessionResponse = sessionResponse;
+        this.capabilities = initialResponse.capabilities;
+        this.tracks = initialResponse.capabilities.tracks;
 
-      // 3. Store capabilities and tracks
-      this.capabilities = sessionResponse.capabilities!;
-      this.tracks = sessionResponse.capabilities!.tracks;
+        prefetchedIceServers = initialResponse.ice_servers.ice_servers.map(
+          (server) => {
+            const rtcServer: RTCIceServer = { urls: server.uris };
+            if (server.credentials) {
+              rtcServer.username = server.credentials.username;
+              rtcServer.credential = server.credentials.password;
+            }
+            return rtcServer;
+          }
+        );
+      } else {
+        this.setStatus("waiting");
+
+        const tPoll = performance.now();
+        const sessionResponse =
+          await this.coordinatorClient.pollSessionReady();
+        sessionPollingMs = performance.now() - tPoll;
+
+        this.sessionResponse = sessionResponse;
+        this.capabilities = sessionResponse.capabilities!;
+        this.tracks = sessionResponse.capabilities!.tracks;
+      }
+
       this.emit("capabilitiesReceived", this.capabilities);
+
+      const selectedProtocol =
+        initialResponse.selected_transport?.protocol ??
+        this.sessionResponse?.selected_transport?.protocol;
+      const selectedVersion =
+        initialResponse.selected_transport?.version ??
+        this.sessionResponse?.selected_transport?.version ??
+        REACTOR_WEBRTC_VERSION;
 
       console.debug(
         "[Reactor] Session ready, transport:",
-        sessionResponse.selected_transport!.protocol,
+        selectedProtocol,
         "tracks:",
         this.tracks.length
       );
 
-      // 4. Instantiate transport based on selected_transport
-      const protocol = sessionResponse.selected_transport!.protocol;
-      if (protocol !== "webrtc") {
-        throw new Error(`Unsupported transport protocol: ${protocol}`);
+      // 3. Instantiate transport based on selected_transport
+      if (selectedProtocol !== "webrtc") {
+        throw new Error(`Unsupported transport protocol: ${selectedProtocol}`);
       }
 
       this.transportClient = new WebRTCTransportClient({
         baseUrl: this.coordinatorUrl,
-        sessionId: sessionResponse.session_id,
+        sessionId: initialResponse.session_id,
         jwtToken: this.local ? "local" : jwtToken!,
-        webrtcVersion:
-          sessionResponse.selected_transport?.version ?? REACTOR_WEBRTC_VERSION,
+        webrtcVersion: selectedVersion,
         maxPollAttempts: options?.maxAttempts,
       });
       this.setupTransportHandlers();
 
-      // 5. Connect transport using capabilities tracks
+      // 4. Connect transport using capabilities tracks (pass pre-fetched ICE servers if available)
       const tTransport = performance.now();
-      await this.transportClient.connect(this.tracks);
+      await this.transportClient.connect(this.tracks, prefetchedIceServers);
       const transportConnectingMs = performance.now() - tTransport;
 
       this.connectionTimings = {

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -56,7 +56,10 @@ export interface TransportClient {
    * connection negotiation, and transceiver setup. For sendonly tracks,
    * no media flows until {@link publishTrack} is called.
    */
-  connect(tracks: TrackCapability[]): Promise<void>;
+  connect(
+    tracks: TrackCapability[],
+    prefetchedIceServers?: RTCIceServer[]
+  ): Promise<void>;
 
   /**
    * Reconnects an existing session with a fresh transport negotiation.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -322,11 +322,20 @@ export class WebRTCTransportClient implements TransportClient {
   // Connection Lifecycle
   // ─────────────────────────────────────────────────────────────────────────
 
-  async connect(tracks: TrackCapability[]): Promise<void> {
+  async connect(
+    tracks: TrackCapability[],
+    prefetchedIceServers?: RTCIceServer[]
+  ): Promise<void> {
     this.setStatus("connecting");
     this.resetTransportTimings();
 
-    const iceServers = await this.fetchIceServers();
+    const iceServers = prefetchedIceServers ?? (await this.fetchIceServers());
+    if (prefetchedIceServers) {
+      console.debug(
+        "[WebRTCTransport] Using pre-fetched ICE servers:",
+        prefetchedIceServers.length
+      );
+    }
 
     this.peerConnection = webrtc.createPeerConnection({ iceServers });
     this.setupPeerConnectionHandlers();

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -40,10 +40,10 @@ type EventHandler = (...args: any[]) => void;
 const PING_INTERVAL_MS = 5_000;
 const STATS_INTERVAL_MS = 2_000;
 
-const INITIAL_BACKOFF_MS = 200;
+const INITIAL_BACKOFF_MS = 50;
 const MAX_BACKOFF_MS = 15_000;
-const BACKOFF_MULTIPLIER = 2;
-const DEFAULT_MAX_POLL_ATTEMPTS = 6;
+const BACKOFF_MULTIPLIER = 1.5;
+const DEFAULT_MAX_POLL_ATTEMPTS = 10;
 
 export interface WebRTCTransportConfig extends TransportClientConfig {
   webrtcVersion?: string;

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -99,35 +99,11 @@ export const CapabilitiesSchema = z.object({
   emission_fps: z.number().nullable().optional(),
 });
 
-// GET /sessions/{id}/info — Response (200)
-export const SessionInfoResponseSchema = z.object({
-  session_id: z.string(),
-  state: z.string(),
-  cluster: z.string(),
-});
-
-// POST /sessions — Response (201)
-export const CreateSessionResponseSchema = SessionInfoResponseSchema.extend({
-  model: z.object({ name: z.string(), version: z.string().optional() }),
-  server_info: z.object({ server_version: z.string() }),
-});
-
-// GET /sessions/{id} — Response (200)
-export const SessionResponseSchema = CreateSessionResponseSchema.extend({
-  selected_transport: TransportDeclarationSchema.optional(),
-  capabilities: CapabilitiesSchema.optional(),
-});
-
-// DELETE /sessions/{id} — Request
-export const TerminateSessionRequestSchema = z.object({
-  reason: z.string().optional(),
-});
-
 // ─────────────────────────────────────────────────────────────────────────────
-// WebRTC Transport Schemas
+// ICE Server Schemas (defined before session schemas because
+// CreateSessionResponseSchema references IceServersResponseSchema)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// GET /sessions/{id}/transport/webrtc/ice_servers — Response (200)
 export const IceServerCredentialsSchema = z.object({
   username: z.string(),
   password: z.string(),
@@ -140,6 +116,35 @@ export const IceServerSchema = z.object({
 
 export const IceServersResponseSchema = z.object({
   ice_servers: z.array(IceServerSchema),
+});
+
+// GET /sessions/{id}/info — Response (200)
+export const SessionInfoResponseSchema = z.object({
+  session_id: z.string(),
+  state: z.string(),
+  cluster: z.string(),
+});
+
+// POST /sessions — Response (201)
+// The coordinator may enrich this response with capabilities, selected_transport,
+// and ice_servers when the runtime reports them within a bounded wait window.
+export const CreateSessionResponseSchema = SessionInfoResponseSchema.extend({
+  model: z.object({ name: z.string(), version: z.string().optional() }),
+  server_info: z.object({ server_version: z.string() }),
+  selected_transport: TransportDeclarationSchema.optional(),
+  capabilities: CapabilitiesSchema.optional(),
+  ice_servers: IceServersResponseSchema.optional(),
+});
+
+// GET /sessions/{id} — Response (200)
+export const SessionResponseSchema = CreateSessionResponseSchema.extend({
+  selected_transport: TransportDeclarationSchema.optional(),
+  capabilities: CapabilitiesSchema.optional(),
+});
+
+// DELETE /sessions/{id} — Request
+export const TerminateSessionRequestSchema = z.object({
+  reason: z.string().optional(),
 });
 
 // POST/PUT /sessions/{id}/transport/webrtc/sdp_params — Request

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -21,6 +21,17 @@ const DEFAULT_DATA_CHANNEL_LABEL = "data";
 const FORCE_RELAY_MODE = false;
 
 /**
+ * When true, ICE gathering resolves early on the first srflx or relay
+ * candidate instead of waiting for the full "complete" state. This
+ * reduces connection time by 0.5–1.5s but may omit slower relay
+ * candidates from the initial offer, potentially affecting connectivity
+ * on restrictive networks.
+ *
+ * Set to false to wait for full ICE gathering (safer, slower).
+ */
+const EARLY_ICE_GATHERING = false;
+
+/**
  * Safe cross-browser default for the maximum data channel message size (bytes).
  * Most browsers negotiate 256 KiB via SCTP; we use a slightly lower value to
  * leave room for framing overhead.
@@ -157,19 +168,17 @@ export async function addIceCandidate(
 /**
  * Waits for ICE gathering to produce usable candidates, then resolves.
  *
- * Strategy: resolve as soon as we have at least one server-reflexive (srflx)
- * or relay candidate, which means STUN/TURN succeeded and we have a
- * routable candidate. Falls back to a hard timeout if no such candidate
- * arrives (e.g. host-only networks).
+ * When {@link EARLY_ICE_GATHERING} is enabled, resolves as soon as the first
+ * server-reflexive (srflx) or relay candidate arrives, which typically takes
+ * 50–200ms. This avoids waiting for the full "complete" state (2–5s) when
+ * TURN-TCP or TURN-TLS candidates are still being gathered.
  *
- * This avoids waiting for the full "complete" state which can take 2-5s
- * when TURN-TCP or TURN-TLS candidates are still being gathered.
- * Any remaining candidates (relay, etc.) trickle in after the offer is
- * sent and are usable once setRemoteDescription is called on both sides.
+ * When disabled, waits for the full "complete" state or the hard timeout,
+ * ensuring all candidate types (including relay) are in the offer.
  */
 export function waitForIceGathering(
   pc: RTCPeerConnection,
-  timeoutMs: number = 500
+  timeoutMs: number = EARLY_ICE_GATHERING ? 500 : 5000
 ): Promise<void> {
   return new Promise((resolve) => {
     if (pc.iceGatheringState === "complete") {
@@ -193,6 +202,7 @@ export function waitForIceGathering(
     };
 
     const onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
+      if (!EARLY_ICE_GATHERING) return;
       if (!event.candidate) return;
       const typ = event.candidate.type;
       if (typ === "srflx" || typ === "relay") {

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -155,11 +155,21 @@ export async function addIceCandidate(
 }
 
 /**
- * Waits for ICE gathering to complete with a timeout.
+ * Waits for ICE gathering to produce usable candidates, then resolves.
+ *
+ * Strategy: resolve as soon as we have at least one server-reflexive (srflx)
+ * or relay candidate, which means STUN/TURN succeeded and we have a
+ * routable candidate. Falls back to a hard timeout if no such candidate
+ * arrives (e.g. host-only networks).
+ *
+ * This avoids waiting for the full "complete" state which can take 2-5s
+ * when TURN-TCP or TURN-TLS candidates are still being gathered.
+ * Any remaining candidates (relay, etc.) trickle in after the offer is
+ * sent and are usable once setRemoteDescription is called on both sides.
  */
 export function waitForIceGathering(
   pc: RTCPeerConnection,
-  timeoutMs: number = 5000
+  timeoutMs: number = 500
 ): Promise<void> {
   return new Promise((resolve) => {
     if (pc.iceGatheringState === "complete") {
@@ -167,21 +177,42 @@ export function waitForIceGathering(
       return;
     }
 
+    let resolved = false;
+    const cleanup = () => {
+      if (resolved) return;
+      resolved = true;
+      pc.removeEventListener("icegatheringstatechange", onGatheringStateChange);
+      pc.removeEventListener("icecandidate", onIceCandidate);
+      resolve();
+    };
+
     const onGatheringStateChange = () => {
       if (pc.iceGatheringState === "complete") {
-        pc.removeEventListener(
-          "icegatheringstatechange",
-          onGatheringStateChange
+        cleanup();
+      }
+    };
+
+    const onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
+      if (!event.candidate) return;
+      const typ = event.candidate.type;
+      if (typ === "srflx" || typ === "relay") {
+        console.debug(
+          `[WebRTC] ICE gathering early-complete: got ${typ} candidate`
         );
-        resolve();
+        cleanup();
       }
     };
 
     pc.addEventListener("icegatheringstatechange", onGatheringStateChange);
+    pc.addEventListener("icecandidate", onIceCandidate);
 
     setTimeout(() => {
-      pc.removeEventListener("icegatheringstatechange", onGatheringStateChange);
-      resolve();
+      if (!resolved) {
+        console.debug(
+          `[WebRTC] ICE gathering timeout (${timeoutMs}ms), proceeding with current candidates`
+        );
+      }
+      cleanup();
     }, timeoutMs);
   });
 }


### PR DESCRIPTION
## Why

Session connect times are ~3-5s due to conservative polling backoffs, a full ICE gathering wait, and a strictly sequential connection flow where each step blocks on the previous one.

## What Changed

### Faster polling (commit 1)

- Session poll backoff: 200ms/2x/20-max → 50ms/1.5x/30-max
- SDP answer poll backoff: 200ms/2x/6-max → 50ms/1.5x/10-max
- Bumped version to 2.8.1

### Early ICE gathering with feature flag (commit 2)

- Added `EARLY_ICE_GATHERING` flag in `webrtc.ts` (default: `false`).
  When enabled, ICE gathering resolves on the first `srflx` or `relay` candidate (500ms timeout) instead of waiting for full completion (5s timeout). Gated behind the flag to allow rollback if it causes connectivity issues on restrictive networks.

### Enriched POST /sessions response handling (commit 2)

Server-side (REA-1553, separate PR: [reactor#1781](https://github.com/reactor-team/reactor/pull/1781)), POST /sessions now optionally returns `capabilities`, `selected_transport`, and `ice_servers` in the response when the runtime reports them within 200ms.

Client-side changes to consume this:

- Extended `CreateSessionResponseSchema` (Zod) with optional `selected_transport`, `capabilities`, and `ice_servers` fields.
- `Reactor.connect()` checks if the POST response is enriched. If all three fields are present, skips the polling loop and ICE server fetch entirely. Falls back to the existing flow otherwise.
- Updated `TransportClient.connect()` interface to accept optional `prefetchedIceServers`. `WebRTCTransportClient` uses them directly, skipping the GET `.../ice_servers` call.
- Moved `IceServerSchema` / `IceServersResponseSchema` above session schemas in `types.ts` (Zod declaration order dependency).

### Files changed

| File | Change |
|------|--------|
| `src/core/types.ts` | Added ICE + enriched response fields to `CreateSessionResponseSchema` |
| `src/core/Reactor.ts` | Enriched-response fast path in `connect()` |
| `src/core/TransportClient.ts` | `connect()` accepts optional `prefetchedIceServers` |
| `src/core/WebRTCTransportClient.ts` | Skips ICE fetch when pre-fetched servers provided |
| `src/utils/webrtc.ts` | `EARLY_ICE_GATHERING` flag + conditional early-complete logic |

## Expected Impact

With enriched response (server + client deployed together):
- Eliminates GET /sessions/:id polling loop (~200-400ms + 2 CORS preflights)
- Eliminates GET .../ice_servers fetch (~1 RTT + 1 CORS preflight)
- **Estimated savings: 500ms-1.5s** depending on RTT

Without enriched response (client-only, old server):
- Falls back to existing polling flow, no regression

topic: REA-1075-reduce-session-connect-latency
reviewers: bryce