### PR TITLE
[REA-1654][2/3] feat: parallel transport preparation with optional preset tracks

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -49,6 +49,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
       prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -61,6 +61,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
       prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
   WebRTCTransportClient: vi.fn().mockImplementation(() => {
     transportHandlers = {};
     mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
       prepare: vi.fn().mockResolvedValue(undefined),
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
@@ -236,6 +237,56 @@ describe("Reactor", () => {
       const info = r.getSessionInfo();
       expect(info).toBeDefined();
       expect(info!.session_id).toBe(MOCK_SESSION_ID);
+      await r.disconnect();
+    });
+
+    it("uses parallel path when tracks are preset", async () => {
+      const r = new Reactor({
+        modelName: "echo",
+        modelTracks: [
+          { name: "main_video", kind: "video", direction: "recvonly" },
+        ],
+      });
+      await r.connect("jwt-token");
+
+      expect(mockTransportClient.prepare).toHaveBeenCalledWith([
+        { name: "main_video", kind: "video", direction: "recvonly" },
+      ]);
+      expect(mockTransportClient.connect).toHaveBeenCalled();
+      await r.disconnect();
+    });
+
+    it("uses sequential path when tracks are not preset", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await r.connect("jwt-token");
+
+      expect(mockTransportClient.prepare).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "main_video" }),
+        ])
+      );
+      expect(mockTransportClient.connect).toHaveBeenCalled();
+      await r.disconnect();
+    });
+
+    it("calls warmup in sequential path (no preset tracks)", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await r.connect("jwt-token");
+
+      expect(mockTransportClient.warmup).toHaveBeenCalled();
+      await r.disconnect();
+    });
+
+    it("does not call warmup in parallel path (preset tracks)", async () => {
+      const r = new Reactor({
+        modelName: "echo",
+        modelTracks: [
+          { name: "main_video", kind: "video", direction: "recvonly" },
+        ],
+      });
+      await r.connect("jwt-token");
+
+      expect(mockTransportClient.warmup).not.toHaveBeenCalled();
       await r.disconnect();
     });
   });

--- a/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
@@ -148,6 +148,41 @@ describe("WebRTCTransportClient", () => {
     });
   });
 
