### PR TITLE
[REA-1654][1/3] refactor: split WebRTC transport into prepare + connect two-phase API

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -49,9 +49,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
-      fetchIceServers: vi.fn().mockResolvedValue([]),
+      prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
-      reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -61,9 +61,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
-      fetchIceServers: vi.fn().mockResolvedValue([]),
+      prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
-      reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),
@@ -340,11 +339,12 @@ describe("Reactor (extended)", () => {
       expect(r.getSessionId()).toBe(MOCK_SESSION_ID);
 
       await r.reconnect();
-      expect(mockTransportClient.reconnect).toHaveBeenCalledWith(
+      expect(mockTransportClient.prepare).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ name: "main_video" }),
         ])
       );
+      expect(mockTransportClient.connect).toHaveBeenCalledWith(true);
       await r.disconnect();
     });
 

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -52,9 +52,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
-      fetchIceServers: vi.fn().mockResolvedValue([]),
+      prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
-      reconnect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/webrtc-transport-client-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-transport-client-extended.test.ts
@@ -128,7 +128,8 @@ describe("WebRTCTransportClient (extended)", () => {
 
   async function connectClient(client: WebRTCTransportClient) {
     setupFullConnect();
-    await client.connect(MOCK_TRACKS);
+    await client.prepare(MOCK_TRACKS);
+    await client.connect();
   }
 
   // ── publishTrack() guards ─────────────────────────────────────────────
@@ -369,15 +370,14 @@ describe("WebRTCTransportClient (extended)", () => {
     });
   });
 
-  // ── reconnect() ───────────────────────────────────────────────────────
+  // ── reconnect via prepare + connect("PUT") ─────────────
 
