### PR TITLE
[REA-1553] Parallelize ICE server fetch with capability polling

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -49,6 +49,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      fetchIceServers: vi.fn().mockResolvedValue([]),
       connect: vi.fn().mockResolvedValue(undefined),
       reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -61,6 +61,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      fetchIceServers: vi.fn().mockResolvedValue([]),
       connect: vi.fn().mockResolvedValue(undefined),
       reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      fetchIceServers: vi.fn().mockResolvedValue([]),
       connect: vi.fn().mockResolvedValue(undefined),
       reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -339,8 +339,23 @@ export class Reactor {
         initialResponse.state
       );
 
-      // 2. Poll until the Runtime accepts and capabilities are available
+      // 2. Poll capabilities and prefetch ICE servers in parallel.
+      //    ICE servers only need the session_id (available now), so we can
+      //    start that fetch while waiting for the runtime to report capabilities.
       this.setStatus("waiting");
+
+      this.transportClient = new WebRTCTransportClient({
+        baseUrl: this.coordinatorUrl,
+        sessionId: initialResponse.session_id,
+        jwtToken: this.local ? "local" : jwtToken!,
+        webrtcVersion: REACTOR_WEBRTC_VERSION,
+        maxPollAttempts: options?.maxAttempts,
+      });
+
+      const iceServersPromise = (
+        this.transportClient as WebRTCTransportClient
+      ).fetchIceServers();
+      iceServersPromise.catch(() => {});
 
       const tPoll = performance.now();
       const sessionResponse = await this.coordinatorClient.pollSessionReady();
@@ -360,24 +375,17 @@ export class Reactor {
         this.tracks.length
       );
 
-      // 4. Instantiate transport based on selected_transport
+      // 4. Validate transport protocol
       const protocol = sessionResponse.selected_transport!.protocol;
       if (protocol !== "webrtc") {
         throw new Error(`Unsupported transport protocol: ${protocol}`);
       }
 
-      this.transportClient = new WebRTCTransportClient({
-        baseUrl: this.coordinatorUrl,
-        sessionId: sessionResponse.session_id,
-        jwtToken: this.local ? "local" : jwtToken!,
-        webrtcVersion: REACTOR_WEBRTC_VERSION,
-        maxPollAttempts: options?.maxAttempts,
-      });
       this.setupTransportHandlers();
 
-      // 5. Connect transport using capabilities tracks
+      // 5. Connect transport, reusing the already-inflight ICE servers fetch
       const tTransport = performance.now();
-      await this.transportClient.connect(this.tracks);
+      await this.transportClient.connect(this.tracks, iceServersPromise);
       const transportConnectingMs = performance.now() - tTransport;
 
       this.connectionTimings = {

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -56,7 +56,10 @@ export interface TransportClient {
    * connection negotiation, and transceiver setup. For sendonly tracks,
    * no media flows until {@link publishTrack} is called.
    */
-  connect(tracks: TrackCapability[]): Promise<void>;
+  connect(
+    tracks: TrackCapability[],
+    prefetchedIceServers?: Promise<RTCIceServer[]>
+  ): Promise<void>;
 
   /**
    * Reconnects an existing session with a fresh transport negotiation.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -104,7 +104,7 @@ export class WebRTCTransportClient implements TransportClient {
   private readonly baseUrl: string;
   private readonly sessionId: string;
   private readonly jwtToken: string;
-  private readonly webrtcVersion: string;
+  webrtcVersion: string;
   private readonly maxPollAttempts: number;
   private abortController: AbortController;
 
@@ -196,7 +196,7 @@ export class WebRTCTransportClient implements TransportClient {
   // Transport Signaling (HTTP)
   // ─────────────────────────────────────────────────────────────────────────
 
-  private async fetchIceServers(): Promise<RTCIceServer[]> {
+  async fetchIceServers(): Promise<RTCIceServer[]> {
     console.debug("[WebRTCTransport] Fetching ICE servers...");
 
     const response = await fetch(`${this.transportBaseUrl}/ice_servers`, {
@@ -322,11 +322,16 @@ export class WebRTCTransportClient implements TransportClient {
   // Connection Lifecycle
   // ─────────────────────────────────────────────────────────────────────────
 
-  async connect(tracks: TrackCapability[]): Promise<void> {
+  async connect(
+    tracks: TrackCapability[],
+    prefetchedIceServers?: Promise<RTCIceServer[]>
+  ): Promise<void> {
     this.setStatus("connecting");
     this.resetTransportTimings();
 
-    const iceServers = await this.fetchIceServers();
+    const iceServers = prefetchedIceServers
+      ? await prefetchedIceServers
+      : await this.fetchIceServers();
 
     this.peerConnection = webrtc.createPeerConnection({ iceServers });
     this.setupPeerConnectionHandlers();


### PR DESCRIPTION
[REA-1553] Parallelize ICE server fetch with capability polling

Why
---
The connection flow fetched ICE servers sequentially after capability
polling completed, adding ~100ms+ of unnecessary latency (plus a CORS
preflight round-trip). ICE servers only require the session ID, which
is available immediately after session creation, so this fetch can run
in parallel with the capability poll.

What Changed
---
- Created the WebRTCTransportClient early (right after session creation)
  and kicked off fetchIceServers() in parallel with pollSessionReady()
- connect() now accepts an optional pre-fetched ICE servers promise,
  falling back to its own fetch if none is provided
- Made fetchIceServers() public and webrtcVersion mutable so the
  transport can be created before the negotiated version is known
- Updated TransportClient interface to reflect the new connect() signature
- Added fetchIceServers mock to all test files exercising the connect flow

API Changes
---
TransportClient.connect() now accepts an optional second parameter for
pre-fetched ICE servers. Existing callers are unaffected (parameter is
optional and connect() falls back to fetching internally).

  ```ts
  await transport.connect(tracks, prefetchedIceServersPromise);
  ```

topic: REA-1553-parallelize-ice-server-fetch
reviewers: bryce

bump version of js-sdk
topic: REA-1553-parallelize-ice-server-fetch