### PR TITLE
[REA-1447] [1/2] JS SDK: add FileRef, uploadFile returns FileRef, sendCommand detects FileRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:unit": "pnpm --filter @reactor-team/js-sdk test:unit",
     "test:integration": "pnpm --filter @reactor-team/js-sdk test:integration",
     "format:check": "prettier --check .",
+    "format": "prettier --write .",
     "local-build": "pnpm --filter @reactor-team/js-sdk build && echo '\n@reactor-team/js-sdk built. Link with:\n  pnpm link '$(realpath packages/js-sdk)",
     "install:create-app": "pnpm --filter create-reactor-app install-cli"
   },

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -116,7 +116,8 @@ describe("Reactor (extended)", () => {
       expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
         "set_effect",
         { effect: "blur" },
-        "application"
+        "application",
+        undefined
       );
       await r.disconnect();
     });

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -10,10 +10,13 @@
 import {
   type CreateSessionRequest,
   type CreateSessionResponse,
+  type CreateUploadRequest,
+  type CreateUploadResponse,
   type SessionResponse,
   type SessionInfoResponse,
   type TerminateSessionRequest,
   CreateSessionResponseSchema,
+  CreateUploadResponseSchema,
   SessionResponseSchema,
   SessionInfoResponseSchema,
   SessionState,
@@ -408,6 +411,47 @@ export class CoordinatorClient {
     throw new Error(
       `Failed to terminate session: ${response.status} ${errorText}`
     );
+  }
+
+  /**
+   * Allocates an upload slot for a file.
+   * Returns a presigned PUT URL the caller can use to upload the file
+   * directly to the object store (production) or local runtime (local dev).
+   */
+  async createUpload(
+    sessionId: string,
+    request: CreateUploadRequest
+  ): Promise<CreateUploadResponse> {
+    console.debug("[CoordinatorClient] Creating upload slot...", {
+      sessionId,
+      name: request.name,
+      size: request.size,
+    });
+
+    const response = await fetch(
+      `${this.baseUrl}/sessions/${sessionId}/uploads`,
+      {
+        method: "POST",
+        headers: {
+          ...this.getHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(request),
+        signal: this.signal,
+      }
+    );
+
+    await this.checkVersionMismatch(response);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to create upload slot: ${response.status} ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+    return CreateUploadResponseSchema.parse(data);
   }
 
   getSessionId(): string | undefined {

--- a/packages/js-sdk/src/core/FileRef.ts
+++ b/packages/js-sdk/src/core/FileRef.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Reference to an uploaded file, returned by {@link Reactor.uploadFile}.
+ *
+ * Pass a `FileRef` as a value in {@link Reactor.sendCommand} and it will
+ * be serialized into the `uploads` section of the wire envelope, separate
+ * from scalar arguments. The runtime resolves each reference to bytes
+ * before dispatching the event to the model handler.
+ */
+export class FileRef {
+  /** @internal Marker so sendCommand can detect FileRef values. */
+  readonly __isFileRef = true as const;
+
+  constructor(
+    public readonly uploadId: string,
+    public readonly name: string,
+    public readonly mimeType: string,
+    public readonly size: number
+  ) {}
+}

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -33,6 +33,12 @@ const OptionsSchema = z.object({
 });
 export type Options = z.input<typeof OptionsSchema>;
 
+export { FileRef } from "./FileRef";
+import { FileRef } from "./FileRef";
+
+/** @deprecated Use {@link FileRef} instead. */
+export type UploadResult = FileRef;
+
 type EventHandler = (...args: any[]) => void;
 
 export class Reactor {
@@ -81,6 +87,10 @@ export class Reactor {
 
   /**
    * Sends a command to the model via the data channel.
+   *
+   * When any value in `data` is a {@link FileRef}, it is automatically
+   * extracted and serialized into a separate `uploads` section on the
+   * wire, keyed by the parameter name.  Scalar values remain in `data`.
    */
   async sendCommand(
     command: string,
@@ -94,7 +104,32 @@ export class Reactor {
     }
 
     try {
-      this.transportClient?.sendCommand(command, data, scope);
+      let uploads: Record<string, object> | undefined;
+
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        const scalarData: Record<string, unknown> = {};
+        const extractedUploads: Record<string, object> = {};
+
+        for (const [key, value] of Object.entries(data)) {
+          if (value instanceof FileRef) {
+            extractedUploads[key] = {
+              upload_id: value.uploadId,
+              name: value.name,
+              mime_type: value.mimeType,
+              size: value.size,
+            };
+          } else {
+            scalarData[key] = value;
+          }
+        }
+
+        if (Object.keys(extractedUploads).length > 0) {
+          uploads = extractedUploads;
+          data = scalarData;
+        }
+      }
+
+      this.transportClient?.sendCommand(command, data, scope, uploads);
     } catch (error) {
       console.error("[Reactor] Failed to send message:", error);
       this.createError(
@@ -104,6 +139,79 @@ export class Reactor {
         true
       );
     }
+  }
+
+  /**
+   * Uploads a file to the session's object store and returns a {@link FileRef}.
+   *
+   * Flow:
+   *  1. POST /sessions/{id}/uploads → allocate presigned PUT URL
+   *  2. PUT file bytes to the presigned URL
+   *  3. Send `fileUploaded` notification on the runtime data channel
+   *     (fires `@file_uploaded` on the model if registered)
+   *  4. Return a `FileRef` to pass into {@link sendCommand}
+   *
+   * Works identically in local and production modes.
+   */
+  async uploadFile(
+    file: File | Blob,
+    options?: { name?: string }
+  ): Promise<FileRef> {
+    if (this.status !== "ready") {
+      throw new Error(
+        `Cannot upload file, status is "${this.status}". Must be "ready".`
+      );
+    }
+    if (!this.coordinatorClient || !this.sessionId) {
+      throw new Error("No active session. Call connect() first.");
+    }
+
+    const name = options?.name ?? (file instanceof File ? file.name : "upload");
+    const mimeType = file.type || "application/octet-stream";
+    const size = file.size;
+
+    if (size <= 0) {
+      throw new Error("File is empty");
+    }
+
+    const slot = await this.coordinatorClient.createUpload(this.sessionId, {
+      name,
+      size,
+      mime_type: mimeType,
+    });
+
+    const putResponse = await fetch(slot.presigned_url, {
+      method: "PUT",
+      body: file,
+      headers: {
+        "Content-Length": String(size),
+      },
+    });
+    if (!putResponse.ok) {
+      throw new Error(
+        `File upload failed: ${putResponse.status} ${putResponse.statusText}`
+      );
+    }
+
+    await this.sendCommand(
+      "fileUploaded",
+      {
+        upload_id: slot.presigned_id,
+        name,
+        mime_type: mimeType,
+        size,
+      },
+      "runtime"
+    );
+
+    console.debug("[Reactor] File uploaded:", {
+      uploadId: slot.presigned_id,
+      name,
+      mimeType,
+      size,
+    });
+
+    return new FileRef(slot.presigned_id, name, mimeType, size);
   }
 
   /**

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -36,9 +36,6 @@ export type Options = z.input<typeof OptionsSchema>;
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
 
-/** @deprecated Use {@link FileRef} instead. */
-export type UploadResult = FileRef;
-
 type EventHandler = (...args: any[]) => void;
 
 export class Reactor {

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -81,7 +81,12 @@ export interface TransportClient {
    * @param data The command payload.
    * @param scope "application" for model commands, "runtime" for platform messages.
    */
-  sendCommand(command: string, data: any, scope: MessageScope): void;
+  sendCommand(
+    command: string,
+    data: any,
+    scope: MessageScope,
+    uploads?: Record<string, object>
+  ): void;
 
   /**
    * Publishes a MediaStreamTrack to a named sendonly track.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -494,7 +494,8 @@ export class WebRTCTransportClient implements TransportClient {
   sendCommand(
     command: string,
     data: any,
-    scope: MessageScope = "application"
+    scope: MessageScope = "application",
+    uploads?: Record<string, object>
   ): void {
     if (!this.dataChannel) {
       throw new Error("[WebRTCTransport] Data channel not available");
@@ -506,7 +507,8 @@ export class WebRTCTransportClient implements TransportClient {
         command,
         data,
         scope,
-        this.maxMessageBytes
+        this.maxMessageBytes,
+        uploads
       );
     } catch (error) {
       console.warn("[WebRTCTransport] Failed to send message:", error);

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -6,6 +6,7 @@ import type {
   ConnectOptions,
 } from "../types";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
+import { FileRef } from "./FileRef";
 import { create } from "zustand/react";
 import { createContext } from "react";
 
@@ -33,6 +34,7 @@ export interface ReactorActions {
   publish(name: string, track: MediaStreamTrack): Promise<void>;
   unpublish(name: string): Promise<void>;
   reconnect(options?: ConnectOptions): Promise<void>;
+  uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef>;
 }
 
 // Internal state not exposed to components
@@ -236,6 +238,17 @@ export const createReactorStore = (
           console.debug("[ReactorStore] Reconnect completed successfully");
         } catch (error) {
           console.error("[ReactorStore] Failed to reconnect:", error);
+          throw error;
+        }
+      },
+      uploadFile: async (file: File | Blob, options?: { name?: string }) => {
+        console.debug("[ReactorStore] Uploading file");
+        try {
+          const result = await get().internal.reactor.uploadFile(file, options);
+          console.debug("[ReactorStore] File uploaded successfully", result);
+          return result;
+        } catch (error) {
+          console.error("[ReactorStore] Failed to upload file:", error);
           throw error;
         }
       },

--- a/packages/js-sdk/src/core/types.ts
+++ b/packages/js-sdk/src/core/types.ts
@@ -124,6 +124,24 @@ export const TerminateSessionRequestSchema = z.object({
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Upload API Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+// POST /sessions/{id}/uploads — Request
+export const CreateUploadRequestSchema = z.object({
+  name: z.string(),
+  size: z.number().int().positive(),
+  mime_type: z.string(),
+});
+
+// POST /sessions/{id}/uploads — Response (201)
+export const CreateUploadResponseSchema = z.object({
+  presigned_id: z.string(),
+  presigned_url: z.string(),
+  path: z.string(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // WebRTC Transport Schemas
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -173,6 +191,9 @@ export type SessionInfoResponse = z.infer<typeof SessionInfoResponseSchema>;
 export type TerminateSessionRequest = z.infer<
   typeof TerminateSessionRequestSchema
 >;
+
+export type CreateUploadRequest = z.infer<typeof CreateUploadRequestSchema>;
+export type CreateUploadResponse = z.infer<typeof CreateUploadResponseSchema>;
 
 export type IceServer = z.infer<typeof IceServerSchema>;
 export type IceServersResponse = z.infer<typeof IceServersResponseSchema>;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -21,6 +21,9 @@ export type {
   SessionResponse,
 } from "./core/types";
 
+export { FileRef } from "./core/FileRef";
+export type { UploadResult } from "./core/Reactor";
+
 export interface ReactorError {
   code: string;
   message: string;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -22,7 +22,6 @@ export type {
 } from "./core/types";
 
 export { FileRef } from "./core/FileRef";
-export type { UploadResult } from "./core/Reactor";
 
 export interface ReactorError {
   code: string;

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -251,13 +251,17 @@ export function sendMessage(
   command: string,
   data: any,
   scope: MessageScope = "application",
-  maxBytes: number = DEFAULT_MAX_MESSAGE_BYTES
+  maxBytes: number = DEFAULT_MAX_MESSAGE_BYTES,
+  uploads?: Record<string, object>
 ): void {
   if (channel.readyState !== "open") {
     throw new Error(`Data channel not open: ${channel.readyState}`);
   }
   const jsonData = typeof data === "string" ? JSON.parse(data) : data;
-  const inner = { type: command, data: jsonData };
+  const inner: Record<string, any> = { type: command, data: jsonData };
+  if (uploads && Object.keys(uploads).length > 0) {
+    inner.uploads = uploads;
+  }
   const payload = { scope, data: inner };
   const serialized = JSON.stringify(payload);
 


### PR DESCRIPTION
## Summary

Add file upload support with a two-step pattern: upload, then send. File references are first-class values you pass into `sendCommand` like any other argument.

### How it looks

```js
const reactor = new Reactor({ apiUrl: "http://localhost:8080", modelName: "my-model", local: true });
await reactor.connect();

// Step 1: upload returns a FileRef (bytes go to storage)
const ref = await reactor.uploadFile(file);

// Step 2: pass the ref into sendCommand — it gets serialized automatically
reactor.sendCommand("set_overlay_image", { overlay_image: ref, overlay_strength: 0.8 });

// Multiple files in one command
const styleRef = await reactor.uploadFile(styleFile);
const contentRef = await reactor.uploadFile(contentFile);
reactor.sendCommand("blend_images", { style: styleRef, content: contentRef, factor: 0.5 });
```

`sendCommand` detects `FileRef` values, extracts them into a separate `uploads` dict on the wire (keyed by parameter name), and keeps scalar args in `data`. No key collisions, N files per command.

### What changed

- **`FileRef` class** — new first-class reference type returned by `uploadFile()`, detectable by `instanceof` so `sendCommand` can automatically extract file references. Fields: `uploadId`, `name`, `mimeType`, `size`.
- **`uploadFile()`** — allocates a presigned upload slot via the coordinator, PUTs the file bytes, sends a runtime-scope `fileUploaded` notification (fires `@file_uploaded` on the model if registered), and returns a `FileRef`.
- **`sendCommand()`** — scans args for `FileRef` values, splits into `data` + `uploads`. Wire envelope: `{type, data, uploads}`.
- **`sendMessage()` in `webrtc.ts`** — accepts optional `uploads` parameter.
- **`TransportClient.sendCommand`** and **`WebRTCTransportClient.sendCommand`** — accept optional `uploads`.
- **`store.ts`** — exposes `uploadFile` action returning `FileRef`.
- **`CoordinatorClient.createUpload()`** — new method to allocate presigned upload slots.

## Test plan

- [x] All 233 tests pass
- [x] New tests in follow-up PR #105