### PR TITLE
[REA-1581][2/6] feat: codegen OpenAPI parser + ingress validation

### DIFF
--- a/packages/codegen/__tests__/parser.test.ts
+++ b/packages/codegen/__tests__/parser.test.ts
@@ -1,0 +1,616 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadSchema, parseSchema } from "../src/openapi/index.js";
+import type { OpenApiSchema } from "../src/openapi/index.js";
+
+// ---------------------------------------------------------------------------
+// Minimal inline fixtures — keep each test narrow and readable.
+// The committed `example` fixture is exercised by the `schema.json fixture`
+// suite at the bottom of the file.
+// ---------------------------------------------------------------------------
+
+function baseSchema(overrides: Partial<OpenApiSchema> = {}): OpenApiSchema {
+  return {
+    openapi: "3.1.0",
+    info: { title: "test_model", version: "1.2.3" },
+    ...overrides,
+  };
+}
+
+describe("loadSchema", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-parser-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads and parses a well-formed OpenAPI JSON document", () => {
+    const filePath = path.join(tmpDir, "schema.json");
+    fs.writeFileSync(filePath, JSON.stringify(baseSchema()));
+
+    const result = loadSchema(filePath);
+
+    expect(result.openapi).toBe("3.1.0");
+    expect(result.info.title).toBe("test_model");
+    expect(result.info.version).toBe("1.2.3");
+  });
+
+  it("throws when the document is missing the `openapi` field", () => {
+    const filePath = path.join(tmpDir, "bad.json");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ info: { title: "x", version: "0" } }),
+    );
+
+    expect(() => loadSchema(filePath)).toThrow(/missing "openapi" field/);
+  });
+
+  it("propagates JSON parse errors for malformed files", () => {
+    const filePath = path.join(tmpDir, "garbage.json");
+    fs.writeFileSync(filePath, "{ not json");
+
+    expect(() => loadSchema(filePath)).toThrow();
+  });
+});
+
+describe("parseSchema — modelName / modelVersion", () => {
+  it("reads modelName from info.title and modelVersion from info.version", () => {
+    const ir = parseSchema(
+      baseSchema({ info: { title: "helios", version: "2.5.0" } }),
+    );
+
+    expect(ir.modelName).toBe("helios");
+    expect(ir.modelVersion).toBe("2.5.0");
+  });
+
+  it("returns empty arrays when the schema declares no events/messages/tracks", () => {
+    const ir = parseSchema(baseSchema());
+
+    expect(ir.events).toEqual([]);
+    expect(ir.messages).toEqual([]);
+    expect(ir.tracks).toEqual([]);
+  });
+});
+
+describe("parseSchema — events (paths → operations)", () => {
+  it("extracts one event per `path.post` operation", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/set_prompt": {
+            post: {
+              operationId: "set_prompt",
+              summary: "Set the scene prompt",
+              requestBody: {
+                required: true,
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        prompt: { type: "string", default: "" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "/events/set_seed": {
+            post: {
+              operationId: "set_seed",
+              summary: "RNG seed",
+              requestBody: {
+                required: true,
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        seed: { type: "integer", default: 0, minimum: 0 },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events).toHaveLength(2);
+    const [setPrompt, setSeed] = ir.events;
+
+    expect(setPrompt.name).toBe("set_prompt");
+    expect(setPrompt.description).toBe("Set the scene prompt");
+    expect(setPrompt.fields.prompt).toEqual({
+      type: "string",
+      default: "",
+      description: undefined,
+      minimum: undefined,
+      maximum: undefined,
+      minLength: undefined,
+      maxLength: undefined,
+      enum: undefined,
+      format: undefined,
+    });
+
+    expect(setSeed.fields.seed).toMatchObject({
+      type: "integer",
+      default: 0,
+      minimum: 0,
+    });
+  });
+
+  it("falls back to the final path segment when operationId is absent", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/start": {
+            // @ts-expect-error deliberately malformed to test the fallback
+            post: { summary: "start" },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events[0].name).toBe("start");
+  });
+
+  it("skips path items that have no `post` operation", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/no_post": {},
+        },
+      }),
+    );
+
+    expect(ir.events).toEqual([]);
+  });
+
+  it("produces an empty field map when the requestBody is missing", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/ping": {
+            post: { operationId: "ping" },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events[0].fields).toEqual({});
+  });
+
+  it("preserves enum, min/max and length constraints on fields", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/configure": {
+            post: {
+              operationId: "configure",
+              summary: "",
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        sr_scale: {
+                          type: "string",
+                          enum: ["1x", "2x"],
+                          default: "1x",
+                        },
+                        strength: {
+                          type: "number",
+                          minimum: 0,
+                          maximum: 1,
+                        },
+                        label: {
+                          type: "string",
+                          minLength: 1,
+                          maxLength: 64,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const fields = ir.events[0].fields;
+    expect(fields.sr_scale.enum).toEqual(["1x", "2x"]);
+    expect(fields.strength).toMatchObject({ minimum: 0, maximum: 1 });
+    expect(fields.label).toMatchObject({ minLength: 1, maxLength: 64 });
+  });
+});
+
+describe("parseSchema — messages (webhooks → operations)", () => {
+  it("extracts one message per `webhooks.post` operation", () => {
+    const ir = parseSchema(
+      baseSchema({
+        webhooks: {
+          prompt_accepted: {
+            post: {
+              operationId: "prompt_accepted",
+              summary: "A prompt was accepted and scheduled.",
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        prompt: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.messages).toHaveLength(1);
+    expect(ir.messages[0]).toMatchObject({
+      name: "prompt_accepted",
+      description: "A prompt was accepted and scheduled.",
+    });
+    expect(ir.messages[0].fields.prompt).toMatchObject({ type: "string" });
+  });
+
+  it("uses the webhook key as the message name when operationId is absent", () => {
+    const ir = parseSchema(
+      baseSchema({
+        webhooks: {
+          generation_started: {
+            // @ts-expect-error deliberately malformed
+            post: { summary: "started" },
+          },
+        },
+      }),
+    );
+
+    expect(ir.messages[0].name).toBe("generation_started");
+  });
+});
+
+describe("parseSchema — $ref resolution", () => {
+  it("resolves a property $ref against components.schemas", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/set_image": {
+            post: {
+              operationId: "set_image",
+              summary: "",
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        image: {
+                          $ref: "#/components/schemas/ReactorUploadReference",
+                          default: null,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            ReactorUploadReference: {
+              type: "object",
+              format: "reactor-upload-reference",
+              description:
+                "Reference to a file uploaded via the presigned-URL protocol.",
+            },
+          },
+        },
+      }),
+    );
+
+    const imageField = ir.events[0].fields.image;
+    expect(imageField.type).toBe("object");
+    expect(imageField.format).toBe("reactor-upload-reference");
+    expect(imageField.description).toMatch(/presigned-URL/);
+    // The `default: null` from the original property is preserved.
+    expect(imageField.default).toBeNull();
+  });
+
+  it("throws for an unresolved $ref", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          paths: {
+            "/events/bad": {
+              post: {
+                operationId: "bad",
+                summary: "",
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          x: { $ref: "#/components/schemas/Missing" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(/Unresolved \$ref/);
+  });
+});
+
+describe("parseSchema — tracks (x-reactor extension)", () => {
+  it("passes through track name / kind / direction verbatim", () => {
+    const ir = parseSchema(
+      baseSchema({
+        "x-reactor": {
+          tracks: [
+            { name: "main_video", kind: "video", direction: "out" },
+            { name: "webcam", kind: "video", direction: "in" },
+            { name: "mic", kind: "audio", direction: "in" },
+          ],
+        },
+      }),
+    );
+
+    expect(ir.tracks).toEqual([
+      { name: "main_video", kind: "video", direction: "out" },
+      { name: "webcam", kind: "video", direction: "in" },
+      { name: "mic", kind: "audio", direction: "in" },
+    ]);
+  });
+});
+
+describe("parseSchema — ingress validation (injection defence)", () => {
+  // Every schema string that makes it past parseSchema will land verbatim
+  // in generated TypeScript downstream. These tests pin the guard that
+  // keeps hostile or malformed coordinator payloads from reaching the
+  // emitter — the primary defence against supply-chain RCE via a crafted
+  // `info.title`, operationId, field name, or track descriptor.
+
+  it("rejects an info.title containing non-identifier characters", () => {
+    // A modelName like this would both fail npm's package-name rules and,
+    // without validation, land inside an unescaped `"${schema.modelName}"`
+    // in the emitted source.
+    expect(() =>
+      parseSchema(baseSchema({ info: { title: 'hel"ios', version: "1.0.0" } })),
+    ).toThrow(/Invalid info\.title/);
+  });
+
+  it("rejects an info.title starting with a digit", () => {
+    expect(() =>
+      parseSchema(baseSchema({ info: { title: "1helios", version: "1.0.0" } })),
+    ).toThrow(/Invalid info\.title/);
+  });
+
+  it("rejects an info.version containing control characters", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({ info: { title: "helios", version: "1.0.0\n;evil()" } }),
+      ),
+    ).toThrow(/Invalid info\.version/);
+  });
+
+  it("rejects an event operationId that would break out of a string literal", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          paths: {
+            "/events/x": {
+              post: {
+                operationId: 'set_prompt"; evil()',
+                requestBody: {
+                  content: {
+                    "application/json": { schema: { type: "object" } },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(/Invalid event name/);
+  });
+
+  it("rejects a webhook operationId with non-identifier chars", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          webhooks: {
+            bad: {
+              post: {
+                operationId: "prompt-accepted",
+                requestBody: {
+                  content: {
+                    "application/json": { schema: { type: "object" } },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(/Invalid message name/);
+  });
+
+  it("rejects an event field name containing whitespace", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          paths: {
+            "/events/set_prompt": {
+              post: {
+                operationId: "set_prompt",
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          "bad name": { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(/Invalid field name on event "set_prompt"/);
+  });
+
+  it("rejects an unknown track.kind", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          "x-reactor": {
+            // @ts-expect-error intentionally invalid runtime value
+            tracks: [{ name: "v", kind: "screen", direction: "out" }],
+          },
+        }),
+      ),
+    ).toThrow(/Invalid track "v" kind/);
+  });
+
+  it("rejects an unknown track.direction", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          "x-reactor": {
+            // @ts-expect-error intentionally invalid runtime value
+            tracks: [{ name: "v", kind: "video", direction: "bidi" }],
+          },
+        }),
+      ),
+    ).toThrow(/Invalid track "v" direction/);
+  });
+
+  it("rejects a track name containing injection characters", () => {
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          "x-reactor": {
+            tracks: [
+              { name: 'main"; evil()', kind: "video", direction: "out" },
+            ],
+          },
+        }),
+      ),
+    ).toThrow(/Invalid track name/);
+  });
+
+  it("accepts a well-formed snake_case schema (regression guard)", () => {
+    // Verify the validator doesn't reject the common case — the shape
+    // every real Reactor model schema actually uses.
+    expect(() =>
+      parseSchema(
+        baseSchema({
+          info: { title: "helios", version: "1.0.5-ge6187a05" },
+          paths: {
+            "/events/set_prompt": {
+              post: {
+                operationId: "set_prompt",
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: { prompt: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          webhooks: {
+            prompt_accepted: {
+              post: {
+                operationId: "prompt_accepted",
+                requestBody: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: { prompt: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "x-reactor": {
+            tracks: [
+              { name: "main_video", kind: "video", direction: "out" },
+              { name: "webcam", kind: "video", direction: "in" },
+            ],
+          },
+        }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("schema.json fixture (example)", () => {
+  it("parses the committed dummy fixture end-to-end", () => {
+    // Smoke test against the in-repo `example` fixture — just enough
+    // shape to exercise events + webhooks with and without fields, and
+    // a single output track. Detailed per-field assertions live in the
+    // inline-fixture suites above; this test only pins the fixture's
+    // top-level contract so downstream CLI tests can rely on it.
+    const fixturePath = path.join(__dirname, "..", "schema.json");
+    const raw = loadSchema(fixturePath);
+    const ir = parseSchema(raw);
+
+    expect(ir.modelName).toBe("example");
+    expect(ir.modelVersion).toBe("0.1.0");
+    expect(ir.events.map((e) => e.name).sort()).toEqual(["ping", "set_value"]);
+    expect(ir.messages.map((m) => m.name).sort()).toEqual([
+      "pong",
+      "value_changed",
+    ]);
+    expect(ir.tracks).toEqual([
+      { name: "output_video", kind: "video", direction: "out" },
+    ]);
+
+    // `ping` + `pong` are intentionally field-less — the emitter uses
+    // that to exercise its empty-params / empty-data code path.
+    const ping = ir.events.find((e) => e.name === "ping")!;
+    expect(ping.fields).toEqual({});
+    const pong = ir.messages.find((m) => m.name === "pong")!;
+    expect(pong.fields).toEqual({});
+  });
+});

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [
     "reactor",
@@ -28,7 +30,9 @@
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "tsup": "^8.5.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
+export { loadSchema, parseSchema } from "./openapi/index.js";
+export type { OpenApiSchema } from "./openapi/index.js";
 export type {
   CodegenOptions,
   EventSchema,

--- a/packages/codegen/src/openapi/index.ts
+++ b/packages/codegen/src/openapi/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+export { loadSchema, parseSchema } from "./parser.js";
+export type { OpenApiSchema } from "./types.js";

--- a/packages/codegen/src/openapi/parser.ts
+++ b/packages/codegen/src/openapi/parser.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import * as fs from "node:fs";
+import type {
+  EventSchema,
+  FieldSchema,
+  MessageSchema,
+  ModelSchema,
+  TrackSchema,
+} from "../types.js";
+import type {
+  OpenApiComponentSchemaObject,
+  OpenApiSchema,
+  OpenApiSchemaProperty,
+} from "./types.js";
+
+/**
+ * Read an OpenAPI schema JSON file from disk and validate the top-level
+ * shape. Throws if the file is missing the mandatory `openapi` field.
+ */
+export function loadSchema(filePath: string): OpenApiSchema {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const parsed = JSON.parse(raw);
+
+  if (!parsed.openapi) {
+    throw new Error(
+      `Schema file is missing "openapi" field — expected an OpenAPI 3.x document: ${filePath}`,
+    );
+  }
+
+  return parsed as OpenApiSchema;
+}
+
+// ---------------------------------------------------------------------------
+// Ingress validation.
+//
+// Every schema string that flows past this point will land verbatim in
+// generated TypeScript — either as an identifier (via toPascalCase /
+// toCamelCase in the emitter), as the discriminator of a TS string literal
+// ("${name}"), or inside a JSDoc body. Without validation here, a schema
+// fetched from the coordinator could inject arbitrary TS into the package
+// that ultimately ships to npmjs.org.
+//
+// We deliberately constrain *names* (identifier-shaped tokens) and *enum
+// members* (fixed set); free-form *descriptions* pass through unchanged
+// because they can legitimately contain any prose, and the emitter is
+// responsible for making them safe inside comment bodies.
+// ---------------------------------------------------------------------------
+
+/** Model name — must double as both an npm package segment and a TS class prefix. */
+const MODEL_NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * Token name (events, messages, tracks, fields). Must be a valid JS
+ * identifier start char followed by identifier chars — snake_case,
+ * camelCase, PascalCase all work. No hyphens, dots, or whitespace.
+ */
+const TOKEN_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Permissive version check: anything the emitter's header formatter and
+ * npm's strict semver would both accept, minus control characters and
+ * quotes. We don't re-implement semver here — the `v` strip in the
+ * emitter + npm's own validator catches malformed versions at publish
+ * time; this is just a guard against shell/code-injection characters.
+ */
+const MODEL_VERSION_RE = /^[a-zA-Z0-9][a-zA-Z0-9.\-+_]*$/;
+
+const TRACK_KINDS = new Set(["video", "audio"]);
+const TRACK_DIRECTIONS = new Set(["in", "out"]);
+
+function requireName(value: string, context: string, regex: RegExp): void {
+  if (typeof value !== "string" || !regex.test(value)) {
+    throw new Error(
+      `Invalid ${context}: ${JSON.stringify(value)} — must match ${regex}`,
+    );
+  }
+}
+
+/**
+ * Transform a raw OpenAPI schema into the normalised {@link ModelSchema}
+ * IR. Resolves `$ref` pointers against `#/components/schemas/*`, extracts
+ * events from `paths`, messages from `webhooks`, and tracks from the
+ * `x-reactor` extension.
+ *
+ * The returned IR is what every downstream codegen stage (emitter, CLI,
+ * tests) consumes — nothing else should touch the raw OpenAPI shape.
+ *
+ * Throws an `Error` with a pinpoint message on the first validation
+ * failure so bad schemas fail loudly at ingress rather than producing
+ * broken — or worse, attacker-controlled — TypeScript downstream.
+ */
+export function parseSchema(raw: OpenApiSchema): ModelSchema {
+  // Top-level identity — must round-trip cleanly into an npm package name
+  // (`@reactor-models/<title>`) and a TS class prefix (`<Title>Model`).
+  requireName(raw.info?.title, "info.title (model name)", MODEL_NAME_RE);
+  requireName(
+    raw.info?.version,
+    "info.version (model version)",
+    MODEL_VERSION_RE,
+  );
+  const components = raw.components?.schemas ?? {};
+
+  function refSchemaToFieldSchema(
+    resolved: OpenApiComponentSchemaObject,
+    original: OpenApiSchemaProperty,
+  ): FieldSchema {
+    return {
+      type: resolved.type ?? "object",
+      format: resolved.format,
+      description: resolved.description ?? original.description,
+      default: original.default,
+    };
+  }
+
+  function resolveProperty(prop: OpenApiSchemaProperty): FieldSchema {
+    if (prop.$ref) {
+      const refName = prop.$ref.replace("#/components/schemas/", "");
+      const resolved = components[refName];
+      if (!resolved) {
+        throw new Error(`Unresolved $ref: ${prop.$ref}`);
+      }
+      return refSchemaToFieldSchema(resolved, prop);
+    }
+    return {
+      type: prop.type ?? "unknown",
+      default: prop.default,
+      description: prop.description,
+      minimum: prop.minimum,
+      maximum: prop.maximum,
+      minLength: prop.minLength,
+      maxLength: prop.maxLength,
+      enum: prop.enum,
+      format: prop.format,
+    };
+  }
+
+  const events: EventSchema[] = [];
+  for (const [pathKey, pathItem] of Object.entries(raw.paths ?? {})) {
+    const op = pathItem.post;
+    if (!op) continue;
+
+    const name = op.operationId ?? pathKey.split("/").pop()!;
+    requireName(name, `event name (path "${pathKey}")`, TOKEN_NAME_RE);
+
+    const props =
+      op.requestBody?.content["application/json"]?.schema?.properties ?? {};
+
+    const fields: Record<string, FieldSchema> = {};
+    for (const [fieldName, fieldDef] of Object.entries(props)) {
+      requireName(fieldName, `field name on event "${name}"`, TOKEN_NAME_RE);
+      fields[fieldName] = resolveProperty(fieldDef);
+    }
+
+    events.push({
+      name,
+      description: op.summary ?? op.description ?? "",
+      fields,
+    });
+  }
+
+  const messages: MessageSchema[] = [];
+  for (const [hookName, hookItem] of Object.entries(raw.webhooks ?? {})) {
+    const op = hookItem.post;
+    if (!op) continue;
+
+    const name = op.operationId ?? hookName;
+    requireName(name, `message name (webhook "${hookName}")`, TOKEN_NAME_RE);
+
+    const props =
+      op.requestBody?.content["application/json"]?.schema?.properties ?? {};
+
+    const fields: Record<string, FieldSchema> = {};
+    for (const [fieldName, fieldDef] of Object.entries(props)) {
+      requireName(fieldName, `field name on message "${name}"`, TOKEN_NAME_RE);
+      fields[fieldName] = resolveProperty(fieldDef);
+    }
+
+    messages.push({
+      name,
+      description: op.summary ?? op.description ?? "",
+      fields,
+    });
+  }
+
+  const tracks: TrackSchema[] = (raw["x-reactor"]?.tracks ?? []).map((t) => {
+    requireName(t.name, `track name`, TOKEN_NAME_RE);
+    // `kind` and `direction` are TS-typed as string unions, but at runtime
+    // they come off a JSON blob with no enforcement, so the types don't
+    // mean anything until we check here.
+    if (!TRACK_KINDS.has(t.kind)) {
+      throw new Error(
+        `Invalid track "${t.name}" kind: ${JSON.stringify(t.kind)} — expected "video" or "audio"`,
+      );
+    }
+    if (!TRACK_DIRECTIONS.has(t.direction)) {
+      throw new Error(
+        `Invalid track "${t.name}" direction: ${JSON.stringify(t.direction)} — expected "in" or "out"`,
+      );
+    }
+    return { name: t.name, kind: t.kind, direction: t.direction };
+  });
+
+  return {
+    modelName: raw.info.title,
+    modelVersion: raw.info.version,
+    events,
+    messages,
+    tracks,
+  };
+}

--- a/packages/codegen/src/openapi/types.ts
+++ b/packages/codegen/src/openapi/types.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// ---------------------------------------------------------------------------
+// Raw OpenAPI 3.1 document types — the shapes we read from schema.json
+// ---------------------------------------------------------------------------
+
+export interface OpenApiInfo {
+  title: string;
+  version: string;
+  description?: string;
+}
+
+export interface OpenApiSchemaProperty {
+  type?: string;
+  default?: unknown;
+  description?: string;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  enum?: (string | number | boolean)[];
+  format?: string;
+  $ref?: string;
+}
+
+export interface OpenApiSchemaObject {
+  type: "object";
+  properties?: Record<string, OpenApiSchemaProperty>;
+  required?: string[];
+}
+
+export interface OpenApiRequestBody {
+  required?: boolean;
+  content: {
+    "application/json": {
+      schema: OpenApiSchemaObject;
+    };
+  };
+}
+
+export interface OpenApiOperation {
+  operationId: string;
+  summary?: string;
+  description?: string;
+  requestBody?: OpenApiRequestBody;
+  responses?: Record<string, unknown>;
+}
+
+export interface OpenApiPathItem {
+  post?: OpenApiOperation;
+}
+
+export interface ReactorTrackExtension {
+  name: string;
+  kind: "video" | "audio";
+  direction: "in" | "out";
+}
+
+export interface ReactorExtensions {
+  tracks?: ReactorTrackExtension[];
+}
+
+export interface OpenApiComponentSchemaObject {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchemaProperty>;
+  required?: string[];
+}
+
+export interface OpenApiComponents {
+  schemas?: Record<string, OpenApiComponentSchemaObject>;
+}
+
+export interface OpenApiSchema {
+  openapi: string;
+  info: OpenApiInfo;
+  "x-reactor"?: ReactorExtensions;
+  paths?: Record<string, OpenApiPathItem>;
+  webhooks?: Record<string, OpenApiPathItem>;
+  components?: OpenApiComponents;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
 
   packages/codegen:
     devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.19.37)
 
   packages/create-app:
     dependencies:


### PR DESCRIPTION
## Why

The emitter in PR 3 produces TypeScript that ships to npmjs.org; every schema string it sees becomes an identifier, a string literal, or a JSDoc body somewhere. A hostile or malformed coordinator payload must not be able to reach it. This PR introduces the OpenAPI reader and the ingress validation that draws that boundary.

## What changed

- `loadSchema(path)` reads + validates top-level shape (rejects docs without an `openapi` field).
- `parseSchema(raw)` normalises the raw document into the `ModelSchema` IR: `paths.*.post` → events, `webhooks.*.post` → messages, `x-reactor.tracks` → tracks.
- Resolves `$ref` pointers against `components.schemas` (notably `ReactorUploadReference` → `format: reactor-upload-reference`).
- Enforces identifier-shaped names on everything the emitter will interpolate.

## Ingress validation rules

| Field | Constraint | Purpose |
|---|---|---|
| `info.title` | `/^[a-z][a-z0-9_]*$/` | Valid npm scope segment + TS class prefix |
| `info.version` | `/^[a-zA-Z0-9][a-zA-Z0-9.\-+_]*$/` | No control chars, no quotes |
| Event / message / track / field names | `/^[a-zA-Z_][a-zA-Z0-9_]*$/` | Plain JS identifier |
| `track.kind` | `{"video","audio"}` | Runtime typecheck on a JSON value |
| `track.direction` | `{"in","out"}` | Runtime typecheck on a JSON value |

Each failure raises a pinpoint error with the offending value. Everything downstream can interpolate schema-sourced strings verbatim.

## Shape of the change

```
packages/codegen/
├── src/
│   ├── openapi/
│   │   ├── types.ts              (raw OpenAPI 3.1 interfaces)
│   │   ├── parser.ts             (loadSchema + parseSchema + validation)
│   │   └── index.ts              (barrel)
│   └── index.ts                  (+ loadSchema, parseSchema exports)
├── __tests__/
│   └── parser.test.ts            (26 tests)
└── package.json                  (+ vitest devDep)
```

## Tests

26 in `parser.test.ts`: load + parse happy paths, `$ref` resolution, empty-field passthrough, `operationId` / path-key fallback, track translation, end-to-end on the Helios fixture, plus 10 rejection tests (non-identifier names, control chars in version, injection chars in event / message / track names, bad `kind` / `direction`).

## Stack

1. [`[1/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/117) scaffold + IR
2. **→ this PR** parser + ingress validation
3. [`[3/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/119) emitter + README + injection defence + version helpers
4. [`[4/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/120) CLI + modelTracks + defaultSdkVersion
5. [`[5/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/121) coordinator fetch + auth exchange
6. [`[6/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/122) Buildkite publish pipeline

Ref: [REA-1581](https://linear.app/reactor-team/issue/REA-1581)
