### PR TITLE
Add optional OpenTelemetry distributed tracing to the JS-SDK

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -62,7 +62,13 @@
     "zod": "^4.0.5"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.4.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zustand": "^5.0.6"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": { "optional": true },
+    "react": { "optional": true },
+    "zustand": { "optional": true }
   }
 }

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -26,6 +26,7 @@ import {
   VERSION_ERROR_CODES,
 } from "./types";
 import { AbortError } from "../types";
+import { tracedFetch, withSpan } from "./telemetry";
 
 const SESSION_POLL_INITIAL_BACKOFF_MS = 200;
 const SESSION_POLL_MAX_BACKOFF_MS = 10_000;
@@ -146,15 +147,19 @@ export class CoordinatorClient {
       ...(extraArgs ? { extra_args: extraArgs } : {}),
     };
 
-    const response = await fetch(`${this.baseUrl}/sessions`, {
-      method: "POST",
-      headers: {
-        ...this.getHeaders(),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(requestBody),
-      signal: this.signal,
-    });
+    const response = await tracedFetch(
+      "reactor.session.create",
+      `${this.baseUrl}/sessions`,
+      {
+        method: "POST",
+        headers: {
+          ...this.getHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+        signal: this.signal,
+      }
+    );
 
     await this.checkVersionMismatch(response);
 
@@ -190,79 +195,88 @@ export class CoordinatorClient {
       throw new Error("No active session. Call createSession() first.");
     }
 
+    const sessionId = this.currentSessionId;
     const maxAttempts = opts?.maxAttempts ?? SESSION_POLL_DEFAULT_MAX_ATTEMPTS;
-    let backoffMs = SESSION_POLL_INITIAL_BACKOFF_MS;
-    let attempt = 0;
 
-    console.debug(
-      "[CoordinatorClient] Polling session until capabilities are available..."
-    );
+    return withSpan(
+      "reactor.session.poll",
+      { "session.id": sessionId },
+      async () => {
+        let backoffMs = SESSION_POLL_INITIAL_BACKOFF_MS;
+        let attempt = 0;
 
-    while (true) {
-      if (this.signal.aborted) {
-        throw new AbortError("Session polling aborted");
-      }
-
-      if (attempt >= maxAttempts) {
-        throw new Error(
-          `Session polling exceeded maximum attempts (${maxAttempts}). ` +
-            `The model may be unavailable or overloaded.`
-        );
-      }
-
-      attempt++;
-
-      const response = await fetch(
-        `${this.baseUrl}/sessions/${this.currentSessionId}`,
-        {
-          method: "GET",
-          headers: this.getHeaders(),
-          signal: this.signal,
-        }
-      );
-
-      await this.checkVersionMismatch(response);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(
-          `Failed to poll session: ${response.status} ${errorText}`
-        );
-      }
-
-      const data = await response.json();
-      const partial = SessionResponseSchema.parse(data);
-
-      const terminalStates: string[] = [
-        SessionState.CLOSED,
-        SessionState.INACTIVE,
-      ];
-      if (terminalStates.includes(partial.state)) {
-        throw new Error(
-          `Session entered terminal state "${partial.state}" while waiting for capabilities`
-        );
-      }
-
-      if (partial.capabilities && partial.selected_transport) {
         console.debug(
-          `[CoordinatorClient] Session ready after ${attempt} poll(s), ` +
-            `transport: ${partial.selected_transport.protocol}, ` +
-            `tracks: ${partial.capabilities.tracks.length}`
+          "[CoordinatorClient] Polling session until capabilities are available..."
         );
-        return partial;
+
+        while (true) {
+          if (this.signal.aborted) {
+            throw new AbortError("Session polling aborted");
+          }
+
+          if (attempt >= maxAttempts) {
+            throw new Error(
+              `Session polling exceeded maximum attempts (${maxAttempts}). ` +
+                `The model may be unavailable or overloaded.`
+            );
+          }
+
+          attempt++;
+
+          const response = await tracedFetch(
+            "reactor.session.poll.attempt",
+            `${this.baseUrl}/sessions/${sessionId}`,
+            {
+              method: "GET",
+              headers: this.getHeaders(),
+              signal: this.signal,
+            }
+          );
+
+          await this.checkVersionMismatch(response);
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(
+              `Failed to poll session: ${response.status} ${errorText}`
+            );
+          }
+
+          const data = await response.json();
+          const partial = SessionResponseSchema.parse(data);
+
+          const terminalStates: string[] = [
+            SessionState.CLOSED,
+            SessionState.INACTIVE,
+          ];
+          if (terminalStates.includes(partial.state)) {
+            throw new Error(
+              `Session entered terminal state "${partial.state}" while waiting for capabilities`
+            );
+          }
+
+          if (partial.capabilities && partial.selected_transport) {
+            console.debug(
+              `[CoordinatorClient] Session ready after ${attempt} poll(s), ` +
+                `transport: ${partial.selected_transport.protocol}, ` +
+                `tracks: ${partial.capabilities.tracks.length}`
+            );
+            return partial;
+          }
+
+          console.debug(
+            `[CoordinatorClient] Session poll ${attempt}/${maxAttempts} — ` +
+              `state: ${partial.state}, waiting ${backoffMs}ms...`
+          );
+
+          await this.sleep(backoffMs);
+          backoffMs = Math.min(
+            backoffMs * SESSION_POLL_BACKOFF_MULTIPLIER,
+            SESSION_POLL_MAX_BACKOFF_MS
+          );
+        }
       }
-
-      console.debug(
-        `[CoordinatorClient] Session poll ${attempt}/${maxAttempts} — ` +
-          `state: ${partial.state}, waiting ${backoffMs}ms...`
-      );
-
-      await this.sleep(backoffMs);
-      backoffMs = Math.min(
-        backoffMs * SESSION_POLL_BACKOFF_MULTIPLIER,
-        SESSION_POLL_MAX_BACKOFF_MS
-      );
-    }
+    );
   }
 
   /**
@@ -275,7 +289,8 @@ export class CoordinatorClient {
       throw new Error("No active session. Call createSession() first.");
     }
 
-    const response = await fetch(
+    const response = await tracedFetch(
+      "reactor.session.get",
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "GET",
@@ -339,7 +354,8 @@ export class CoordinatorClient {
       this.currentSessionId
     );
 
-    const response = await fetch(
+    const response = await tracedFetch(
+      "reactor.session.restart",
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "PUT",
@@ -377,7 +393,8 @@ export class CoordinatorClient {
       ? { reason }
       : undefined;
 
-    const response = await fetch(
+    const response = await tracedFetch(
+      "reactor.session.terminate",
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "DELETE",

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -22,6 +22,7 @@ import {
   REACTOR_WEBRTC_VERSION,
 } from "./types";
 import { z } from "zod";
+import { setEnabled as setTelemetryEnabled, withSpan } from "./telemetry";
 
 const LOCAL_COORDINATOR_URL = "http://localhost:8080";
 export const DEFAULT_BASE_URL = "https://api.reactor.inc";
@@ -60,6 +61,7 @@ export class Reactor {
     if (this.local && options.apiUrl === undefined) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
     }
+    setTelemetryEnabled(!this.local);
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
@@ -167,30 +169,36 @@ export class Reactor {
 
     this.setStatus("connecting");
 
-    try {
-      if (!this.transportClient) {
-        this.transportClient = new WebRTCTransportClient({
-          baseUrl: this.coordinatorUrl,
-          sessionId: this.sessionId,
-          jwtToken: this.local ? "local" : "",
-          maxPollAttempts: options?.maxAttempts,
-        });
-        this.setupTransportHandlers();
+    return withSpan(
+      "reactor.reconnect",
+      { "session.id": this.sessionId, "session.model": this.model },
+      async () => {
+        try {
+          if (!this.transportClient) {
+            this.transportClient = new WebRTCTransportClient({
+              baseUrl: this.coordinatorUrl,
+              sessionId: this.sessionId!,
+              jwtToken: this.local ? "local" : "",
+              maxPollAttempts: options?.maxAttempts,
+            });
+            this.setupTransportHandlers();
+          }
+
+          await this.transportClient.reconnect(this.tracks);
+        } catch (error) {
+          if (isAbortError(error)) return;
+
+          console.error("[Reactor] Failed to reconnect:", error);
+          this.disconnect(true);
+          this.createError(
+            "RECONNECTION_FAILED",
+            `Failed to reconnect: ${error}`,
+            "api",
+            true
+          );
+        }
       }
-
-      await this.transportClient.reconnect(this.tracks);
-    } catch (error) {
-      if (isAbortError(error)) return;
-
-      console.error("[Reactor] Failed to reconnect:", error);
-      this.disconnect(true);
-      this.createError(
-        "RECONNECTION_FAILED",
-        `Failed to reconnect: ${error}`,
-        "api",
-        true
-      );
-    }
+    );
   }
 
   /**
@@ -211,96 +219,105 @@ export class Reactor {
 
     this.connectStartTime = performance.now();
 
-    try {
-      this.coordinatorClient = this.local
-        ? new LocalCoordinatorClient(this.coordinatorUrl, this.model)
-        : new CoordinatorClient({
+    return withSpan(
+      "reactor.connect",
+      { "session.model": this.model },
+      async () => {
+        try {
+          this.coordinatorClient = this.local
+            ? new LocalCoordinatorClient(this.coordinatorUrl, this.model)
+            : new CoordinatorClient({
+                baseUrl: this.coordinatorUrl,
+                jwtToken: jwtToken!,
+                model: this.model,
+              });
+
+          // 1. Create session — slim response with session_id and status
+          const tSession = performance.now();
+          const initialResponse =
+            await this.coordinatorClient.createSession();
+          const sessionCreationMs = performance.now() - tSession;
+
+          this.setSessionId(initialResponse.session_id);
+
+          console.debug(
+            "[Reactor] Session created:",
+            initialResponse.session_id,
+            "state:",
+            initialResponse.state
+          );
+
+          // 2. Poll until the Runtime accepts and capabilities are available
+          this.setStatus("waiting");
+
+          const tPoll = performance.now();
+          const sessionResponse =
+            await this.coordinatorClient.pollSessionReady();
+          const sessionPollingMs = performance.now() - tPoll;
+
+          this.sessionResponse = sessionResponse;
+
+          // 3. Store capabilities and tracks
+          this.capabilities = sessionResponse.capabilities!;
+          this.tracks = sessionResponse.capabilities!.tracks;
+          this.emit("capabilitiesReceived", this.capabilities);
+
+          console.debug(
+            "[Reactor] Session ready, transport:",
+            sessionResponse.selected_transport!.protocol,
+            "tracks:",
+            this.tracks.length
+          );
+
+          // 4. Instantiate transport based on selected_transport
+          const protocol = sessionResponse.selected_transport!.protocol;
+          if (protocol !== "webrtc") {
+            throw new Error(`Unsupported transport protocol: ${protocol}`);
+          }
+
+          this.transportClient = new WebRTCTransportClient({
             baseUrl: this.coordinatorUrl,
-            jwtToken: jwtToken!,
-            model: this.model,
+            sessionId: sessionResponse.session_id,
+            jwtToken: this.local ? "local" : jwtToken!,
+            webrtcVersion:
+              sessionResponse.selected_transport?.version ??
+              REACTOR_WEBRTC_VERSION,
+            maxPollAttempts: options?.maxAttempts,
           });
+          this.setupTransportHandlers();
 
-      // 1. Create session — slim response with session_id and status
-      const tSession = performance.now();
-      const initialResponse = await this.coordinatorClient.createSession();
-      const sessionCreationMs = performance.now() - tSession;
+          // 5. Connect transport using capabilities tracks
+          const tTransport = performance.now();
+          await this.transportClient.connect(this.tracks);
+          const transportConnectingMs = performance.now() - tTransport;
 
-      this.setSessionId(initialResponse.session_id);
+          this.connectionTimings = {
+            sessionCreationMs: sessionCreationMs + sessionPollingMs,
+            transportConnectingMs,
+            totalMs: 0,
+          };
+        } catch (error) {
+          if (isAbortError(error)) return;
 
-      console.debug(
-        "[Reactor] Session created:",
-        initialResponse.session_id,
-        "state:",
-        initialResponse.state
-      );
-
-      // 2. Poll until the Runtime accepts and capabilities are available
-      this.setStatus("waiting");
-
-      const tPoll = performance.now();
-      const sessionResponse = await this.coordinatorClient.pollSessionReady();
-      const sessionPollingMs = performance.now() - tPoll;
-
-      this.sessionResponse = sessionResponse;
-
-      // 3. Store capabilities and tracks
-      this.capabilities = sessionResponse.capabilities!;
-      this.tracks = sessionResponse.capabilities!.tracks;
-      this.emit("capabilitiesReceived", this.capabilities);
-
-      console.debug(
-        "[Reactor] Session ready, transport:",
-        sessionResponse.selected_transport!.protocol,
-        "tracks:",
-        this.tracks.length
-      );
-
-      // 4. Instantiate transport based on selected_transport
-      const protocol = sessionResponse.selected_transport!.protocol;
-      if (protocol !== "webrtc") {
-        throw new Error(`Unsupported transport protocol: ${protocol}`);
+          console.error("[Reactor] Connection failed:", error);
+          this.createError(
+            "CONNECTION_FAILED",
+            `Connection failed: ${error}`,
+            "api",
+            true
+          );
+          try {
+            await this.disconnect(false);
+          } catch (disconnectError) {
+            console.error(
+              "[Reactor] Failed to clean up after connection failure:",
+              disconnectError
+            );
+          }
+          throw error;
+        }
       }
-
-      this.transportClient = new WebRTCTransportClient({
-        baseUrl: this.coordinatorUrl,
-        sessionId: sessionResponse.session_id,
-        jwtToken: this.local ? "local" : jwtToken!,
-        webrtcVersion:
-          sessionResponse.selected_transport?.version ?? REACTOR_WEBRTC_VERSION,
-        maxPollAttempts: options?.maxAttempts,
-      });
-      this.setupTransportHandlers();
-
-      // 5. Connect transport using capabilities tracks
-      const tTransport = performance.now();
-      await this.transportClient.connect(this.tracks);
-      const transportConnectingMs = performance.now() - tTransport;
-
-      this.connectionTimings = {
-        sessionCreationMs: sessionCreationMs + sessionPollingMs,
-        transportConnectingMs,
-        totalMs: 0,
-      };
-    } catch (error) {
-      if (isAbortError(error)) return;
-
-      console.error("[Reactor] Connection failed:", error);
-      this.createError(
-        "CONNECTION_FAILED",
-        `Connection failed: ${error}`,
-        "api",
-        true
-      );
-      try {
-        await this.disconnect(false);
-      } catch (disconnectError) {
-        console.error(
-          "[Reactor] Failed to clean up after connection failure:",
-          disconnectError
-        );
-      }
-      throw error;
-    }
+    );
   }
 
   /**
@@ -368,38 +385,48 @@ export class Reactor {
       return;
     }
 
-    this.coordinatorClient?.abort();
-    this.transportClient?.abort();
+    return withSpan(
+      "reactor.disconnect",
+      {
+        ...(this.sessionId ? { "session.id": this.sessionId } : {}),
+        "session.model": this.model,
+        recoverable,
+      },
+      async () => {
+        this.coordinatorClient?.abort();
+        this.transportClient?.abort();
 
-    if (this.coordinatorClient && !recoverable) {
-      try {
-        await this.coordinatorClient.terminateSession();
-      } catch (error) {
-        console.error("[Reactor] Error terminating session:", error);
-      }
-      this.coordinatorClient = undefined;
-    }
+        if (this.coordinatorClient && !recoverable) {
+          try {
+            await this.coordinatorClient.terminateSession();
+          } catch (error) {
+            console.error("[Reactor] Error terminating session:", error);
+          }
+          this.coordinatorClient = undefined;
+        }
 
-    if (this.transportClient) {
-      try {
-        await this.transportClient.disconnect();
-      } catch (error) {
-        console.error("[Reactor] Error disconnecting transport:", error);
-      }
-      if (!recoverable) {
-        this.transportClient = undefined;
-      }
-    }
+        if (this.transportClient) {
+          try {
+            await this.transportClient.disconnect();
+          } catch (error) {
+            console.error("[Reactor] Error disconnecting transport:", error);
+          }
+          if (!recoverable) {
+            this.transportClient = undefined;
+          }
+        }
 
-    this.setStatus("disconnected");
-    this.resetConnectionTimings();
-    if (!recoverable) {
-      this.setSessionExpiration(undefined);
-      this.setSessionId(undefined);
-      this.capabilities = undefined;
-      this.tracks = [];
-      this.sessionResponse = undefined;
-    }
+        this.setStatus("disconnected");
+        this.resetConnectionTimings();
+        if (!recoverable) {
+          this.setSessionExpiration(undefined);
+          this.setSessionId(undefined);
+          this.capabilities = undefined;
+          this.tracks = [];
+          this.sessionResponse = undefined;
+        }
+      }
+    );
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -17,6 +17,7 @@ import type {
 } from "./TransportClient";
 import type { MessageScope, ConnectionStats } from "../types";
 import { AbortError } from "../types";
+import { tracedFetch, withSpan } from "./telemetry";
 import {
   type TrackCapability,
   type TrackMappingEntry,
@@ -199,11 +200,15 @@ export class WebRTCTransportClient implements TransportClient {
   private async fetchIceServers(): Promise<RTCIceServer[]> {
     console.debug("[WebRTCTransport] Fetching ICE servers...");
 
-    const response = await fetch(`${this.transportBaseUrl}/ice_servers`, {
-      method: "GET",
-      headers: this.getHeaders(),
-      signal: this.signal,
-    });
+    const response = await tracedFetch(
+      "reactor.transport.ice_servers",
+      `${this.transportBaseUrl}/ice_servers`,
+      {
+        method: "GET",
+        headers: this.getHeaders(),
+        signal: this.signal,
+      }
+    );
 
     await this.checkVersionMismatch(response);
 
@@ -238,15 +243,19 @@ export class WebRTCTransportClient implements TransportClient {
       track_mapping: trackMapping,
     };
 
-    const response = await fetch(`${this.transportBaseUrl}/sdp_params`, {
-      method,
-      headers: {
-        ...this.getHeaders(),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(requestBody),
-      signal: this.signal,
-    });
+    const response = await tracedFetch(
+      "reactor.transport.sdp_offer",
+      `${this.transportBaseUrl}/sdp_params`,
+      {
+        method,
+        headers: {
+          ...this.getHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+        signal: this.signal,
+      }
+    );
 
     await this.checkVersionMismatch(response);
 
@@ -261,61 +270,74 @@ export class WebRTCTransportClient implements TransportClient {
   }
 
   private async pollSdpAnswer(): Promise<WebRTCSdpAnswerResponse> {
-    console.debug("[WebRTCTransport] Polling for SDP answer...");
+    return withSpan(
+      "reactor.transport.sdp_poll",
+      { "session.id": this.sessionId },
+      async () => {
+        console.debug("[WebRTCTransport] Polling for SDP answer...");
 
-    const pollStart = performance.now();
-    let backoffMs = INITIAL_BACKOFF_MS;
-    let attempt = 0;
+        const pollStart = performance.now();
+        let backoffMs = INITIAL_BACKOFF_MS;
+        let attempt = 0;
 
-    while (true) {
-      if (this.signal.aborted) {
-        throw new AbortError("SDP polling aborted");
+        while (true) {
+          if (this.signal.aborted) {
+            throw new AbortError("SDP polling aborted");
+          }
+
+          if (attempt >= this.maxPollAttempts) {
+            throw new Error(
+              `SDP polling exceeded maximum attempts (${this.maxPollAttempts})`
+            );
+          }
+
+          attempt++;
+          console.debug(
+            `[WebRTCTransport] SDP poll attempt ${attempt}/${this.maxPollAttempts}`
+          );
+
+          const response = await tracedFetch(
+            "reactor.transport.sdp_poll.attempt",
+            `${this.transportBaseUrl}/sdp_params`,
+            {
+              method: "GET",
+              headers: this.getHeaders(),
+              signal: this.signal,
+            }
+          );
+
+          await this.checkVersionMismatch(response);
+
+          if (response.status === 200) {
+            const data = await response.json();
+            const parsed = WebRTCSdpAnswerResponseSchema.parse(data);
+            this.sdpPollingMs = performance.now() - pollStart;
+            this.sdpPollingAttempts = attempt;
+            console.debug(
+              `[WebRTCTransport] Received SDP answer via polling (${attempt} attempt(s), ${this.sdpPollingMs.toFixed(0)}ms)`
+            );
+            return parsed;
+          }
+
+          if (response.status === 202) {
+            console.debug(
+              `[WebRTCTransport] SDP answer pending, retrying in ${backoffMs}ms...`
+            );
+            await this.sleep(backoffMs);
+            backoffMs = Math.min(
+              backoffMs * BACKOFF_MULTIPLIER,
+              MAX_BACKOFF_MS
+            );
+            continue;
+          }
+
+          const errorText = await response.text();
+          throw new Error(
+            `Failed to poll SDP answer: ${response.status} ${errorText}`
+          );
+        }
       }
-
-      if (attempt >= this.maxPollAttempts) {
-        throw new Error(
-          `SDP polling exceeded maximum attempts (${this.maxPollAttempts})`
-        );
-      }
-
-      attempt++;
-      console.debug(
-        `[WebRTCTransport] SDP poll attempt ${attempt}/${this.maxPollAttempts}`
-      );
-
-      const response = await fetch(`${this.transportBaseUrl}/sdp_params`, {
-        method: "GET",
-        headers: this.getHeaders(),
-        signal: this.signal,
-      });
-
-      await this.checkVersionMismatch(response);
-
-      if (response.status === 200) {
-        const data = await response.json();
-        const parsed = WebRTCSdpAnswerResponseSchema.parse(data);
-        this.sdpPollingMs = performance.now() - pollStart;
-        this.sdpPollingAttempts = attempt;
-        console.debug(
-          `[WebRTCTransport] Received SDP answer via polling (${attempt} attempt(s), ${this.sdpPollingMs.toFixed(0)}ms)`
-        );
-        return parsed;
-      }
-
-      if (response.status === 202) {
-        console.debug(
-          `[WebRTCTransport] SDP answer pending, retrying in ${backoffMs}ms...`
-        );
-        await this.sleep(backoffMs);
-        backoffMs = Math.min(backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
-        continue;
-      }
-
-      const errorText = await response.text();
-      throw new Error(
-        `Failed to poll SDP answer: ${response.status} ${errorText}`
-      );
-    }
+    );
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/telemetry.ts
+++ b/packages/js-sdk/src/core/telemetry.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Optional OpenTelemetry instrumentation for the Reactor JS-SDK.
+ *
+ * When @opentelemetry/api is installed and a TracerProvider is registered,
+ * this module creates spans for every coordinator HTTP call and injects
+ * W3C traceparent headers for distributed tracing. When the package is
+ * absent or telemetry is disabled (local mode), every function is a no-op.
+ */
+
+import { REACTOR_SDK_VERSION } from "./types";
+
+// ---------------------------------------------------------------------------
+// Minimal type stubs matching @opentelemetry/api so we don't need the import
+// at compile time. The actual module is resolved lazily at runtime.
+// ---------------------------------------------------------------------------
+
+interface OtelSpan {
+  setAttribute(key: string, value: string | number | boolean): this;
+  setStatus(status: { code: number; message?: string }): this;
+  recordException(error: unknown): void;
+  end(): void;
+}
+
+interface OtelTracer {
+  startActiveSpan<T>(
+    name: string,
+    options: Record<string, unknown>,
+    fn: (span: OtelSpan) => T
+  ): T;
+  startActiveSpan<T>(name: string, fn: (span: OtelSpan) => T): T;
+}
+
+interface OtelApi {
+  trace: {
+    getTracer(name: string, version?: string): OtelTracer;
+  };
+  context: {
+    active(): unknown;
+  };
+  propagation: {
+    inject(context: unknown, carrier: Record<string, string>): void;
+  };
+  SpanStatusCode: { ERROR: number };
+}
+
+// ---------------------------------------------------------------------------
+// Lazy async resolution of @opentelemetry/api.
+//
+// Uses dynamic import() so bundlers (webpack, vite) can resolve the module
+// from the consuming app's node_modules. If the package isn't installed,
+// the import fails and telemetry stays permanently disabled.
+//
+// The resolved API is cached after the first successful import. Detection
+// is checked on every tracedFetch/withSpan call via getApi(), which returns
+// the cached value synchronously once resolved.
+// ---------------------------------------------------------------------------
+
+let cachedApi: OtelApi | null | undefined; // undefined = not yet tried
+let resolvePromise: Promise<void> | undefined;
+
+function tryResolve(): Promise<void> {
+  if (!resolvePromise) {
+    resolvePromise = import("@opentelemetry/api")
+      .then((mod) => {
+        cachedApi = mod as unknown as OtelApi;
+        console.debug("[Reactor:Telemetry] @opentelemetry/api resolved", {
+          hasTrace: !!cachedApi?.trace,
+          hasContext: !!cachedApi?.context,
+          hasPropagation: !!cachedApi?.propagation,
+        });
+      })
+      .catch((err) => {
+        cachedApi = null;
+        console.debug(
+          "[Reactor:Telemetry] @opentelemetry/api not available:",
+          err
+        );
+      });
+  }
+  return resolvePromise;
+}
+
+// Kick off resolution immediately at module load time.
+tryResolve();
+
+function getApi(): OtelApi | undefined {
+  if (cachedApi === undefined) return undefined; // still resolving
+  return cachedApi ?? undefined;
+}
+
+let enabled = true;
+
+/**
+ * Module-level kill switch. Called by Reactor when `local: true`.
+ */
+export function setEnabled(flag: boolean): void {
+  enabled = flag;
+}
+
+function getTracer(): OtelTracer | undefined {
+  if (!enabled) return undefined;
+  const api = getApi();
+  if (!api) return undefined;
+  return api.trace.getTracer("@reactor-team/js-sdk", REACTOR_SDK_VERSION);
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+const SPAN_STATUS_ERROR = 2;
+
+/**
+ * Wraps `fetch()` with an OTEL span and W3C traceparent header injection.
+ * When telemetry is unavailable or disabled, delegates directly to `fetch()`.
+ */
+export function tracedFetch(
+  spanName: string,
+  url: string | URL | Request,
+  init?: RequestInit
+): Promise<Response> {
+  const api = getApi();
+  const tracer = getTracer();
+  if (!tracer || !api) {
+    console.debug("[Reactor:Telemetry] tracedFetch BYPASS", spanName, {
+      enabled,
+      apiState: cachedApi === undefined ? "resolving" : cachedApi === null ? "unavailable" : "ready",
+      hasTracer: !!tracer,
+    });
+    return fetch(url, init);
+  }
+  console.debug("[Reactor:Telemetry] tracedFetch ACTIVE", spanName);
+
+  const method = init?.method ?? "GET";
+
+  return tracer.startActiveSpan(spanName, {}, (span: OtelSpan) => {
+    const headers: Record<string, string> = {};
+    const existing = init?.headers;
+    if (existing) {
+      if (existing instanceof Headers) {
+        existing.forEach((v, k) => {
+          headers[k] = v;
+        });
+      } else if (Array.isArray(existing)) {
+        for (const [k, v] of existing) headers[k] = v;
+      } else {
+        Object.assign(headers, existing);
+      }
+    }
+
+    api.propagation.inject(api.context.active(), headers);
+
+    span.setAttribute("http.method", method);
+    span.setAttribute("http.url", String(url));
+
+    return fetch(url, { ...init, headers })
+      .then((response) => {
+        span.setAttribute("http.status_code", response.status);
+        if (!response.ok) {
+          span.setStatus({
+            code: SPAN_STATUS_ERROR,
+            message: `HTTP ${response.status}`,
+          });
+        }
+        span.end();
+        return response;
+      })
+      .catch((error) => {
+        span.recordException(error);
+        span.setStatus({ code: SPAN_STATUS_ERROR });
+        span.end();
+        throw error;
+      });
+  });
+}
+
+/**
+ * Wraps an async function in an OTEL span. When telemetry is unavailable
+ * or disabled, just calls `fn()` directly.
+ */
+export function withSpan<T>(
+  spanName: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const tracer = getTracer();
+  if (!tracer) {
+    return fn();
+  }
+
+  return tracer.startActiveSpan(spanName, {}, (span: OtelSpan) => {
+    for (const [k, v] of Object.entries(attrs)) {
+      span.setAttribute(k, v);
+    }
+
+    return fn()
+      .then((result) => {
+        span.end();
+        return result;
+      })
+      .catch((error) => {
+        span.recordException(error);
+        span.setStatus({ code: SPAN_STATUS_ERROR });
+        span.end();
+        throw error;
+      });
+  });
+}

--- a/packages/js-sdk/tsup.config.ts
+++ b/packages/js-sdk/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     entry: ["src/index.ts"],
     resolve: true,
   },