+  // ── warmup() ──────────────────────────────────────────────────────────
+
+  describe("warmup()", () => {
+    it("prefetches ICE servers so prepare() reuses them", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+
+      await client.warmup();
+
+      mockSdpOfferAccepted();
+      mockSdpAnswerReady();
+
+      await client.prepare(MOCK_TRACKS);
+      await client.connect();
+
+      // ICE servers fetched only once (by warmup), not again by prepare
+      const iceServerCalls = mockFetch.mock.calls.filter(
+        (c: any) => typeof c[0] === "string" && c[0].includes("ice_servers")
+      );
+      expect(iceServerCalls).toHaveLength(1);
+    });
+
+    it("prepare() fetches ICE servers itself when warmup() was not called", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+
+      await client.prepare(MOCK_TRACKS);
+
+      const iceServerCalls = mockFetch.mock.calls.filter(
+        (c: any) => typeof c[0] === "string" && c[0].includes("ice_servers")
+      );
+      expect(iceServerCalls).toHaveLength(1);
+    });
+  });
+
   // ── Event emitter ──────────────────────────────────────────────────────
 
   describe("event emitter", () => {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -26,10 +26,17 @@ import { z } from "zod";
 const LOCAL_COORDINATOR_URL = "http://localhost:8080";
 export const DEFAULT_BASE_URL = "https://api.reactor.inc";
 
+const TrackHintSchema = z.object({
+  name: z.string(),
+  kind: z.enum(["video", "audio"]),
+  direction: z.enum(["recvonly", "sendonly"]),
+});
+
 const OptionsSchema = z.object({
   apiUrl: z.string().default(DEFAULT_BASE_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
+  modelTracks: z.array(TrackHintSchema).optional(),
 });
 export type Options = z.input<typeof OptionsSchema>;
 
@@ -53,6 +60,7 @@ export class Reactor {
 
   private capabilities?: Capabilities;
   private tracks: TrackCapability[] = [];
+  private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
 
   constructor(options: Options) {
@@ -62,6 +70,9 @@ export class Reactor {
     this.local = validatedOptions.local;
     if (this.local && options.apiUrl === undefined) {
       this.coordinatorUrl = LOCAL_COORDINATOR_URL;
+    }
+    if (validatedOptions.modelTracks) {
+      this.presetTracks = validatedOptions.modelTracks;
     }
   }
 
@@ -352,48 +363,64 @@ export class Reactor {
         initialResponse.state
       );
 
-      // 2. Poll until the Runtime accepts and capabilities are available
       this.setStatus("waiting");
-
-      const tPoll = performance.now();
-      const sessionResponse = await this.coordinatorClient.pollSessionReady();
-      const sessionPollingMs = performance.now() - tPoll;
-
-      this.sessionResponse = sessionResponse;
-
-      // 3. Store capabilities and tracks
-      this.capabilities = sessionResponse.capabilities!;
-      this.tracks = sessionResponse.capabilities!.tracks;
-      this.emit("capabilitiesReceived", this.capabilities);
-
-      console.debug(
-        "[Reactor] Session ready, transport:",
-        sessionResponse.selected_transport!.protocol,
-        "tracks:",
-        this.tracks.length
-      );
-
-      // 4. Validate transport protocol
-      const protocol = sessionResponse.selected_transport!.protocol;
-      if (protocol !== "webrtc") {
-        throw new Error(`Unsupported transport protocol: ${protocol}`);
-      }
 
       this.transportClient = new WebRTCTransportClient({
         baseUrl: this.coordinatorUrl,
-        sessionId: sessionResponse.session_id,
+        sessionId: initialResponse.session_id,
         jwtToken: this.local ? "local" : jwtToken!,
         webrtcVersion: REACTOR_WEBRTC_VERSION,
         maxPollAttempts: options?.maxAttempts,
       });
       this.setupTransportHandlers();
 
-      // 5. Prepare SDP offer (ICE fetch + PeerConnection + createOffer),
-      //    then send it and poll for the answer.
-      const tTransport = performance.now();
-      await this.transportClient.prepare(this.tracks);
-      await this.transportClient.connect();
-      const transportConnectingMs = performance.now() - tTransport;
+      let sessionPollingMs: number;
+      let transportConnectingMs: number;
+
+      if (this.presetTracks) {
+        // 2a. Parallel path: tracks are known at build time, so we can
+        //     prepare the transport while waiting for the Runtime.
+        const tParallel = performance.now();
+        const [sessionResponse] = await Promise.all([
+          this.coordinatorClient.pollSessionReady(),
+          this.transportClient.prepare(this.presetTracks),
+        ]);
+        sessionPollingMs = performance.now() - tParallel;
+
+        this.sessionResponse = sessionResponse;
+        this.capabilities = sessionResponse.capabilities!;
+        this.tracks = this.presetTracks;
+        this.emit("capabilitiesReceived", this.capabilities);
+
+        const tConnect = performance.now();
+        await this.transportClient.connect();
+        transportConnectingMs = performance.now() - tConnect;
+      } else {
+        // 2b. Sequential path: tracks come from the poll response, but
+        //     we can still warm up the transport (ICE fetch) in parallel.
+        this.transportClient.warmup();
+
+        const tPoll = performance.now();
+        const sessionResponse = await this.coordinatorClient.pollSessionReady();
+        sessionPollingMs = performance.now() - tPoll;
+
+        this.sessionResponse = sessionResponse;
+        this.capabilities = sessionResponse.capabilities!;
+        this.tracks = sessionResponse.capabilities!.tracks;
+        this.emit("capabilitiesReceived", this.capabilities);
+
+        const protocol = sessionResponse.selected_transport!.protocol;
+        if (protocol !== "webrtc") {
+          throw new Error(`Unsupported transport protocol: ${protocol}`);
+        }
+
+        const tTransport = performance.now();
+        await this.transportClient.prepare(this.tracks);
+        await this.transportClient.connect();
+        transportConnectingMs = performance.now() - tTransport;
+      }
+
+      console.debug("[Reactor] Session ready, tracks:", this.tracks.length);
 
       this.connectionTimings = {
         sessionCreationMs: sessionCreationMs + sessionPollingMs,

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -50,12 +50,25 @@ export interface TransportClientConfig {
 
 export interface TransportClient {
   /**
+   * Optional early work the transport can do before tracks are known.
+   *
+   * For example, fetching signaling credentials that only require the
+   * session_id. Results are cached internally and reused by
+   * {@link prepare}. Safe to call in parallel with session polling.
+   *
+   * Calling this is optional — {@link prepare} will do the work itself
+   * if `warmup()` was not called.
+   */
+  warmup(): Promise<void>;
+
+  /**
    * Phase 1: Prepare the transport for connection.
    *
    * Performs all setup that can happen before the Runtime is confirmed
-   * ready — e.g. fetching signaling credentials, creating the local
-   * connection object, and configuring media tracks. This phase can run
-   * in parallel with session polling since it only requires the
+   * ready — e.g. creating the local connection object and configuring
+   * media tracks. If {@link warmup} was called, reuses its cached
+   * results (e.g. signaling credentials). This phase can run in
+   * parallel with session polling since it only requires the
    * session_id and cluster assignment, not full Runtime readiness.
    *
    * Must be called before {@link connect}.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -103,6 +103,7 @@ export class WebRTCTransportClient implements TransportClient {
 
   private pendingSdpOffer?: string;
   private pendingTrackMapping?: TrackMappingEntry[];
+  private cachedIceServers?: Promise<RTCIceServer[]>;
 
   private readonly baseUrl: string;
   private readonly sessionId: string;
@@ -325,6 +326,14 @@ export class WebRTCTransportClient implements TransportClient {
   // Connection Lifecycle
   // ─────────────────────────────────────────────────────────────────────────
 
+  async warmup(): Promise<void> {
+    if (!this.cachedIceServers) {
+      this.cachedIceServers = this.fetchIceServers();
+      this.cachedIceServers.catch(() => {});
+    }
+    await this.cachedIceServers;
+  }
+
   async prepare(tracks: TrackCapability[]): Promise<void> {
     this.setStatus("connecting");
     this.resetTransportTimings();
@@ -343,7 +352,10 @@ export class WebRTCTransportClient implements TransportClient {
     this.peerConnected = false;
     this.dataChannelOpen = false;
 
-    const iceServers = await this.fetchIceServers();
+    const iceServers = this.cachedIceServers
+      ? await this.cachedIceServers
+      : await this.fetchIceServers();
+    this.cachedIceServers = undefined;
 
     this.peerConnection = webrtc.createPeerConnection({ iceServers });
     this.setupPeerConnectionHandlers();


### PR DESCRIPTION
## Why

The connection flow currently blocks on `pollSessionReady` (1-5 seconds) before beginning transport preparation (ICE fetch, PeerConnection, createOffer). These two phases are independent — the transport prep only needs the session_id and cluster assignment, not the full Runtime readiness.

When the model's tracks are known ahead of time (e.g. from a codegen-generated model SDK that reads them from the OpenAPI schema), we can overlap the full transport preparation with the session-ready poll, shaving ~130ms off the critical connection path.

Even when the tracks are NOT known ahead of time, we can still overlap the ICE server fetch (which doesn't need tracks) with the session poll via `warmup()`.

## What Changed

**1. Added `warmup()` to the `TransportClient` interface**

A new optional method that kicks off early transport work before tracks are known (for WebRTC: ICE server fetch). Results are cached internally and reused by `prepare()`. If `warmup()` is never called, `prepare()` does the work itself.

**2. Added optional `modelTracks` field to `Reactor` constructor options**

This is a **performance hint** — completely optional and never required. Users of the base SDK are never exposed to the concept of specifying tracks. The SDK continues to work exactly as before when `modelTracks` is not provided.

**3. Two optimized connection flows**

When `modelTracks` IS provided (typically by codegen-generated model SDKs — users never see this):

```ts
// Internal — generated SDK passes tracks automatically
const reactor = new Reactor({
  modelName: "helios",
  modelTracks: [
    { name: "main_video", kind: "video", direction: "recvonly" },
  ],
});
await reactor.connect(token);
```

Full parallel overlap — `prepare()` (ICE + PeerConnection + SDP offer) runs alongside the poll:

```
createSession ──┬── pollSessionReady ─────────────────────┬── connect
                │     (waits for Runtime, ~1-5s)          │
                └── prepare (ICE + PC + offer) ───────────┘
                     ^^^ fully parallel with poll ^^^
```

When `modelTracks` is NOT provided (default), ICE fetch still runs in parallel via `warmup()`:

```
createSession ──┬── pollSessionReady ─────────────────────┬── prepare ── connect
                │     (waits for Runtime, ~1-5s)          │   (ICE already cached)
                └── warmup (ICE fetch) ───────────────────┘
                     ^^^ parallel with poll ^^^
```

**Important:** The `modelTracks` option is an internal optimization for machine-generated code. Human users call `new Reactor({ modelName })` or `new HeliosModel()` and never need to think about tracks. The session poll still happens in both paths to confirm the Runtime is alive and ready.