### PR TITLE
[REA-1654][3/3] feat: reconnect uses two-phase transport API

### DIFF
--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -349,6 +349,31 @@ describe("Reactor (extended)", () => {
       await r.disconnect();
     });
 
+    it("reconnects with preset tracks", async () => {
+      const presetTracks = [
+        {
+          name: "main_video" as const,
+          kind: "video" as const,
+          direction: "recvonly" as const,
+        },
+      ];
+      const r = new Reactor({
+        modelName: "echo",
+        modelTracks: presetTracks,
+      });
+      await r.connect("jwt");
+      transportHandlers["statusChanged"]("connected");
+
+      await r.disconnect(true);
+      mockTransportClient.prepare.mockClear();
+      mockTransportClient.connect.mockClear();
+
+      await r.reconnect();
+      expect(mockTransportClient.prepare).toHaveBeenCalledWith(presetTracks);
+      expect(mockTransportClient.connect).toHaveBeenCalledWith(true);
+      await r.disconnect();
+    });
+
     it("warns when already ready", async () => {
       const r = new Reactor({ modelName: "echo" });
       await connectAndReady(r);


### PR DESCRIPTION
## Why

PR [1/3] split the transport into `prepare()` + `connect()` and updated the connect call sites. The `reconnect()` path should use the same two-phase API consistently and have proper test coverage, including with preset `modelTracks`.

## What Changed

Added test coverage for the reconnect path with preset `modelTracks`, verifying that `reconnect()` correctly calls `prepare(tracks)` then `connect(true)`.

```ts
// reconnect() internally:
await this.transportClient.prepare(this.tracks);
await this.transportClient.connect(true);  // true = reconnect
```

The test confirms that when `modelTracks` is provided at construction time, the preset tracks are preserved through disconnect/reconnect and correctly passed to `prepare()` on reconnection.