### PR TITLE
[REA-1581][1/6] feat: add @reactor-team/codegen package scaffold + IR types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .pnpm-store
 dist
 node_modules
+.generated

--- a/packages/codegen/.gitignore
+++ b/packages/codegen/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.generated/

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -1,0 +1,35 @@
+# @reactor-team/codegen
+
+Code generator that turns a model's OpenAPI schema into a strongly-typed
+npm package (`@reactor-models/<name>`) wrapping `@reactor-team/js-sdk`.
+
+> **Scaffolding stage.** This package currently contains only the IR
+> (intermediate representation) types and package plumbing. The parser,
+> emitter, and CLI are introduced in follow-up PRs on the same
+> [REA-1581](https://linear.app/reactor-team/issue/REA-1581) stack.
+
+## Intermediate representation
+
+All downstream stages consume a normalised `ModelSchema`, decoupled
+from the raw OpenAPI shape:
+
+```ts
+import type { ModelSchema } from "@reactor-team/codegen";
+
+interface ModelSchema {
+  modelName: string;
+  modelVersion: string;
+  events: EventSchema[];
+  messages: MessageSchema[];
+  tracks: TrackSchema[];
+}
+```
+
+See `src/types.ts` for the full IR.
+
+## Fixture
+
+`schema.json` is a committed dummy OpenAPI document (model name `example`)
+used by parser and CLI tests in later PRs of the stack. It is intentionally
+minimal — just enough shape to exercise events with and without fields,
+webhooks with and without fields, and a single output track.

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@reactor-team/codegen",
+  "version": "0.1.0",
+  "description": "Code generator for strongly-typed Reactor model SDKs",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch"
+  },
+  "keywords": [
+    "reactor",
+    "codegen",
+    "sdk"
+  ],
+  "author": "Reactor Technologies, Inc.",
+  "license": "MIT",
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/codegen/schema.json
+++ b/packages/codegen/schema.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "example",
+    "version": "0.1.0",
+    "description": "Dummy OpenAPI document used as the in-repo test fixture for @reactor-team/codegen. Not a real model — just enough shape to exercise events with and without fields, webhooks with and without fields, and a single output track."
+  },
+  "x-reactor": {
+    "tracks": [
+      {
+        "name": "output_video",
+        "kind": "video",
+        "direction": "out"
+      }
+    ]
+  },
+  "paths": {
+    "/events/set_value": {
+      "post": {
+        "operationId": "set_value",
+        "summary": "Set an arbitrary string value.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Arbitrary string value the model should echo back via value_changed."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/ping": {
+      "post": {
+        "operationId": "ping",
+        "summary": "A no-parameter event; exercises the empty-params code path."
+      }
+    }
+  },
+  "webhooks": {
+    "value_changed": {
+      "post": {
+        "operationId": "value_changed",
+        "summary": "Emitted whenever set_value is applied.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "The new value."
+                  }
+                },
+                "required": ["value"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "pong": {
+      "post": {
+        "operationId": "pong",
+        "summary": "No-field webhook; exercises the empty-fields code path."
+      }
+    }
+  }
+}

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+export type {
+  CodegenOptions,
+  EventSchema,
+  FieldSchema,
+  GeneratedFile,
+  GeneratedPackage,
+  MessageSchema,
+  ModelSchema,
+  TrackSchema,
+} from "./types.js";

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// ---------------------------------------------------------------------------
+// Internal IR — the normalised representation the emitter consumes.
+// Decoupled from the raw OpenAPI shape so the emitter never parses OpenAPI.
+// ---------------------------------------------------------------------------
+
+export interface FieldSchema {
+  type: string;
+  default?: unknown;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  enum?: (string | number | boolean)[];
+  format?: string;
+}
+
+export interface EventSchema {
+  name: string;
+  description: string;
+  fields: Record<string, FieldSchema>;
+}
+
+export interface MessageSchema {
+  name: string;
+  description: string;
+  fields: Record<string, FieldSchema>;
+}
+
+export interface TrackSchema {
+  name: string;
+  kind: "video" | "audio";
+  direction: "in" | "out";
+}
+
+export interface ModelSchema {
+  modelName: string;
+  modelVersion: string;
+  events: EventSchema[];
+  messages: MessageSchema[];
+  tracks: TrackSchema[];
+}
+
+// ---------------------------------------------------------------------------
+// Codegen pipeline types
+// ---------------------------------------------------------------------------
+
+export interface CodegenOptions {
+  modelName: string;
+  modelVersion: string;
+  sdkVersion: string;
+  schema: ModelSchema;
+  outputDir: string;
+}
+
+export interface GeneratedFile {
+  path: string;
+  content: string;
+}
+
+export interface GeneratedPackage {
+  files: GeneratedFile[];
+}

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", ".generated"]
+}

--- a/packages/codegen/tsup.config.ts
+++ b/packages/codegen/tsup.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,15 @@ importers:
         specifier: ^3.6.2
         version: 3.8.1
 
+  packages/codegen:
+    devDependencies:
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   packages/create-app:
     dependencies:
       '@reactor-team/js-sdk':


### PR DESCRIPTION
## Why

First PR of the **REA-1581** stack. Lands the empty package shell and the intermediate representation (IR) that every downstream stage of the codegen consumes.

The IR is deliberately decoupled from the raw OpenAPI shape: the emitter in PR 3 never parses OpenAPI, only the IR. This makes each subsequent PR trivial to review in isolation.

## What changed

- Added `@reactor-team/codegen` to the workspace (package scaffold only, no logic).
- Defined the `ModelSchema` IR and its leaf types (`EventSchema`, `MessageSchema`, `TrackSchema`, `FieldSchema`).
- Defined `CodegenOptions`, `GeneratedFile`, `GeneratedPackage` — the types the emitter produces.
- Committed the Helios OpenAPI fixture used by parser + emitter tests in later PRs.

## Shape of the change

```
packages/codegen/
├── package.json              (empty package shell)
├── tsconfig.json
├── tsup.config.ts
├── .gitignore
├── README.md                 (stub — full reference lands in PR 4)
├── schema.json               (Helios OpenAPI fixture for downstream tests)
└── src/
    ├── types.ts              (the IR)
    └── index.ts              (IR type re-exports; no logic yet)
```

## Tests

None in this PR by design — vitest is introduced in PR 2 alongside the first piece of logic worth testing. `pnpm --filter @reactor-team/codegen build` is clean on the empty package.

## Stack

1. **→ this PR** scaffold + IR
2. [`[2/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/118) parser + ingress validation
3. [`[3/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/119) emitter + README + injection defence + version helpers
4. [`[4/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/120) CLI + modelTracks + defaultSdkVersion
5. [`[5/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/121) coordinator fetch + auth exchange
6. [`[6/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/122) Buildkite publish pipeline

Ref: [REA-1581](https://linear.app/reactor-team/issue/REA-1581)
