### PR TITLE
[REA-1573] Fix local-mode presigned upload URL using runtime port instead of SDK-configured port

### DIFF
--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -596,9 +596,9 @@ describe("Reactor (extended)", () => {
     });
   });
 
-  // ── uploadFile() local URL rewrite (REA-1573) ──────────────────────────
+  // ── uploadFile() local URL rewrite ─────────────────────────────────────
 
-  describe("uploadFile() local URL rewrite (REA-1573)", () => {
+  describe("uploadFile() local URL rewrite", () => {
     const LOCAL_UPLOAD_RESPONSE = {
       presigned_id: "local-upload-id",
       presigned_url: "http://localhost:8090/uploads/local-upload-id",

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -618,9 +618,8 @@ describe("Reactor (extended)", () => {
       });
       await connectAndReady(r);
 
-      const { LocalCoordinatorClient: LCC } = await import(
-        "../../src/core/LocalCoordinatorClient"
-      );
+      const { LocalCoordinatorClient: LCC } =
+        await import("../../src/core/LocalCoordinatorClient");
       const localCoord = (LCC as any).mock.results.at(-1)!.value;
       localCoord.createUpload = vi
         .fn()
@@ -635,9 +634,7 @@ describe("Reactor (extended)", () => {
         ([, opts]: any) => opts?.method === "PUT"
       );
       expect(putCall).toBeDefined();
-      expect(putCall![0]).toBe(
-        "http://localhost:8080/uploads/local-upload-id"
-      );
+      expect(putCall![0]).toBe("http://localhost:8080/uploads/local-upload-id");
 
       vi.unstubAllGlobals();
       await r.disconnect();
@@ -656,9 +653,8 @@ describe("Reactor (extended)", () => {
       });
       await connectAndReady(r);
 
-      const { LocalCoordinatorClient: LCC } = await import(
-        "../../src/core/LocalCoordinatorClient"
-      );
+      const { LocalCoordinatorClient: LCC } =
+        await import("../../src/core/LocalCoordinatorClient");
       const localCoord = (LCC as any).mock.results.at(-1)!.value;
       localCoord.createUpload = vi
         .fn()
@@ -724,9 +720,8 @@ describe("Reactor (extended)", () => {
       });
       await connectAndReady(r);
 
-      const { LocalCoordinatorClient: LCC } = await import(
-        "../../src/core/LocalCoordinatorClient"
-      );
+      const { LocalCoordinatorClient: LCC } =
+        await import("../../src/core/LocalCoordinatorClient");
       const localCoord = (LCC as any).mock.results.at(-1)!.value;
       localCoord.createUpload = vi.fn().mockResolvedValue(uploadWithQuery);
 

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -596,6 +596,157 @@ describe("Reactor (extended)", () => {
     });
   });
 
+  // ── uploadFile() local URL rewrite (REA-1573) ──────────────────────────
+
+  describe("uploadFile() local URL rewrite (REA-1573)", () => {
+    const LOCAL_UPLOAD_RESPONSE = {
+      presigned_id: "local-upload-id",
+      presigned_url: "http://localhost:8090/uploads/local-upload-id",
+      path: "sessions/local/uploads/local-upload-id/photo.jpg",
+    };
+
+    it("rewrites presigned URL host+port to match SDK-configured apiUrl", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const r = new Reactor({
+        modelName: "echo",
+        local: true,
+        apiUrl: "http://localhost:8080",
+      });
+      await connectAndReady(r);
+
+      const { LocalCoordinatorClient: LCC } = await import(
+        "../../src/core/LocalCoordinatorClient"
+      );
+      const localCoord = (LCC as any).mock.results.at(-1)!.value;
+      localCoord.createUpload = vi
+        .fn()
+        .mockResolvedValue(LOCAL_UPLOAD_RESPONSE);
+
+      const file = new File(["img-data"], "photo.jpg", {
+        type: "image/jpeg",
+      });
+      await r.uploadFile(file);
+
+      const putCall = mockFetch.mock.calls.find(
+        ([, opts]: any) => opts?.method === "PUT"
+      );
+      expect(putCall).toBeDefined();
+      expect(putCall![0]).toBe(
+        "http://localhost:8080/uploads/local-upload-id"
+      );
+
+      vi.unstubAllGlobals();
+      await r.disconnect();
+    });
+
+    it("rewrites scheme when SDK uses https", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const r = new Reactor({
+        modelName: "echo",
+        local: true,
+        apiUrl: "https://my-tunnel.example.com",
+      });
+      await connectAndReady(r);
+
+      const { LocalCoordinatorClient: LCC } = await import(
+        "../../src/core/LocalCoordinatorClient"
+      );
+      const localCoord = (LCC as any).mock.results.at(-1)!.value;
+      localCoord.createUpload = vi
+        .fn()
+        .mockResolvedValue(LOCAL_UPLOAD_RESPONSE);
+
+      const file = new File(["img-data"], "photo.jpg", {
+        type: "image/jpeg",
+      });
+      await r.uploadFile(file);
+
+      const putCall = mockFetch.mock.calls.find(
+        ([, opts]: any) => opts?.method === "PUT"
+      );
+      expect(putCall![0]).toBe(
+        "https://my-tunnel.example.com/uploads/local-upload-id"
+      );
+
+      vi.unstubAllGlobals();
+      await r.disconnect();
+    });
+
+    it("does not rewrite presigned URL in production mode", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const r = new Reactor({ modelName: "echo" });
+      await connectAndReady(r);
+
+      const fileContent = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+      const file = new File([fileContent], "ref.jpg", {
+        type: "image/jpeg",
+      });
+      await r.uploadFile(file);
+
+      const putCall = mockFetch.mock.calls.find(
+        ([, opts]: any) => opts?.method === "PUT"
+      );
+      expect(putCall![0]).toBe(MOCK_UPLOAD_RESPONSE.presigned_url);
+
+      vi.unstubAllGlobals();
+      await r.disconnect();
+    });
+
+    it("preserves path and query params during rewrite", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const uploadWithQuery = {
+        presigned_id: "q-upload",
+        presigned_url:
+          "http://localhost:9000/uploads/q-upload?token=abc&expires=123",
+        path: "sessions/local/uploads/q-upload/file.bin",
+      };
+
+      const r = new Reactor({
+        modelName: "echo",
+        local: true,
+        apiUrl: "http://localhost:8080",
+      });
+      await connectAndReady(r);
+
+      const { LocalCoordinatorClient: LCC } = await import(
+        "../../src/core/LocalCoordinatorClient"
+      );
+      const localCoord = (LCC as any).mock.results.at(-1)!.value;
+      localCoord.createUpload = vi.fn().mockResolvedValue(uploadWithQuery);
+
+      const file = new File(["data"], "file.bin", {
+        type: "application/octet-stream",
+      });
+      await r.uploadFile(file);
+
+      const putCall = mockFetch.mock.calls.find(
+        ([, opts]: any) => opts?.method === "PUT"
+      );
+      expect(putCall![0]).toBe(
+        "http://localhost:8080/uploads/q-upload?token=abc&expires=123"
+      );
+
+      vi.unstubAllGlobals();
+      await r.disconnect();
+    });
+  });
+
   // ── sendCommand() with FileRef ──────────────────────────────────────────
 
   describe("sendCommand() with FileRef", () => {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -148,7 +148,9 @@ export class Reactor {
    *     (fires `@file_uploaded` on the model if registered)
    *  4. Return a `FileRef` to pass into {@link sendCommand}
    *
-   * Works identically in local and production modes.
+   * In local mode, the presigned URL returned by the runtime is rewritten
+   * to use the SDK-configured base URL (scheme + host), so port-forwarded
+   * setups work correctly (REA-1573).
    */
   async uploadFile(
     file: File | Blob,
@@ -177,7 +179,17 @@ export class Reactor {
       mime_type: mimeType,
     });
 
-    const putResponse = await fetch(slot.presigned_url, {
+    let presignedUrl = slot.presigned_url;
+    if (this.local) {
+      const target = new URL(this.coordinatorUrl);
+      const parsed = new URL(presignedUrl);
+      parsed.protocol = target.protocol;
+      parsed.hostname = target.hostname;
+      parsed.port = target.port;
+      presignedUrl = parsed.toString();
+    }
+
+    const putResponse = await fetch(presignedUrl, {
       method: "PUT",
       body: file,
       headers: {


### PR DESCRIPTION
## Summary

Fixes [REA-1573](https://linear.app/reactor-team/issue/REA-1573): In local mode, the runtime returns a `presigned_url` that uses its own listen port (e.g. `:8090`), but the SDK may be configured to connect on a different port (e.g. `:8080` via port-forwarding). The SDK then PUTs to the wrong port and the upload fails.

**Fix:** After receiving the presigned URL from the local runtime, the SDK rewrites the `protocol`, `hostname`, and `port` to match the SDK-configured `coordinatorUrl`. Production mode is unaffected — the rewrite only applies when `local: true`.

Mirrors the same fix applied to the Python SDK in [REA-1462].

## What Changed

- `Reactor.ts` — `uploadFile()` now rewrites the presigned URL's origin to match `this.coordinatorUrl` when in local mode
- Version bump: `2.9.0` → `2.9.1`
- 4 new unit tests covering:
  - Rewrites host+port in local mode
  - Rewrites scheme (e.g. http→https for tunnel setups)
  - Does NOT rewrite in production mode
  - Preserves path and query parameters during rewrite

## Test plan

- [x] All 250 unit tests pass (`pnpm test:unit`)
- [x] New tests specifically cover the local URL rewrite logic
- [x] Production mode upload flow unchanged (existing tests still pass)