+  external: ["@opentelemetry/api", "react", "zustand"],
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.0.0
         version: 2.11.0
+      '@opentelemetry/api':
+        specifier: ^1.4.0
+        version: 1.9.1
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -284,6 +287,10 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@reactor-team/js-sdk@2.7.0':
     resolution: {integrity: sha512-hDvWCef3PqHe9lQqBYar/1h4eqO3tqqkf8g3n74NQf8YMtuccwuUvjErJ2KdSfmAqLhW/fychg8atSe3MS1glA==}
@@ -1207,6 +1214,8 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@reactor-team/js-sdk@2.7.0(@types/node@22.19.15)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))':
     dependencies:


### PR DESCRIPTION
Why
---
We need end-to-end trace visibility from the browser through the coordinator,
supervisor, and runtime. By instrumenting the SDK's HTTP hot path with OTEL
spans and W3C traceparent propagation, client-side traces link directly to
server-side spans in Grafana Tempo, giving us full session lifecycle latency
breakdowns without any code changes from SDK consumers.

What Changed
---
- Added `telemetry.ts` with `tracedFetch()` and `withSpan()` helpers that
  wrap fetch calls with OTEL spans and inject traceparent headers; uses lazy
  dynamic `import("@opentelemetry/api")` for bundler-compatible detection
  via the global API registry
- Replaced all 5 `fetch()` calls in `CoordinatorClient.ts` with `tracedFetch()`;
  wrapped `pollSessionReady()` loop in a parent `withSpan`
- Replaced all 3 `fetch()` calls in `WebRTCTransportClient.ts` with
  `tracedFetch()`; wrapped `pollSdpAnswer()` loop in a parent `withSpan`
- Wrapped `connect()`, `reconnect()`, and `disconnect()` in `Reactor.ts`
  with root `withSpan` calls; telemetry is disabled for local mode via
  `setEnabled(!this.local)`
- Added `@opentelemetry/api` as optional peer dependency with
  `peerDependenciesMeta` and marked it as external in `tsup.config.ts`

API Changes
---
No new public API. Tracing activates automatically when the consuming app
installs `@opentelemetry/api` and registers a TracerProvider:

  ```ts
  import { WebTracerProvider } from "@opentelemetry/sdk-trace-web";
  const provider = new WebTracerProvider({ ... });
  provider.register();

  // SDK auto-detects — spans and traceparent headers are now active
  const reactor = new Reactor({ modelName: "helios" });
  ```

topic: add-optional-otel-tracing-to-js-sdk
labels: draft