### PR TITLE
[REA-1564] Stop using server-returned transport version as WebRTC header

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -265,8 +265,7 @@ export class Reactor {
         baseUrl: this.coordinatorUrl,
         sessionId: sessionResponse.session_id,
         jwtToken: this.local ? "local" : jwtToken!,
-        webrtcVersion:
-          sessionResponse.selected_transport?.version ?? REACTOR_WEBRTC_VERSION,
+        webrtcVersion: REACTOR_WEBRTC_VERSION,
         maxPollAttempts: options?.maxAttempts,
       });
       this.setupTransportHandlers();


### PR DESCRIPTION
The SDK was using selected_transport.version from the session response
as the Reactor-WebRTC-Version header on transport requests. The server
returns a 3-part version (1.0.0) from the protobuf Version message,
but the coordinator middleware expects 2-part N.M format (1.0),
causing all sdp_params requests to be rejected with a 400.

Always use the SDK's own REACTOR_WEBRTC_VERSION from package.json.