-  describe("reconnect()", () => {
+  describe("reconnect (prepare + connect PUT)", () => {
     it("tears down old connection and creates new one with PUT", async () => {
       const client = createClient();
       await connectClient(client);
       simulateConnected();
 
-      // Setup mocks for reconnect
       mockFetch.mockReset();
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -390,9 +390,9 @@ describe("WebRTCTransportClient (extended)", () => {
         json: () => Promise.resolve({ sdp_answer: "v=0\r\nnew-answer" }),
       });
 
-      await client.reconnect(MOCK_TRACKS);
+      await client.prepare(MOCK_TRACKS);
+      await client.connect(true);
 
-      // SDP offer should use PUT for reconnect
       expect(mockFetch.mock.calls[1][1].method).toBe("PUT");
     });
   });
@@ -404,7 +404,7 @@ describe("WebRTCTransportClient (extended)", () => {
       const client = createClient();
       mockFetch.mockResolvedValueOnce({ ok: false, status: 426 });
 
-      await expect(client.connect(MOCK_TRACKS)).rejects.toThrow(
+      await expect(client.prepare(MOCK_TRACKS)).rejects.toThrow(
         "CLIENT_VERSION_TOO_OLD"
       );
     });
@@ -413,7 +413,7 @@ describe("WebRTCTransportClient (extended)", () => {
       const client = createClient();
       mockFetch.mockResolvedValueOnce({ ok: false, status: 501 });
 
-      await expect(client.connect(MOCK_TRACKS)).rejects.toThrow(
+      await expect(client.prepare(MOCK_TRACKS)).rejects.toThrow(
         "SERVER_VERSION_TOO_OLD"
       );
     });

--- a/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
@@ -190,59 +190,45 @@ describe("WebRTCTransportClient", () => {
     });
   });
 
-  // ── connect() ─────────────────────────────────────────────────────────
+  // ── prepare() ──────────────────────────────────────────────────────
 
-  describe("connect()", () => {
-    it("fetches ICE servers, creates PC, sends offer, polls answer", async () => {
+  describe("prepare()", () => {
+    it("fetches ICE servers and creates PeerConnection with transceivers", async () => {
       const client = createClient();
-      setupFullConnect();
+      mockIceServersFetch();
 
-      await client.connect(MOCK_TRACKS);
+      await client.prepare(MOCK_TRACKS);
 
-      // Verify ICE servers fetch
       expect(mockFetch.mock.calls[0][0]).toBe(
         "https://api.test.com/sessions/test-session-id/transport/webrtc/ice_servers"
       );
-
-      // Verify SDP offer POST
-      expect(mockFetch.mock.calls[1][0]).toBe(
-        "https://api.test.com/sessions/test-session-id/transport/webrtc/sdp_params"
-      );
-      expect(mockFetch.mock.calls[1][1].method).toBe("POST");
-
-      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
-      expect(body.sdp_offer).toBeDefined();
-      expect(body.track_mapping).toHaveLength(1);
-      expect(body.track_mapping[0].name).toBe("main_video");
-
-      // Verify SDP answer GET
-      expect(mockFetch.mock.calls[2][0]).toBe(
-        "https://api.test.com/sessions/test-session-id/transport/webrtc/sdp_params"
-      );
-      expect(mockFetch.mock.calls[2][1].method).toBe("GET");
+      expect(mockPC.addTransceiver).toHaveBeenCalledWith("video", {
+        direction: "recvonly",
+      });
+      expect(mockPC.createOffer).toHaveBeenCalled();
     });
 
     it("sets status to connecting", async () => {
       const client = createClient();
-      setupFullConnect();
+      mockIceServersFetch();
 
       const handler = vi.fn();
       client.on("statusChanged", handler);
 
-      await client.connect(MOCK_TRACKS);
+      await client.prepare(MOCK_TRACKS);
       expect(handler).toHaveBeenCalledWith("connecting");
     });
 
     it("creates transceivers for each track", async () => {
       const client = createClient();
-      setupFullConnect();
+      mockIceServersFetch();
 
       const tracks: TrackCapability[] = [
         { name: "main_video", kind: "video", direction: "recvonly" },
         { name: "webcam", kind: "video", direction: "sendonly" },
       ];
 
-      await client.connect(tracks);
+      await client.prepare(tracks);
       expect(mockPC.addTransceiver).toHaveBeenCalledTimes(2);
       expect(mockPC.addTransceiver).toHaveBeenCalledWith("video", {
         direction: "recvonly",
@@ -256,21 +242,70 @@ describe("WebRTCTransportClient", () => {
       const client = createClient();
       mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
 
-      await expect(client.connect(MOCK_TRACKS)).rejects.toThrow(
+      await expect(client.prepare(MOCK_TRACKS)).rejects.toThrow(
         "Failed to fetch ICE servers"
       );
+    });
+  });
+
+  // ── connect() ───────────────────────────────────────────────
+
+  describe("connect()", () => {
+    it("sends the SDP offer and polls for the answer", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
+      mockSdpOfferAccepted();
+      mockSdpAnswerReady();
+      await client.connect();
+
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        "https://api.test.com/sessions/test-session-id/transport/webrtc/sdp_params"
+      );
+      expect(mockFetch.mock.calls[1][1].method).toBe("POST");
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(body.sdp_offer).toBeDefined();
+      expect(body.track_mapping).toHaveLength(1);
+      expect(body.track_mapping[0].name).toBe("main_video");
+
+      expect(mockFetch.mock.calls[2][0]).toBe(
+        "https://api.test.com/sessions/test-session-id/transport/webrtc/sdp_params"
+      );
+      expect(mockFetch.mock.calls[2][1].method).toBe("GET");
+    });
+
+    it("uses PUT method for reconnections", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
+      mockSdpOfferAccepted();
+      mockSdpAnswerReady();
+      await client.connect(true);
+
+      expect(mockFetch.mock.calls[1][1].method).toBe("PUT");
+    });
+
+    it("throws when called without prepare", async () => {
+      const client = createClient();
+
+      await expect(client.connect()).rejects.toThrow("No prepared connection");
     });
 
     it("throws when SDP offer is rejected", async () => {
       const client = createClient();
       mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
         text: () => Promise.resolve("server error"),
       });
 
-      await expect(client.connect(MOCK_TRACKS)).rejects.toThrow(
+      await expect(client.connect()).rejects.toThrow(
         "Failed to send SDP offer"
       );
     });
@@ -278,24 +313,26 @@ describe("WebRTCTransportClient", () => {
     it("polls SDP answer when 202 is returned", async () => {
       const client = createClient({ maxPollAttempts: 3 });
       mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
       mockSdpOfferAccepted();
-      // First poll → 202
       mockFetch.mockResolvedValueOnce({ ok: true, status: 202 });
-      // Second poll → 200
       mockSdpAnswerReady();
 
-      await client.connect(MOCK_TRACKS);
-      // ICE + POST + GET(202) + GET(200) = 4
+      await client.connect();
+      // ICE(prepare) + POST + GET(202) + GET(200) = 4
       expect(mockFetch).toHaveBeenCalledTimes(4);
     });
 
     it("throws after exhausting SDP poll attempts", async () => {
       const client = createClient({ maxPollAttempts: 2 });
       mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
       mockSdpOfferAccepted();
       mockFetch.mockResolvedValue({ ok: true, status: 202 });
 
-      await expect(client.connect(MOCK_TRACKS)).rejects.toThrow(
+      await expect(client.connect()).rejects.toThrow(
         "exceeded maximum attempts"
       );
     });

--- a/packages/js-sdk/__tests__/unit/webrtc-transport-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-transport-timings.test.ts
@@ -109,7 +109,8 @@ describe("WebRTCTransportClient connection timings", () => {
   it("records ICE and data channel durations after connection", async () => {
     const client = createClient();
     setupFullConnect();
-    await client.connect(MOCK_TRACKS);
+    await client.prepare(MOCK_TRACKS);
+    await client.connect();
 
     mockPC.connectionState = "connected";
     mockPC.onconnectionstatechange!();
@@ -130,7 +131,8 @@ describe("WebRTCTransportClient connection timings", () => {
   it("returns undefined when only ICE connected but data channel not open", async () => {
     const client = createClient();
     setupFullConnect();
-    await client.connect(MOCK_TRACKS);
+    await client.prepare(MOCK_TRACKS);
+    await client.connect();
 
     mockPC.connectionState = "connected";
     mockPC.onconnectionstatechange!();
@@ -141,7 +143,8 @@ describe("WebRTCTransportClient connection timings", () => {
   it("clears timings on disconnect", async () => {
     const client = createClient();
     setupFullConnect();
-    await client.connect(MOCK_TRACKS);
+    await client.prepare(MOCK_TRACKS);
+    await client.connect();
 
     mockPC.connectionState = "connected";
     mockPC.onconnectionstatechange!();

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -295,7 +295,8 @@ export class Reactor {
         this.setupTransportHandlers();
       }
 
-      await this.transportClient.reconnect(this.tracks);
+      await this.transportClient.prepare(this.tracks);
+      await this.transportClient.connect(true);
     } catch (error) {
       if (isAbortError(error)) return;
 
@@ -351,23 +352,8 @@ export class Reactor {
         initialResponse.state
       );
 
-      // 2. Poll capabilities and prefetch ICE servers in parallel.
-      //    ICE servers only need the session_id (available now), so we can
-      //    start that fetch while waiting for the runtime to report capabilities.
+      // 2. Poll until the Runtime accepts and capabilities are available
       this.setStatus("waiting");
-
-      this.transportClient = new WebRTCTransportClient({
-        baseUrl: this.coordinatorUrl,
-        sessionId: initialResponse.session_id,
-        jwtToken: this.local ? "local" : jwtToken!,
-        webrtcVersion: REACTOR_WEBRTC_VERSION,
-        maxPollAttempts: options?.maxAttempts,
-      });
-
-      const iceServersPromise = (
-        this.transportClient as WebRTCTransportClient
-      ).fetchIceServers();
-      iceServersPromise.catch(() => {});
 
       const tPoll = performance.now();
       const sessionResponse = await this.coordinatorClient.pollSessionReady();
@@ -393,11 +379,20 @@ export class Reactor {
         throw new Error(`Unsupported transport protocol: ${protocol}`);
       }
 
+      this.transportClient = new WebRTCTransportClient({
+        baseUrl: this.coordinatorUrl,
+        sessionId: sessionResponse.session_id,
+        jwtToken: this.local ? "local" : jwtToken!,
+        webrtcVersion: REACTOR_WEBRTC_VERSION,
+        maxPollAttempts: options?.maxAttempts,
+      });
       this.setupTransportHandlers();
 
-      // 5. Connect transport, reusing the already-inflight ICE servers fetch
+      // 5. Prepare SDP offer (ICE fetch + PeerConnection + createOffer),
+      //    then send it and poll for the answer.
       const tTransport = performance.now();
-      await this.transportClient.connect(this.tracks, iceServersPromise);
+      await this.transportClient.prepare(this.tracks);
+      await this.transportClient.connect();
       const transportConnectingMs = performance.now() - tTransport;
 
       this.connectionTimings = {

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -50,22 +50,30 @@ export interface TransportClientConfig {
 
 export interface TransportClient {
   /**
-   * Establishes the transport connection using server-declared tracks.
+   * Phase 1: Prepare the transport for connection.
    *
-   * Internally handles: signaling (ICE servers, SDP offer/answer),
-   * connection negotiation, and transceiver setup. For sendonly tracks,
-   * no media flows until {@link publishTrack} is called.
+   * Performs all setup that can happen before the Runtime is confirmed
+   * ready — e.g. fetching signaling credentials, creating the local
+   * connection object, and configuring media tracks. This phase can run
+   * in parallel with session polling since it only requires the
+   * session_id and cluster assignment, not full Runtime readiness.
+   *
+   * Must be called before {@link connect}.
    */
-  connect(
-    tracks: TrackCapability[],
-    prefetchedIceServers?: Promise<RTCIceServer[]>
-  ): Promise<void>;
+  prepare(tracks: TrackCapability[]): Promise<void>;
 
   /**
-   * Reconnects an existing session with a fresh transport negotiation.
-   * Uses the same tracks as the original connection.
+   * Phase 2: Complete the transport connection.
+   *
+   * Sends the prepared signaling data to the server, waits for the
+   * server's response, and finishes the connection handshake. Must only
+   * be called after the Runtime is confirmed ready (i.e. after
+   * {@link prepare} and session polling have both completed).
+   *
+   * @param reconnect If true, signals a reconnection to an existing
+   *   session rather than an initial connection.
    */
-  reconnect(tracks: TrackCapability[]): Promise<void>;
+  connect(reconnect?: boolean): Promise<void>;
 
   /**
    * Tears down the transport connection and releases all resources.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -101,6 +101,9 @@ export class WebRTCTransportClient implements TransportClient {
   private sdpPollingMs?: number;
   private sdpPollingAttempts?: number;
 
+  private pendingSdpOffer?: string;
+  private pendingTrackMapping?: TrackMappingEntry[];
+
   private readonly baseUrl: string;
   private readonly sessionId: string;
   private readonly jwtToken: string;
@@ -196,7 +199,7 @@ export class WebRTCTransportClient implements TransportClient {
   // Transport Signaling (HTTP)
   // ─────────────────────────────────────────────────────────────────────────
 
-  async fetchIceServers(): Promise<RTCIceServer[]> {
+  private async fetchIceServers(): Promise<RTCIceServer[]> {
     console.debug("[WebRTCTransport] Fetching ICE servers...");
 
     const response = await fetch(`${this.transportBaseUrl}/ice_servers`, {
@@ -322,16 +325,25 @@ export class WebRTCTransportClient implements TransportClient {
   // Connection Lifecycle
   // ─────────────────────────────────────────────────────────────────────────
 
-  async connect(
-    tracks: TrackCapability[],
-    prefetchedIceServers?: Promise<RTCIceServer[]>
-  ): Promise<void> {
+  async prepare(tracks: TrackCapability[]): Promise<void> {
     this.setStatus("connecting");
     this.resetTransportTimings();
 
-    const iceServers = prefetchedIceServers
-      ? await prefetchedIceServers
-      : await this.fetchIceServers();
+    this.stopPing();
+    this.stopStatsPolling();
+
+    if (this.dataChannel) {
+      this.dataChannel.close();
+      this.dataChannel = undefined;
+    }
+    if (this.peerConnection) {
+      webrtc.closePeerConnection(this.peerConnection);
+      this.peerConnection = undefined;
+    }
+    this.peerConnected = false;
+    this.dataChannelOpen = false;
+
+    const iceServers = await this.fetchIceServers();
 
     this.peerConnection = webrtc.createPeerConnection({ iceServers });
     this.setupPeerConnectionHandlers();
@@ -355,74 +367,36 @@ export class WebRTCTransportClient implements TransportClient {
       );
     }
 
-    const sdpOffer = await webrtc.createOffer(this.peerConnection);
+    this.pendingSdpOffer = await webrtc.createOffer(this.peerConnection);
+    this.pendingTrackMapping = this.buildTrackMapping(tracks);
 
-    const trackMapping = this.buildTrackMapping(tracks);
+    console.debug("[WebRTCTransport] SDP offer prepared");
+  }
 
-    await this.sendSdpOffer(sdpOffer, trackMapping, "POST");
+  async connect(reconnect: boolean = false): Promise<void> {
+    if (!this.pendingSdpOffer || !this.pendingTrackMapping) {
+      throw new Error(
+        "[WebRTCTransport] No prepared connection. Call prepare() first."
+      );
+    }
+
+    const method = reconnect ? "PUT" : "POST";
+
+    const sdpOffer = this.pendingSdpOffer;
+    const trackMapping = this.pendingTrackMapping;
+    this.pendingSdpOffer = undefined;
+    this.pendingTrackMapping = undefined;
+
+    await this.sendSdpOffer(sdpOffer, trackMapping, method);
 
     const answerResponse = await this.pollSdpAnswer();
 
     this.iceStartTime = performance.now();
     await webrtc.setRemoteDescription(
-      this.peerConnection,
+      this.peerConnection!,
       answerResponse.sdp_answer
     );
     console.debug("[WebRTCTransport] Remote description set");
-  }
-
-  async reconnect(tracks: TrackCapability[]): Promise<void> {
-    this.setStatus("connecting");
-
-    this.stopPing();
-    this.stopStatsPolling();
-
-    if (this.dataChannel) {
-      this.dataChannel.close();
-      this.dataChannel = undefined;
-    }
-    if (this.peerConnection) {
-      webrtc.closePeerConnection(this.peerConnection);
-      this.peerConnection = undefined;
-    }
-    this.peerConnected = false;
-    this.dataChannelOpen = false;
-    this.resetTransportTimings();
-
-    const iceServers = await this.fetchIceServers();
-
-    this.peerConnection = webrtc.createPeerConnection({ iceServers });
-    this.setupPeerConnectionHandlers();
-
-    this.dataChannel = webrtc.createDataChannel(this.peerConnection);
-    this.setupDataChannelHandlers();
-
-    this.transceiverMap.clear();
-    for (const track of tracks) {
-      const transceiver = this.peerConnection.addTransceiver(track.kind, {
-        direction: track.direction,
-      });
-      this.transceiverMap.set(track.name, {
-        name: track.name,
-        kind: track.kind,
-        direction: track.direction,
-        transceiver,
-      });
-    }
-
-    const sdpOffer = await webrtc.createOffer(this.peerConnection);
-    const trackMapping = this.buildTrackMapping(tracks);
-
-    await this.sendSdpOffer(sdpOffer, trackMapping, "PUT");
-
-    const answerResponse = await this.pollSdpAnswer();
-
-    this.iceStartTime = performance.now();
-    await webrtc.setRemoteDescription(
-      this.peerConnection,
-      answerResponse.sdp_answer
-    );
-    console.debug("[WebRTCTransport] Remote description set (reconnect)");
   }
 
   async disconnect(): Promise<void> {


### PR DESCRIPTION
## Why

To enable parallel transport preparation during connection, the transport layer needs to be split into two independent phases: one that can run before the Runtime is ready (fetching signaling credentials, creating the local connection, configuring tracks) and one that must wait (sending signaling data and completing the handshake).

Today the transport uses a single monolithic `connect(tracks)` method that does everything sequentially. This prevents callers from overlapping transport preparation with other async work like session polling.

## What Changed

Replaced the single `connect(tracks)` / `reconnect(tracks)` methods on the `TransportClient` interface with a transport-agnostic two-phase API:

- **`prepare(tracks)`** — performs all setup that can happen before the Runtime is confirmed ready (in WebRTC: fetches ICE servers, creates RTCPeerConnection, adds transceivers, generates the SDP offer). Stores results internally.
- **`connect(reconnect?)`** — completes the connection handshake (in WebRTC: sends the SDP offer, polls for the answer, sets remote description). The `reconnect` flag controls whether this is an initial connection or a reconnection.

Updated `Reactor.ts` call sites to use the new API sequentially — no behavioral change yet.

**Before:**
```ts
await this.transportClient.connect(this.tracks);
// reconnect:
await this.transportClient.reconnect(this.tracks);
```

**After:**
```ts
await this.transportClient.prepare(this.tracks);
await this.transportClient.connect();
// reconnect:
await this.transportClient.prepare(this.tracks);
await this.transportClient.connect(true);
```

No user-facing change. This is a pure internal refactor that enables the parallel connect flow in [2/3].