### PR TITLE
[REA-1581][4/6] feat: reactor-codegen CLI, modelTracks, committed defaultSdkVersion

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -1,35 +1,336 @@
 # @reactor-team/codegen
 
-Code generator that turns a model's OpenAPI schema into a strongly-typed
-npm package (`@reactor-models/<name>`) wrapping `@reactor-team/js-sdk`.
+Code generator that turns a model's OpenAPI schema into a strongly-typed npm package (`@reactor-models/<name>`).
 
-> **Scaffolding stage.** This package currently contains only the IR
-> (intermediate representation) types and package plumbing. The parser,
-> emitter, and CLI are introduced in follow-up PRs on the same
-> [REA-1581](https://linear.app/reactor-team/issue/REA-1581) stack.
+## How it works
 
-## Intermediate representation
+```
+schema.json ──▶ codegen ──▶ @reactor-models/helios (npm package)
+                              ├── src/index.ts      (typed client)
+                              ├── package.json
+                              ├── tsconfig.json
+                              └── dist/             (built output)
+```
 
-All downstream stages consume a normalised `ModelSchema`, decoupled
-from the raw OpenAPI shape:
+The codegen reads a model's OpenAPI schema (events, messages, tracks) and produces a TypeScript package with:
 
-```ts
-import type { ModelSchema } from "@reactor-team/codegen";
+- **Typed event methods** — `setPrompt({ prompt: "..." })` instead of `sendCommand("set_prompt", { prompt: "..." })`
+- **Typed message listeners** — `onChunkComplete((msg) => msg.chunk_index)` with full autocomplete
+- **Per-message listener helpers** — `onPromptAccepted(handler)`, `onGenerationStarted(handler)`, etc.
+- **File upload passthrough** — `uploadFile()` exposed when any event uses upload references
+- **Track constants + fast-path opt-in** — `HeliosTracks` is passed to `Reactor` as `modelTracks`, unlocking parallel SDP preparation for faster first-frame latency
+- **JSDoc** from model descriptions, constraints, and defaults
 
-interface ModelSchema {
-  modelName: string;
-  modelVersion: string;
-  events: EventSchema[];
-  messages: MessageSchema[];
-  tracks: TrackSchema[];
+## CLI usage
+
+```bash
+reactor-codegen \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output ./out/helios
+```
+
+The model name and version are read directly from the schema's `info.title` and `info.version` fields.
+
+### Options
+
+| Flag                     | Required | Description                                                                                                                                                                          |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--schema <path>`        | Yes      | Path to the model's OpenAPI schema JSON                                                                                                                                              |
+| `--sdk-version <semver>` | No       | `@reactor-team/js-sdk` version to pin as a dependency. Defaults to the `defaultSdkVersion` field in this package's `package.json` when omitted                                       |
+| `--output <path>`        | Yes      | Output directory for the generated package, or a `.ts` file path when `--standalone`                                                                                                 |
+| `--standalone`           | No       | Emit only the typed source file (no `package.json` / `tsup.config.ts` / `tsconfig.json`). Drop-in use in an existing project; skips build                                            |
+| `--react`                | No       | Also emit a React entry point: `<Prefix>Provider`, `use<Prefix>()`, one hook per message. Full-package mode adds a `./react` subpath export; standalone writes a sibling `.react.ts` |
+| `--dry-run`              | No       | Print generated files to stdout without writing to disk                                                                                                                              |
+| `--no-build`             | No       | Skip `pnpm install` + `tsup` build (just generate source)                                                                                                                            |
+
+### Standalone mode
+
+Use `--standalone` when you want the typed client as a single `.ts` file inside an existing project — no separate npm package, no build step. `--output` becomes a file path (or a directory, in which case `index.ts` is written inside it):
+
+```bash
+# Drop a typed Helios client into an existing project's src/ folder.
+reactor-codegen \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output ./src/helios.ts \
+  --standalone
+```
+
+The emitted `.ts` file is byte-identical to the `src/index.ts` produced by the full-package mode — it still imports `Reactor` (and `FileRef` when needed) from `@reactor-team/js-sdk`, so make sure `@reactor-team/js-sdk` is already a dependency of the host project.
+
+### React output (`--react`)
+
+Pass `--react` to additionally emit a React entry point. In full-package mode this is published as a subpath export so non-React consumers never resolve a `react` import:
+
+```bash
+reactor-codegen \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output ./out/helios \
+  --react
+```
+
+Generated shape:
+
+| Mode                     | Files                                                                                          | Import path                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| full package + `--react` | `src/index.ts` + `src/react.ts` + package scaffold (with `./react` subpath + `react` peer dep) | `@reactor-models/<name>` / `@reactor-models/<name>/react`   |
+| `--standalone --react`   | `<base>.ts` + `<base>.react.ts` (no package scaffold)                                          | relative imports; the React file imports from `./<base>.js` |
+
+The React file declares `"use client"` (Next.js RSC compat), uses `React.createElement` (no JSX in the emitted file, so it stays `.ts`), and exposes:
+
+- **`<Prefix>Provider`** — wraps `ReactorProvider` with `modelName: MODEL_NAME` and `modelTracks: [...<Prefix>Tracks]` pre-configured. Accepts the same `jwtToken` / `connectOptions` props.
+- **`use<Prefix>()`** — typed commands bound to the nearest provider: one method per model event (camelCase) plus `status` and (when any event takes an upload reference) `uploadFile`.
+- **`use<Prefix>Message(handler)`** — typed catch-all over the discriminated union.
+- **`use<Prefix><PascalMessage>(handler)`** — one filtered hook per message type, handler receives the exact typed message.
+
+Usage in a host app:
+
+```tsx
+import {
+  HeliosProvider,
+  useHelios,
+  useHeliosChunkComplete,
+} from "@reactor-models/helios/react";
+
+function App({ jwtToken }: { jwtToken: string }) {
+  return (
+    <HeliosProvider jwtToken={jwtToken} connectOptions={{ autoConnect: true }}>
+      <Controller />
+    </HeliosProvider>
+  );
+}
+
+function Controller() {
+  const { setPrompt, start, status } = useHelios();
+  useHeliosChunkComplete((msg) => {
+    console.log(`chunk ${msg.chunk_index}: ${msg.frames_emitted} frames`);
+  });
+  return (
+    <button onClick={() => setPrompt({ prompt: "..." }).then(start)}>Go</button>
+  );
 }
 ```
 
-See `src/types.ts` for the full IR.
+The generated package gains `peerDependencies: { react: ">=18" }` only when `--react` is used. Without it, the output is fully framework-agnostic.
 
-## Fixture
+## Local development
 
-`schema.json` is a committed dummy OpenAPI document (model name `example`)
-used by parser and CLI tests in later PRs of the stack. It is intentionally
-minimal — just enough shape to exercise events with and without fields,
-webhooks with and without fields, and a single output track.
+```bash
+# Run codegen against the test schema (Helios)
+pnpm tsx src/cli.ts \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output .generated/helios
+
+# Dry-run to preview output without writing files
+pnpm tsx src/cli.ts \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output .generated/helios \
+  --dry-run
+
+# With React hooks (adds src/react.ts + ./react subpath export)
+pnpm tsx src/cli.ts \
+  --schema schema.json \
+  --sdk-version 2.9.1 \
+  --output .generated/helios \
+  --react
+
+# Or use the shorthand script
+pnpm codegen:test
+```
+
+Run the vitest suite (parser, emitter, and snapshot regression tests):
+
+```bash
+pnpm test            # one-shot
+pnpm test:watch      # watch mode
+```
+
+## Programmatic API
+
+The codegen can also be used as a library:
+
+```typescript
+import {
+  loadSchema,
+  parseSchema,
+  generateModelSdk,
+  writePackage,
+} from "@reactor-team/codegen";
+
+const rawSchema = loadSchema("schema.json");
+const schema = parseSchema(rawSchema);
+
+const pkg = generateModelSdk({
+  modelName: schema.modelName,
+  modelVersion: schema.modelVersion,
+  sdkVersion: "2.9.1",
+  schema,
+  outputDir: "./out/helios",
+});
+
+writePackage(pkg, "./out/helios");
+```
+
+## Generated package usage
+
+The output is a standard npm package that developers install and use:
+
+```typescript
+import { HeliosModel } from "@reactor-models/helios";
+
+const helios = new HeliosModel();
+await helios.connect(token);
+
+// Typed events — full autocomplete, type checking
+await helios.setPrompt({ prompt: "a sunset over the ocean" });
+await helios.setSrScale({ sr_scale: "2x" });
+await helios.start();
+
+// Typed message listeners — discriminated union
+const unsub = helios.onChunkComplete((msg) => {
+  console.log(`Chunk ${msg.chunk_index}: ${msg.frames_emitted} frames`);
+});
+
+// File uploads
+const ref = await helios.uploadFile(imageBlob);
+await helios.setImage({ image: ref });
+
+// Options (optional)
+const heliosLocal = new HeliosModel({ local: true });
+const heliosCustom = new HeliosModel({ apiUrl: "https://custom.api.com" });
+
+// Access the underlying Reactor instance for advanced use
+helios.reactor.on("statusChanged", (status) => {
+  /* ... */
+});
+```
+
+### Parallel SDP preparation
+
+When a model declares tracks in its OpenAPI schema, the generated client passes them to `new Reactor({ modelTracks: [...HeliosTracks] })`. This lets the SDK prepare the WebRTC offer in parallel with session polling — saving roughly one round-trip on `connect()`. No developer action required; the fast path is on by default whenever tracks are declared.
+
+The schema direction (`"in"`/`"out"`, model perspective) is translated to the transport direction (`"sendonly"`/`"recvonly"`, client perspective):
+
+| Schema direction                          | `modelTracks[*].direction` |
+| ----------------------------------------- | -------------------------- |
+| `"out"` (model produces, client receives) | `"recvonly"`               |
+| `"in"` (model consumes, client sends)     | `"sendonly"`               |
+
+## OpenAPI schema format
+
+The input is a standard OpenAPI 3.1 JSON document with Reactor extensions. The repo also ships a minimal `schema.json` fixture in this directory that the parser and CLI tests use; real models ship a richer schema via the coordinator's model registry.
+
+### Events (client → model)
+
+Events are defined as `POST` operations under `/events/{name}`:
+
+```json
+{
+  "paths": {
+    "/events/set_prompt": {
+      "post": {
+        "operationId": "set_prompt",
+        "summary": "Set and encode scene prompt",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": { "type": "string", "default": "" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Messages (model → client)
+
+Messages are defined as OpenAPI `webhooks`:
+
+```json
+{
+  "webhooks": {
+    "prompt_accepted": {
+      "post": {
+        "operationId": "prompt_accepted",
+        "summary": "A prompt was accepted and scheduled for encoding.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": { "type": "string" }
+                },
+                "required": ["prompt"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Tracks
+
+Tracks are declared in the `x-reactor` extension:
+
+```json
+{
+  "x-reactor": {
+    "tracks": [{ "name": "main_video", "kind": "video", "direction": "out" }]
+  }
+}
+```
+
+### Upload references (`$ref`)
+
+File upload parameters use a `$ref` to the `ReactorUploadReference` component schema:
+
+```json
+{
+  "image": {
+    "$ref": "#/components/schemas/ReactorUploadReference",
+    "default": null
+  }
+}
+```
+
+The component schema uses `"format": "reactor-upload-reference"` which the codegen maps to the SDK's `FileRef` type.
+
+### Supported field types
+
+| JSON Schema `type`                                     | TypeScript output                 |
+| ------------------------------------------------------ | --------------------------------- |
+| `"string"`                                             | `string`                          |
+| `"integer"`                                            | `number`                          |
+| `"number"`                                             | `number`                          |
+| `"boolean"`                                            | `boolean`                         |
+| `"object"` with `"format": "reactor-upload-reference"` | `FileRef`                         |
+| `"object"` (no format)                                 | `Record<string, unknown>`         |
+| Any type with `"enum"`                                 | Union literal (e.g. `"a" \| "b"`) |
+
+### Supported field constraints
+
+| JSON Schema field | JSDoc tag    |
+| ----------------- | ------------ |
+| `"minimum"`       | `@minimum`   |
+| `"maximum"`       | `@maximum`   |
+| `"minLength"`     | `@minLength` |
+| `"maxLength"`     | `@maxLength` |
+| `"default"`       | `@default`   |
+| `"description"`   | JSDoc body   |

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -1,0 +1,454 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+//
+// These tests exercise the CLI end-to-end as a black box: spawn the binary,
+// check its exit status, and inspect its filesystem side-effects. They do
+// NOT assert on stdout/stderr text — that output is for humans and we don't
+// want a test suite that churns every time we tweak a log line.
+// ---------------------------------------------------------------------------
+
+const CLI_PATH = path.join(__dirname, "..", "src", "cli.ts");
+const SCHEMA_PATH = path.join(__dirname, "..", "schema.json");
+
+function runCli(args: string[]): SpawnSyncReturns<string> {
+  return spawnSync("pnpm", ["tsx", CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, CI: "1" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing + error paths
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — argument validation", () => {
+  it("exits non-zero when no arguments are given", () => {
+    expect(runCli([]).status).not.toBe(0);
+  });
+
+  it("exits non-zero when only --schema is provided", () => {
+    expect(runCli(["--schema", SCHEMA_PATH]).status).not.toBe(0);
+  });
+
+  it("exits non-zero on an unknown option", () => {
+    expect(runCli(["--not-a-flag", "x"]).status).not.toBe(0);
+  });
+
+  it("exits non-zero on --help", () => {
+    expect(runCli(["--help"]).status).not.toBe(0);
+  });
+
+  it("falls back to defaultSdkVersion in package.json when --sdk-version is omitted", () => {
+    // The codegen's own package.json pins the team's current JS SDK support
+    // target in `defaultSdkVersion`. A CI invocation that doesn't explicitly
+    // pass `--sdk-version` should pick that up so periodic republish pipelines
+    // don't have to re-specify it on every run. The emitted package.json's
+    // `@reactor-team/js-sdk` dep is the observable proof that the default
+    // flowed through.
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+    try {
+      const result = runCli([
+        "--schema",
+        SCHEMA_PATH,
+        "--output",
+        path.join(outputDir, "example"),
+        "--no-build",
+      ]);
+
+      expect(result.status).toBe(0);
+      const pkgJson = JSON.parse(
+        fs.readFileSync(
+          path.join(outputDir, "example", "package.json"),
+          "utf-8",
+        ),
+      );
+      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.1");
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dry run — happy path, writes nothing
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — --dry-run", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exits 0 and writes nothing to disk", () => {
+    const outputDir = path.join(tmpDir, "example");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--dry-run",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputDir)).toBe(false);
+  });
+
+  it("exits non-zero when the schema file does not exist", () => {
+    const result = runCli([
+      "--schema",
+      path.join(tmpDir, "missing.json"),
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      path.join(tmpDir, "out"),
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-build write — actually emits files to disk
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — --no-build write", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes the expected files and exits 0", () => {
+    const outputDir = path.join(tmpDir, "example");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--no-build",
+    ]);
+
+    expect(result.status).toBe(0);
+
+    const expected = [
+      "src/index.ts",
+      "package.json",
+      "tsup.config.ts",
+      "tsconfig.json",
+      "README.md",
+    ];
+    for (const rel of expected) {
+      expect(fs.existsSync(path.join(outputDir, rel))).toBe(true);
+    }
+
+    // The generated client must wire `modelTracks` (the committed dummy
+    // fixture declares one track) — this is the user-visible contract for PR 4.
+    const src = fs.readFileSync(path.join(outputDir, "src/index.ts"), "utf-8");
+    expect(src).toContain("modelTracks: [...ExampleTracks]");
+    expect(src).toContain("ExampleTracks = [");
+    expect(src).toContain('direction: "recvonly"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --standalone — emit only the typed source file (drop-in use in existing
+// projects). No package.json / tsup.config.ts / tsconfig.json.
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — --standalone", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a single .ts file at the explicit --output file path", () => {
+    const outputFile = path.join(tmpDir, "existing-project", "example.ts");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputFile,
+      "--standalone",
+    ]);
+
+    expect(result.status).toBe(0);
+
+    // Exactly the one .ts file, no package scaffold.
+    expect(fs.existsSync(outputFile)).toBe(true);
+    const siblings = fs.readdirSync(path.dirname(outputFile));
+    expect(siblings).toEqual(["example.ts"]);
+
+    const src = fs.readFileSync(outputFile, "utf-8");
+    expect(src).toContain("import { Reactor");
+    expect(src).toContain("export class ExampleModel");
+    expect(src).toContain("modelTracks: [...ExampleTracks]");
+    // Source must be identical to what the full-package mode would emit —
+    // standalone must never diverge from the package scaffold's src/index.ts.
+    expect(src).toContain(
+      "// Auto-generated by @reactor-team/codegen — DO NOT EDIT",
+    );
+  });
+
+  it("treats a non-.ts --output as a directory and writes index.ts inside it", () => {
+    const outputDir = path.join(tmpDir, "src");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--standalone",
+    ]);
+
+    expect(result.status).toBe(0);
+    const expectedFile = path.join(outputDir, "index.ts");
+    expect(fs.existsSync(expectedFile)).toBe(true);
+    expect(fs.readdirSync(outputDir)).toEqual(["index.ts"]);
+  });
+
+  it("in --dry-run writes nothing and exits 0", () => {
+    const outputFile = path.join(tmpDir, "example.ts");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputFile,
+      "--standalone",
+      "--dry-run",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --react — emit provider + hooks (full-package mode)
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — --react (full package)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("emits src/react.ts, re-exports it from src/index.ts, and keeps one root export", () => {
+    const outputDir = path.join(tmpDir, "example");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--no-build",
+      "--react",
+    ]);
+
+    expect(result.status).toBe(0);
+
+    for (const rel of [
+      "src/index.ts",
+      "src/react.ts",
+      "package.json",
+      "tsup.config.ts",
+      "tsconfig.json",
+      "README.md",
+    ]) {
+      expect(fs.existsSync(path.join(outputDir, rel))).toBe(true);
+    }
+
+    // Provider + hooks live in src/react.ts (not duplicated in
+    // src/index.ts), and src/index.ts re-exports them so the public
+    // surface is a single root import.
+    const index = fs.readFileSync(
+      path.join(outputDir, "src/index.ts"),
+      "utf-8",
+    );
+    const react = fs.readFileSync(
+      path.join(outputDir, "src/react.ts"),
+      "utf-8",
+    );
+    expect(index).toContain('"use client";');
+    expect(index).toContain('export * from "./react.js";');
+    expect(index).not.toContain("export function ExampleProvider(");
+    expect(react).toContain("export function ExampleProvider(");
+    expect(react).toContain("export function useExample()");
+    expect(react).toContain("export function useExampleMessage(");
+
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "package.json"), "utf-8"),
+    );
+    // Exactly one export path — no `./react` subpath, ever.
+    expect(Object.keys(pkgJson.exports)).toEqual(["."]);
+    expect(pkgJson.peerDependencies).toEqual({ react: ">=18" });
+
+    const tsup = fs.readFileSync(
+      path.join(outputDir, "tsup.config.ts"),
+      "utf-8",
+    );
+    expect(tsup).toContain('entry: ["src/index.ts"]');
+    expect(tsup).not.toContain("src/react.ts");
+  });
+
+  it("--dry-run exits 0 and writes nothing", () => {
+    const outputDir = path.join(tmpDir, "example");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--react",
+      "--dry-run",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputDir)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --standalone + --react — sibling .react.ts file + re-export in the main file
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — --standalone --react", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes <base>.ts + <base>.react.ts and wires up the cross-imports", () => {
+    const outputFile = path.join(tmpDir, "src", "example.ts");
+    const reactFile = path.join(tmpDir, "src", "example.react.ts");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputFile,
+      "--standalone",
+      "--react",
+    ]);
+
+    expect(result.status).toBe(0);
+
+    expect(fs.existsSync(outputFile)).toBe(true);
+    expect(fs.existsSync(reactFile)).toBe(true);
+    expect(fs.readdirSync(path.dirname(outputFile)).sort()).toEqual([
+      "example.react.ts",
+      "example.ts",
+    ]);
+
+    const main = fs.readFileSync(outputFile, "utf-8");
+    const react = fs.readFileSync(reactFile, "utf-8");
+
+    // Main file: re-export points at the chosen sibling basename, not
+    // the full-package default `./react.js`.
+    expect(main).toContain('"use client";');
+    expect(main).toContain('export * from "./example.react.js";');
+    expect(main).not.toContain('export * from "./react.js";');
+    // Main file still has the plain-JS surface.
+    expect(main).toContain("export class ExampleModel");
+    expect(main).not.toContain("export function ExampleProvider(");
+
+    // React file: imports back from the chosen main basename.
+    expect(react).toContain('from "./example.js"');
+    expect(react).not.toContain('from "./index.js"');
+    expect(react).toContain("export function ExampleProvider(");
+    expect(react).toContain("export function useExample()");
+  });
+
+  it("with --output as a directory, writes index.ts + index.react.ts", () => {
+    const outputDir = path.join(tmpDir, "src");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputDir,
+      "--standalone",
+      "--react",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.readdirSync(outputDir).sort()).toEqual([
+      "index.react.ts",
+      "index.ts",
+    ]);
+    const main = fs.readFileSync(path.join(outputDir, "index.ts"), "utf-8");
+    const react = fs.readFileSync(
+      path.join(outputDir, "index.react.ts"),
+      "utf-8",
+    );
+    // Main basename is still `index`, so the React file's back-import
+    // (`./index.js`) passes through unchanged. The sibling basename is
+    // `index.react`, so the main file's re-export gets rewritten from
+    // the emitter default `./react.js` to `./index.react.js`.
+    expect(main).toContain('export * from "./index.react.js";');
+    expect(react).toContain('from "./index.js"');
+  });
+
+  it("in --dry-run writes nothing and exits 0", () => {
+    const outputFile = path.join(tmpDir, "example.ts");
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      outputFile,
+      "--standalone",
+      "--react",
+      "--dry-run",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBe(false);
+  });
+});

--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -375,17 +375,41 @@ describe("generateTrackConstants", () => {
     expect(generateTrackConstants("Helios", [])).toBe("");
   });
 
-  it("emits an `as const` object keyed by uppercased track name", () => {
+  it("emits a const array of SDK-shape track hints", () => {
     const tracks: TrackSchema[] = [
       { name: "main_video", kind: "video", direction: "out" },
     ];
     const out = generateTrackConstants("Helios", tracks);
 
-    expect(out).toContain("export const HeliosTracks = {");
+    expect(out).toContain("export const HeliosTracks = [");
     expect(out).toContain(
-      'MAIN_VIDEO: { name: "main_video", kind: "video", direction: "out" },',
+      '{ name: "main_video", kind: "video", direction: "recvonly" },',
     );
-    expect(out).toContain("} as const;");
+    expect(out).toContain("] as const;");
+  });
+
+  it("translates schema directions to transport directions", () => {
+    // Model perspective ("out" = model produces) → client perspective
+    // ("recvonly" = client receives).
+    const out = generateTrackConstants("Helios", [
+      { name: "main_video", kind: "video", direction: "out" },
+      { name: "webcam", kind: "video", direction: "in" },
+      { name: "mic", kind: "audio", direction: "in" },
+    ]);
+
+    expect(out).toContain(
+      '{ name: "main_video", kind: "video", direction: "recvonly" },',
+    );
+    expect(out).toContain(
+      '{ name: "webcam", kind: "video", direction: "sendonly" },',
+    );
+    expect(out).toContain(
+      '{ name: "mic", kind: "audio", direction: "sendonly" },',
+    );
+    // Never leak the schema-side "in"/"out" values into the generated
+    // constant — they are not valid `modelTracks[*].direction` values.
+    expect(out).not.toMatch(/direction: "in"/);
+    expect(out).not.toMatch(/direction: "out"/);
   });
 });
 
@@ -641,6 +665,40 @@ describe("generateModelSdk", () => {
     const readme = pkg.files.find((f) => f.path === "README.md")!.content;
     expect(readme).not.toContain("g404f6950");
     expect(readme).toContain("Version **v0.8.3**");
+  });
+
+  it("wires `modelTracks: [...<Prefix>Tracks]` when tracks are declared", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema({
+        tracks: [{ name: "main_video", kind: "video", direction: "out" }],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).toContain("modelTracks: [...HeliosTracks]");
+    expect(src).toContain("export const HeliosTracks = [");
+    expect(src).toContain('direction: "recvonly"');
+  });
+
+  it("omits modelTracks entirely when the schema has no tracks", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(src).not.toContain("modelTracks");
+    expect(src).not.toContain("HeliosTracks");
+    expect(src).toContain(
+      "this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });",
+    );
   });
 
   it("is deterministic for a given input (same output twice)", () => {
@@ -1138,6 +1196,217 @@ describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Typed track helpers (REA-1791).
+//
+// Until this feature, generated SDKs typed commands and messages but
+// left media-track wiring to string literals on the base SDK. These
+// tests pin down the new surface:
+//   - `<Prefix>SendTrackName` / `<Prefix>RecvTrackName` unions.
+//   - `publish<Name>` / `unpublish<Name>` per sendonly track.
+//   - `on<Name>` per recvonly track.
+//   - `use<Prefix>Track(name)` hook (recvonly only).
+//   - `<<Prefix><Track>View>` per video track in each direction.
+// ---------------------------------------------------------------------------
+
+describe("emitter — typed track helpers (REA-1791)", () => {
+  function pkgWith(
+    tracks: TrackSchema[],
+    react = false,
+  ): ReturnType<typeof generateModelSdk> {
+    return generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: {
+        modelName: "helios",
+        modelVersion: "0.1.0",
+        events: [],
+        messages: [],
+        tracks,
+      },
+      outputDir: "/tmp/ignored",
+      react,
+    });
+  }
+
+  function sourceOf(
+    tracks: TrackSchema[],
+    react = false,
+  ): { index: string; react?: string } {
+    const pkg = pkgWith(tracks, react);
+    const index = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const reactFile = react
+      ? pkg.files.find((f) => f.path === "src/react.ts")!.content
+      : undefined;
+    return { index, react: reactFile };
+  }
+
+  // ---- Type-level: name unions -----------------------------------------
+
+  it("emits `<Prefix>SendTrackName` / `<Prefix>RecvTrackName` string-literal unions per direction", () => {
+    const { index } = sourceOf([
+      { name: "webcam", kind: "video", direction: "in" },
+      { name: "mic", kind: "audio", direction: "in" },
+      { name: "main_video", kind: "video", direction: "out" },
+    ]);
+    expect(index).toContain(
+      'export type HeliosSendTrackName =\n  "webcam"\n  | "mic";',
+    );
+    expect(index).toContain(
+      'export type HeliosRecvTrackName =\n  "main_video";',
+    );
+  });
+
+  it("omits a direction's union when the schema has no tracks on that side (no `never` unions)", () => {
+    const { index: recvOnly } = sourceOf([
+      { name: "main_video", kind: "video", direction: "out" },
+    ]);
+    expect(recvOnly).toContain("export type HeliosRecvTrackName");
+    expect(recvOnly).not.toContain("HeliosSendTrackName");
+
+    const { index: sendOnly } = sourceOf([
+      { name: "webcam", kind: "video", direction: "in" },
+    ]);
+    expect(sendOnly).toContain("export type HeliosSendTrackName");
+    expect(sendOnly).not.toContain("HeliosRecvTrackName");
+  });
+
+  // ---- Class methods ---------------------------------------------------
+
+  it("emits `publish<Name>` / `unpublish<Name>` pair per sendonly track", () => {
+    const { index } = sourceOf([
+      { name: "webcam", kind: "video", direction: "in" },
+    ]);
+    expect(index).toContain("async publishWebcam(track: MediaStreamTrack)");
+    expect(index).toContain(
+      'await this.reactor.publishTrack("webcam", track);',
+    );
+    expect(index).toContain("async unpublishWebcam(): Promise<void>");
+    expect(index).toContain('await this.reactor.unpublishTrack("webcam");');
+  });
+
+  it("emits an `on<Name>` subscription per recvonly track, filtering by name internally", () => {
+    const { index } = sourceOf([
+      { name: "main_video", kind: "video", direction: "out" },
+    ]);
+    expect(index).toContain("onMainVideo(");
+    expect(index).toContain(
+      "const wrapped = (name: string, t: MediaStreamTrack, s: MediaStream) => {",
+    );
+    expect(index).toContain('if (name === "main_video") handler(t, s);');
+    expect(index).toContain('this.reactor.on("trackReceived", wrapped);');
+    expect(index).toContain(
+      'return () => this.reactor.off("trackReceived", wrapped);',
+    );
+  });
+
+  it("does not emit any track methods when the schema has no tracks", () => {
+    const { index } = sourceOf([]);
+    expect(index).not.toContain("publishTrack");
+    expect(index).not.toContain("unpublishTrack");
+    expect(index).not.toContain('this.reactor.on("trackReceived"');
+  });
+
+  // ---- React hook ------------------------------------------------------
+
+  it("emits `use<Prefix>Track(name)` only when the schema has at least one recvonly track", () => {
+    const { react: withRecv } = sourceOf(
+      [{ name: "main_video", kind: "video", direction: "out" }],
+      true,
+    );
+    expect(withRecv).toContain("export function useHeliosTrack(");
+    expect(withRecv).toContain("name: HeliosRecvTrackName,");
+    expect(withRecv).toContain("return useReactor((s) => s.tracks[name]);");
+    // The hook is typed on `HeliosRecvTrackName`, so the type has to be imported.
+    expect(withRecv).toContain("type HeliosRecvTrackName");
+
+    const { react: sendOnly } = sourceOf(
+      [{ name: "webcam", kind: "video", direction: "in" }],
+      true,
+    );
+    expect(sendOnly).not.toContain("useHeliosTrack");
+    expect(sendOnly).not.toContain("HeliosRecvTrackName");
+  });
+
+  // ---- React components ------------------------------------------------
+
+  it("emits one `<Prefix><Track>View>` wrapper component per video track, regardless of direction", () => {
+    const { react } = sourceOf(
+      [
+        { name: "main_video", kind: "video", direction: "out" },
+        { name: "webcam", kind: "video", direction: "in" },
+      ],
+      true,
+    );
+    expect(react).toContain("export function HeliosMainVideoView(");
+    expect(react).toContain('track: "main_video"');
+    expect(react).toContain(
+      'export interface HeliosMainVideoViewProps extends Omit<ReactorViewProps, "track"> {}',
+    );
+    expect(react).toContain("export function HeliosWebcamView(");
+    expect(react).toContain('track: "webcam"');
+    expect(react).toContain(
+      'export interface HeliosWebcamViewProps extends Omit<WebcamStreamProps, "track"> {}',
+    );
+  });
+
+  it("pulls ReactorView / WebcamStream (and their props types) from the SDK only when needed", () => {
+    const { react: bothKinds } = sourceOf(
+      [
+        { name: "main_video", kind: "video", direction: "out" },
+        { name: "webcam", kind: "video", direction: "in" },
+      ],
+      true,
+    );
+    expect(bothKinds).toContain("ReactorView");
+    expect(bothKinds).toContain("type ReactorViewProps");
+    expect(bothKinds).toContain("WebcamStream");
+    expect(bothKinds).toContain("type WebcamStreamProps");
+
+    const { react: recvOnly } = sourceOf(
+      [{ name: "main_video", kind: "video", direction: "out" }],
+      true,
+    );
+    expect(recvOnly).toContain("ReactorView");
+    expect(recvOnly).not.toContain("WebcamStream");
+
+    const { react: empty } = sourceOf([], true);
+    expect(empty).not.toContain("ReactorView");
+    expect(empty).not.toContain("WebcamStream");
+  });
+
+  it("skips view components for audio-only tracks (SDK has no audio-only component today)", () => {
+    const { react } = sourceOf(
+      [
+        { name: "mic", kind: "audio", direction: "in" },
+        { name: "main_audio", kind: "audio", direction: "out" },
+      ],
+      true,
+    );
+    // No component imports or definitions referencing these tracks.
+    expect(react).not.toContain("HeliosMicView");
+    expect(react).not.toContain("HeliosMainAudioView");
+    // But the typed hook still exists for audio recvonly tracks — just no component.
+    expect(react).toContain("useHeliosTrack");
+  });
+
+  // ---- Multi-track schemas ---------------------------------------------
+
+  it("emits one publish/on pair per track for multi-track schemas (no naming collision)", () => {
+    const { index } = sourceOf([
+      { name: "webcam", kind: "video", direction: "in" },
+      { name: "screen_share", kind: "video", direction: "in" },
+      { name: "main_video", kind: "video", direction: "out" },
+      { name: "overlay_video", kind: "video", direction: "out" },
+    ]);
+    expect(index).toContain("publishWebcam");
+    expect(index).toContain("publishScreenShare");
+    expect(index).toContain("onMainVideo");
+    expect(index).toContain("onOverlayVideo");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Injection-defence: emitter never trusts IR strings.
 //
 // The parser rejects hostile names at ingress, but the emitter is a
@@ -1284,5 +1553,36 @@ describe("emitter — injection defence (defense in depth)", () => {
     // appear at column 0 of any emitted line.
     expect(src).toContain("first line import 'http://attacker/'");
     expect(src).not.toMatch(/^import 'http:\/\/attacker\/'$/m);
+  });
+
+  it("escapes a hostile track name inside the <Prefix>Tracks constant", () => {
+    // Track-constant emission is re-authored in PR 4 (the schema→transport
+    // direction translation). The escaping has to live on the PR 4 line,
+    // not PR 3's, or the rebase would drop it. This test pins that the
+    // hardening survives the rewrite.
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: hostileBase({
+        tracks: [
+          {
+            name: 'main_video"; evil()',
+            kind: "video",
+            direction: "out",
+          },
+        ],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+
+    expect(src).toContain('name: "main_video\\"; evil()"');
+    expect(src).not.toMatch(/name: "main_video"; evil\(\)"/);
+    // kind / direction come from a closed set but are also routed through
+    // JSON.stringify for consistency — the emitted literal must still be
+    // the expected clean form for well-formed tracks.
+    expect(src).toContain('kind: "video"');
+    expect(src).toContain('direction: "recvonly"');
   });
 });

--- a/packages/codegen/__tests__/readme-emitter.test.ts
+++ b/packages/codegen/__tests__/readme-emitter.test.ts
@@ -172,16 +172,37 @@ describe("README emission", () => {
     expect(md).not.toContain('`"off" | "2x" | "4x"`');
   });
 
-  it("renders a tracks table with the schema → transport direction map", () => {
+  it("renders a user-facing section per track with JS + React usage examples (REA-1791)", () => {
     const md = readmeFor({
       tracks: [
         { name: "main_video", kind: "video", direction: "out" as const },
         { name: "webcam", kind: "video", direction: "in" as const },
       ],
     });
+
     expect(md).toContain("## Tracks");
-    expect(md).toContain("| `main_video` | video | out | `recvonly` |");
-    expect(md).toContain("| `webcam` | video | in | `sendonly` |");
+
+    // One `### <name>` heading per track, matching the Events/Messages layout.
+    expect(md).toContain("### `main_video`");
+    expect(md).toContain("### `webcam`");
+
+    // Recvonly track: JS uses `on<Track>`, React shows the wrapper component.
+    expect(md).toContain("helios.onMainVideo((track, stream)");
+    expect(md).toContain("import { HeliosMainVideoView }");
+    expect(md).toContain("<HeliosMainVideoView");
+
+    // Sendonly track: JS uses `publish<Track>`, React shows the publisher component.
+    expect(md).toContain("await helios.publishWebcam(");
+    expect(md).toContain("await helios.unpublishWebcam(");
+    expect(md).toContain("import { HeliosWebcamView }");
+    expect(md).toContain("<HeliosWebcamView");
+
+    // Docs must NOT leak internals — the README is a product surface.
+    // The previous version dumped `modelTracks`, "parallel SDP", etc.;
+    // those now live in the package's code comments, not in user docs.
+    expect(md).not.toMatch(/modelTracks/);
+    expect(md).not.toMatch(/SDP/);
+    expect(md).not.toMatch(/parallel with session/);
   });
 
   it("cross-links backticked message names in event descriptions", () => {

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "bin": {
+    "reactor-codegen": "dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -21,18 +24,21 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.1 --output .generated/example"
   },
   "keywords": [
     "reactor",
     "codegen",
     "sdk"
   ],
+  "defaultSdkVersion": "2.9.1",
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsup": "^8.5.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.8.3",
     "vitest": "^3.0.0"
   }

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import {
+  loadSchema,
+  parseSchema,
+  generateModelSdk,
+  writePackage,
+} from "./codegen.js";
+
+interface CliArgs {
+  schema: string;
+  sdkVersion: string;
+  output: string;
+  dryRun: boolean;
+  build: boolean;
+  standalone: boolean;
+  react: boolean;
+}
+
+/**
+ * Read `defaultSdkVersion` out of the codegen's own `package.json`. We
+ * use this as the fallback for `--sdk-version` so CI pipelines (and the
+ * typical developer run) don't have to pin a version manually — the
+ * codegen itself ships with whatever the team has committed as the
+ * current support target.
+ *
+ * Kept deliberately defensive: if the file or field ever disappears we
+ * return `undefined` and let `parseArgs` surface a clear "missing
+ * required arg" error, rather than silently generating a package
+ * pointing at the wrong SDK major.
+ */
+function readDefaultSdkVersion(): string | undefined {
+  try {
+    // tsup inlines CLI source to dist/cli.js (CJS), so __dirname is the
+    // dist folder in production and src/ in `tsx` dev mode. The
+    // package.json lives one level up either way.
+    const pkgPath = path.resolve(__dirname, "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    const v = pkg.defaultSdkVersion;
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const DEFAULT_SDK_VERSION = readDefaultSdkVersion();
+
+function usage(): never {
+  console.error(`
+Usage: reactor-codegen [options]
+
+Options:
+  --schema <path>             Path to the model's OpenAPI schema JSON
+  --sdk-version <semver>      JS SDK version to pin as a dependency.
+                              Defaults to the \`defaultSdkVersion\` field in
+                              @reactor-team/codegen's package.json${
+                                DEFAULT_SDK_VERSION
+                                  ? ` (currently ${DEFAULT_SDK_VERSION})`
+                                  : ""
+                              }.
+  --output <path>             Output path — a directory for the generated
+                              package, or a .ts file path when --standalone
+  --standalone                Emit only the typed source file (no
+                              package.json / tsup.config.ts / tsconfig.json).
+                              Intended for drop-in use in an existing
+                              project; implies --no-build.
+  --react                     Emit a React provider, a typed use<Prefix>()
+                              hook, and one hook per message in src/react.ts.
+                              src/index.ts re-exports them, so consumers
+                              import everything from the package root with
+                              no subpath. Adds a \`react\` peer dependency
+                              in full-package mode.
+  --dry-run                   Print generated files without writing to disk
+  --no-build                  Skip the build step (just generate source)
+`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Partial<CliArgs> = {
+    dryRun: false,
+    build: true,
+    standalone: false,
+    react: false,
+    // Start with the committed default so invocations that don't pin a
+    // specific SDK get the team's current support target. An explicit
+    // `--sdk-version` on the command line overwrites this below.
+    sdkVersion: DEFAULT_SDK_VERSION,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--schema":
+        args.schema = argv[++i];
+        break;
+      case "--sdk-version":
+        args.sdkVersion = argv[++i];
+        break;
+      case "--output":
+        args.output = argv[++i];
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--no-build":
+        args.build = false;
+        break;
+      case "--standalone":
+        args.standalone = true;
+        break;
+      case "--react":
+        args.react = true;
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        break;
+      default:
+        console.error(`Unknown option: ${argv[i]}`);
+        usage();
+    }
+  }
+
+  // `sdkVersion` is optional on the CLI: if the user didn't pass one and
+  // the codegen's package.json default is also missing, only then fail.
+  // This keeps "no flag on the command line" the happy path for CI while
+  // still catching a misconfigured install.
+  if (!args.schema || !args.output || !args.sdkVersion) {
+    console.error("Error: missing required arguments.\n");
+    usage();
+  }
+
+  // Standalone output is a single source file — nothing to build.
+  if (args.standalone) {
+    args.build = false;
+  }
+
+  return args as CliArgs;
+}
+
+function run(cmd: string, cwd: string): void {
+  console.log(`  $ ${cmd}`);
+  execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+function buildPackage(outputDir: string): void {
+  console.log("\nBuilding generated package...");
+  run("pnpm install --ignore-workspace --no-frozen-lockfile", outputDir);
+  run("pnpm build", outputDir);
+  console.log("\nBuild complete.");
+}
+
+/**
+ * Resolve the `--output` path for `--standalone` mode. If the caller
+ * passed a `.ts` file we use it verbatim; otherwise we treat the path
+ * as a directory and drop `index.ts` inside it. This matches the shape
+ * developers expect when pointing `--output` at an existing source tree
+ * (e.g. `--output ./src` → `./src/index.ts`).
+ */
+function resolveStandaloneOutputPath(output: string): string {
+  return output.endsWith(".ts") ? output : path.join(output, "index.ts");
+}
+
+/**
+ * Given the resolved standalone `.ts` output path, derive the sibling
+ * React file path by inserting `.react` before the `.ts` extension.
+ * `./src/helios.ts` → `./src/helios.react.ts`
+ * `./src/index.ts` → `./src/index.react.ts`
+ *
+ * The emitter's React file imports from `./index.js` and the main file
+ * re-exports from `./react.js` (both emitter defaults, used for the
+ * full-package layout). In standalone mode the filenames won't always
+ * be `index` / `react`, so we rewrite both sides of the pair to point
+ * at the chosen basenames — see main().
+ */
+function resolveStandaloneReactPath(standaloneOutput: string): string {
+  return standaloneOutput.replace(/\.ts$/, ".react.ts");
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+
+  const rawSchema = loadSchema(args.schema);
+  const schema = parseSchema(rawSchema);
+
+  console.log(`@reactor-team/codegen`);
+  console.log(`  Model:    ${schema.modelName}@${schema.modelVersion}`);
+  console.log(`  SDK pin:  @reactor-team/js-sdk@^${args.sdkVersion}`);
+  console.log(`  Schema:   ${args.schema}`);
+  console.log(`  Output:   ${args.output}`);
+  if (args.standalone) {
+    console.log(`  Mode:     standalone (source-only, no package scaffold)`);
+  }
+  if (args.react) {
+    console.log(`  React:    on (provider + hooks)`);
+  }
+  console.log();
+  console.log(`  Events:   ${schema.events.length}`);
+  console.log(`  Messages: ${schema.messages.length}`);
+  console.log(`  Tracks:   ${schema.tracks.length}`);
+  console.log();
+
+  const pkg = generateModelSdk({
+    modelName: schema.modelName,
+    modelVersion: schema.modelVersion,
+    sdkVersion: args.sdkVersion,
+    schema,
+    outputDir: args.output,
+    react: args.react,
+  });
+
+  if (args.standalone) {
+    // Standalone mode is intentionally narrow: pluck only the source files
+    // off the generated package and drop them at --output. Skipping the
+    // package scaffold (package.json, tsup.config.ts, tsconfig.json) keeps
+    // the emitter as the single source of truth for what a typed client
+    // looks like — we never diverge the "drop-in .ts" from the "full
+    // package" output.
+    //
+    // With --react we also emit the sibling React file. The emitter's
+    // default cross-imports use the full-package filenames
+    // (`./index.js`, `./react.js`); in standalone mode the chosen
+    // basename can be anything, so both sides of the pair are rewritten
+    // to the sibling's actual basename before writing.
+    const indexFile = pkg.files.find((f) => f.path === "src/index.ts");
+    if (!indexFile) {
+      // Defensive: the emitter always emits src/index.ts first; if that
+      // ever changes, fail loudly rather than silently write an empty file.
+      throw new Error(
+        "Internal error: generated package is missing src/index.ts",
+      );
+    }
+
+    const outputFile = path.resolve(resolveStandaloneOutputPath(args.output));
+    const reactFile = args.react
+      ? pkg.files.find((f) => f.path === "src/react.ts")
+      : undefined;
+    const reactOutputFile = args.react
+      ? resolveStandaloneReactPath(outputFile)
+      : undefined;
+    const mainBasename = path.basename(outputFile).replace(/\.ts$/, "");
+    const reactBasename = reactOutputFile
+      ? path.basename(reactOutputFile).replace(/\.ts$/, "")
+      : undefined;
+    // `resolveStandaloneReactPath` always produces `<main>.react.ts`,
+    // so in standalone mode the sibling's basename is never literally
+    // `react` — we can unconditionally rewrite the main file's
+    // re-export path. The React-side back-import (`./index.js`) only
+    // needs rewriting when the main basename isn't already `index`.
+    const indexContent =
+      args.react && reactBasename
+        ? indexFile.content.replace(
+            /export \* from "\.\/react\.js";/g,
+            `export * from "./${reactBasename}.js";`,
+          )
+        : indexFile.content;
+    const reactContent =
+      reactFile && mainBasename !== "index"
+        ? reactFile.content.replace(
+            /from "\.\/index\.js"/g,
+            `from "./${mainBasename}.js"`,
+          )
+        : reactFile?.content;
+
+    if (args.dryRun) {
+      console.log(`--- ${outputFile} ---`);
+      console.log(indexContent);
+      console.log();
+      if (reactContent && reactOutputFile) {
+        console.log(`--- ${reactOutputFile} ---`);
+        console.log(reactContent);
+        console.log();
+      }
+      console.log("(dry run — no files written)");
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+    fs.writeFileSync(outputFile, indexContent, "utf-8");
+    console.log(`Generated standalone source at ${outputFile}`);
+    if (reactContent && reactOutputFile) {
+      fs.writeFileSync(reactOutputFile, reactContent, "utf-8");
+      console.log(`Generated standalone React hooks at ${reactOutputFile}`);
+    }
+    console.log();
+    console.log(`Next steps:`);
+    console.log(
+      `  Ensure @reactor-team/js-sdk@^${args.sdkVersion} is installed in your project`,
+    );
+    if (args.react) {
+      console.log(
+        `  react >=18 is required (the hooks file imports from "react")`,
+      );
+    }
+    console.log(
+      `  Import the Model class` +
+        (args.react ? ", Provider, and hooks " : " ") +
+        `from ${outputFile}` +
+        (args.react ? " — the main file re-exports the React bindings" : ""),
+    );
+    return;
+  }
+
+  if (args.dryRun) {
+    for (const file of pkg.files) {
+      console.log(`--- ${file.path} ---`);
+      console.log(file.content);
+      console.log();
+    }
+    console.log("(dry run — no files written)");
+    return;
+  }
+
+  const outputDir = path.resolve(args.output);
+  writePackage(pkg, outputDir);
+
+  console.log(`Generated ${pkg.files.length} files in ${outputDir}`);
+  for (const file of pkg.files) {
+    console.log(`  ${file.path}`);
+  }
+
+  if (args.build) {
+    buildPackage(outputDir);
+  } else {
+    console.log();
+    console.log(`Next steps:`);
+    console.log(`  cd ${args.output}`);
+    console.log(`  pnpm install`);
+    console.log(`  pnpm build`);
+  }
+}
+
+main();

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -312,6 +312,20 @@ function generateMessageUnion(
 // Track constants
 // ---------------------------------------------------------------------------
 
+/**
+ * The schema expresses track direction from the model's perspective
+ * (`"in"` = model consumes, `"out"` = model produces). The JS SDK's
+ * {@link Reactor} constructor accepts the transport / client
+ * perspective via `modelTracks[*].direction` — `"sendonly"` when the
+ * client sends media into the model, `"recvonly"` when the client
+ * receives media from it.
+ */
+function schemaDirectionToTransport(
+  direction: TrackSchema["direction"],
+): "sendonly" | "recvonly" {
+  return direction === "in" ? "sendonly" : "recvonly";
+}
+
 function generateTrackConstants(
   modelPrefix: string,
   tracks: TrackSchema[],
@@ -319,15 +333,91 @@ function generateTrackConstants(
   if (tracks.length === 0) return "";
 
   const lines: string[] = [];
-  lines.push(`export const ${modelPrefix}Tracks = {`);
+  const doc = generateJsDoc(
+    [
+      `Preset media tracks for the ${modelPrefix} model.`,
+      "",
+      "Declared in the model's OpenAPI schema and passed to the SDK as",
+      "`modelTracks` so the transport can prepare the SDP offer in",
+      "parallel with session polling (faster first-frame latency).",
+    ],
+    0,
+  );
+  lines.push(doc + `export const ${modelPrefix}Tracks = [`);
   for (const track of tracks) {
-    const constName = track.name.toUpperCase();
+    const transportDirection = schemaDirectionToTransport(track.direction);
+    // Route every schema-sourced field through JSON.stringify so a hostile
+    // IR (parser bypass / hand-rolled ModelSchema) can't smuggle a quote
+    // into the constant and turn this array literal into executable code.
+    // `transportDirection` is derived internally from a closed enum, but
+    // we route it through the same helper for consistency.
     lines.push(
-      `  ${constName}: { name: "${track.name}", kind: "${track.kind}", direction: "${track.direction}" },`,
+      `  { name: ${JSON.stringify(track.name)}, kind: ${JSON.stringify(track.kind)}, direction: ${JSON.stringify(transportDirection)} },`,
     );
   }
-  lines.push("} as const;");
+  lines.push("] as const;");
   return lines.join("\n");
+}
+
+/** Tracks the user can publish bytes INTO (client → model). */
+function sendonlyTracks(tracks: TrackSchema[]): TrackSchema[] {
+  return tracks.filter((t) => t.direction === "in");
+}
+
+/** Tracks the user can subscribe bytes OUT of (model → client). */
+function recvonlyTracks(tracks: TrackSchema[]): TrackSchema[] {
+  return tracks.filter((t) => t.direction === "out");
+}
+
+/**
+ * Emit `export type <Prefix>SendTrackName = "a" | "b"` and
+ * `export type <Prefix>RecvTrackName = "c" | "d"` — string-literal
+ * unions of the track names the user can publish to / subscribe to.
+ *
+ * Only emit the direction that actually has tracks. A union with zero
+ * members collapses to `never`, which makes every generated hook
+ * signature uncallable (dead code worth surfacing as absence instead).
+ *
+ * Every name flows through `JSON.stringify` so a hostile IR cannot
+ * smuggle a quote into the literal — same defense-in-depth contract as
+ * every other schema-sourced identifier the emitter writes.
+ */
+function generateTrackTypes(
+  modelPrefix: string,
+  tracks: TrackSchema[],
+): string {
+  const send = sendonlyTracks(tracks);
+  const recv = recvonlyTracks(tracks);
+  if (send.length === 0 && recv.length === 0) return "";
+
+  const parts: string[] = [];
+  if (send.length > 0) {
+    parts.push(
+      generateJsDoc(
+        [
+          `Track names the client can publish into (sendonly, from the client's perspective).`,
+        ],
+        0,
+      ) +
+        `export type ${modelPrefix}SendTrackName =\n  ${send
+          .map((t) => JSON.stringify(t.name))
+          .join("\n  | ")};`,
+    );
+  }
+  if (recv.length > 0) {
+    parts.push(
+      generateJsDoc(
+        [
+          `Track names the client can subscribe to (recvonly, from the client's perspective).`,
+        ],
+        0,
+      ) +
+        `export type ${modelPrefix}RecvTrackName =\n  ${recv
+          .map((t) => JSON.stringify(t.name))
+          .join("\n  | ")};`,
+    );
+  }
+  return parts.join("\n\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -355,10 +445,12 @@ function generateClientClass(
   modelPrefix: string,
   events: EventSchema[],
   messages: MessageSchema[],
+  tracks: TrackSchema[],
 ): string {
   const className = `${modelPrefix}Model`;
   const optionsType = `${modelPrefix}Options`;
   const needsFileRef = events.some(hasUploadRefParam);
+  const hasTracks = tracks.length > 0;
 
   const lines: string[] = [];
 
@@ -373,9 +465,17 @@ function generateClientClass(
   lines.push(`  readonly reactor: Reactor;`);
   lines.push("");
   lines.push(`  constructor(options?: ${optionsType}) {`);
-  lines.push(
-    `    this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });`,
-  );
+  if (hasTracks) {
+    lines.push(`    this.reactor = new Reactor({`);
+    lines.push(`      ...options,`);
+    lines.push(`      modelName: MODEL_NAME,`);
+    lines.push(`      modelTracks: [...${modelPrefix}Tracks],`);
+    lines.push(`    });`);
+  } else {
+    lines.push(
+      `    this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });`,
+    );
+  }
   lines.push(`  }`);
   lines.push("");
   lines.push(`  async connect(jwtToken?: string): Promise<void> {`);
@@ -472,6 +572,88 @@ function generateClientClass(
       `  async uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef> {`,
     );
     lines.push(`    return this.reactor.uploadFile(file, options);`);
+    lines.push(`  }`);
+  }
+
+  // Typed track helpers — one publish/unpublish pair per sendonly track
+  // and one `on<Name>` subscription per recvonly track. Keeps the
+  // generated surface consistent with events ({model}.setFoo(...)) and
+  // messages ({model}.onFoo(...)) so consumers never hand-write a
+  // track name as a string literal.
+  //
+  // The generic `reactor.publishTrack(name, ...)` /
+  // `reactor.on("trackReceived", ...)` APIs remain reachable through
+  // `{model}.reactor` for callers that need to pass a dynamic name —
+  // this generator only emits per-schema sugar.
+  for (const track of sendonlyTracks(tracks)) {
+    const pascal = toPascalCase(track.name);
+    const kindNote = track.kind === "audio" ? " audio" : " video";
+    lines.push("");
+    lines.push(
+      indent(
+        generateJsDoc([
+          `Start sending a ${track.kind === "audio" ? "audio" : "video"} track to the model's "${track.name}" sendonly channel.`,
+          "",
+          `Pass a live MediaStreamTrack (e.g. from \`getUserMedia({${kindNote === " audio" ? " audio: true " : " video: true "}})\`).`,
+          `Safe to call repeatedly — the transport \`replaceTrack()\`s the new value onto the existing RTCRtpSender without renegotiating.`,
+          `@param track - The${kindNote} MediaStreamTrack to publish`,
+        ]),
+        1,
+      ),
+    );
+    lines.push(
+      `  async publish${pascal}(track: MediaStreamTrack): Promise<void> {`,
+    );
+    lines.push(
+      `    await this.reactor.publishTrack(${JSON.stringify(track.name)}, track);`,
+    );
+    lines.push(`  }`);
+
+    lines.push("");
+    lines.push(
+      indent(
+        generateJsDoc([
+          `Stop sending on the "${track.name}" sendonly channel.`,
+          "",
+          `The underlying RTCRtpSender stays alive — future \`publish${pascal}()\` calls resume on the same transceiver without renegotiating.`,
+        ]),
+        1,
+      ),
+    );
+    lines.push(`  async unpublish${pascal}(): Promise<void> {`);
+    lines.push(
+      `    await this.reactor.unpublishTrack(${JSON.stringify(track.name)});`,
+    );
+    lines.push(`  }`);
+  }
+
+  for (const track of recvonlyTracks(tracks)) {
+    const pascal = toPascalCase(track.name);
+    lines.push("");
+    lines.push(
+      indent(
+        generateJsDoc([
+          `Subscribe to the "${track.name}" recvonly ${track.kind} track the model publishes.`,
+          "",
+          "The handler fires once the model starts publishing this track; it receives the live MediaStreamTrack and the parent MediaStream (useful for attaching to a `<video>` / `<audio>` element via `srcObject`).",
+          "@param handler - Called with the received track and its stream",
+          "@returns Unsubscribe function",
+        ]),
+        1,
+      ),
+    );
+    lines.push(
+      `  on${pascal}(\n    handler: (track: MediaStreamTrack, stream: MediaStream) => void,\n  ): () => void {`,
+    );
+    lines.push(
+      `    const wrapped = (name: string, t: MediaStreamTrack, s: MediaStream) => {`,
+    );
+    lines.push(
+      `      if (name === ${JSON.stringify(track.name)}) handler(t, s);`,
+    );
+    lines.push(`    };`);
+    lines.push(`    this.reactor.on("trackReceived", wrapped);`);
+    lines.push(`    return () => this.reactor.off("trackReceived", wrapped);`);
     lines.push(`  }`);
   }
 
@@ -703,7 +885,20 @@ function generateReactFile(options: CodegenOptions): string {
   const modelPrefix = toPascalCase(schema.modelName);
   const events = schema.events;
   const messages = schema.messages;
-  const hasTracks = schema.tracks.length > 0;
+  const tracks = schema.tracks;
+  const hasTracks = tracks.length > 0;
+  const send = sendonlyTracks(tracks);
+  const recv = recvonlyTracks(tracks);
+  // The per-track component wrappers only make sense for tracks the SDK
+  // already has a ready-made React component for. `<ReactorView>` and
+  // `<WebcamStream>` are both video-only today; audio-only tracks
+  // would need bespoke wiring that this emitter intentionally leaves
+  // to the consumer.
+  const sendVideo = send.filter((t) => t.kind === "video");
+  const recvVideo = recv.filter((t) => t.kind === "video");
+  const emitsTrackHook = recv.length > 0;
+  const emitsViewComponents = recvVideo.length > 0;
+  const emitsPublisherComponents = sendVideo.length > 0;
   const needsFileRef = events.some(hasUploadRefParam);
 
   const sections: string[] = [];
@@ -734,6 +929,10 @@ function generateReactFile(options: CodegenOptions): string {
     "type ReactorConnectOptions",
   ];
   if (needsFileRef) sdkImports.push("type FileRef");
+  if (emitsViewComponents)
+    sdkImports.push("ReactorView", "type ReactorViewProps");
+  if (emitsPublisherComponents)
+    sdkImports.push("WebcamStream", "type WebcamStreamProps");
   sections.push(
     `import {\n  ${sdkImports.join(",\n  ")},\n} from "@reactor-team/js-sdk";`,
   );
@@ -757,6 +956,9 @@ function generateReactFile(options: CodegenOptions): string {
         `type ${modelPrefix}${toPascalCase(message.name)}Message`,
       );
     }
+  }
+  if (emitsTrackHook) {
+    localImports.push(`type ${modelPrefix}RecvTrackName`);
   }
   sections.push(
     `import {\n  ${localImports.join(",\n  ")},\n} from "./index.js";`,
@@ -806,8 +1008,134 @@ function generateReactFile(options: CodegenOptions): string {
     sections.push(generateReactHooksForMessages(modelPrefix, messages));
   }
 
+  // Track hook: `use<Prefix>Track(name)` — reactive subscription to a
+  // single recvonly MediaStreamTrack by name. Only emitted when the
+  // schema declares at least one recvonly track; otherwise `name`
+  // would be `never` and the hook uncallable.
+  if (emitsTrackHook) {
+    sections.push("");
+    sections.push(generateTrackHook(modelPrefix));
+  }
+
+  // Per-track wrapper components. One component per video track in
+  // each direction, name derived from the track name so callers never
+  // have to re-type a string literal (`<EchoMainVideoView />` instead
+  // of `<ReactorView track="main_video" />`).
+  if (emitsViewComponents || emitsPublisherComponents) {
+    sections.push("");
+    sections.push(generateTrackComponents(modelPrefix, recvVideo, sendVideo));
+  }
+
   sections.push("");
   return sections.join("\n");
+}
+
+/**
+ * Emit `use<Prefix>Track(name)` — a reactive subscription to the
+ * recvonly MediaStreamTrack with the given name. The hook returns
+ * `undefined` before the track arrives and the live
+ * `MediaStreamTrack` once it does. `name` is typed as
+ * `<Prefix>RecvTrackName` so a typo is a compile error.
+ */
+function generateTrackHook(modelPrefix: string): string {
+  const hookName = `use${modelPrefix}Track`;
+  const nameType = `${modelPrefix}RecvTrackName`;
+  return (
+    generateJsDoc(
+      [
+        `Subscribe to a recvonly MediaStreamTrack the model publishes, by name.`,
+        "",
+        `Returns \`undefined\` until the model emits the track, then the live track for the lifetime of the connection. \`name\` is constrained to the model's declared recvonly channels — use one of \`${nameType}\`.`,
+        "@param name - A recvonly track name declared by the model",
+        "@returns The live MediaStreamTrack, or `undefined` until received",
+      ],
+      0,
+    ) +
+    `export function ${hookName}(
+  name: ${nameType},
+): MediaStreamTrack | undefined {
+  return useReactor((s) => s.tracks[name]);
+}`
+  );
+}
+
+/**
+ * Emit one React component per video track in each direction. For each:
+ *
+ *   - recvonly video → `<<Prefix><Track>View>` wraps `<ReactorView>`
+ *     with `track` pre-bound to the schema-declared name. Audio track
+ *     stays a caller-provided prop because `audioTrack` pairs with the
+ *     video on the same `<video>` element and the schema can't know
+ *     which audio track the caller wants to mix in.
+ *
+ *   - sendonly video → `<<Prefix><Track>View>` wraps `<WebcamStream>`
+ *     with `track` pre-bound. Kept under the `View` suffix to match
+ *     the recvonly naming — both sides visibly render a `<video>`
+ *     element (preview for publish, output for receive), so one name
+ *     pattern is correct for the whole surface.
+ *
+ * Only video tracks get components because `<ReactorView>` /
+ * `<WebcamStream>` are both video-only today. Audio-only tracks would
+ * need a bespoke `<audio>` mounting component the SDK doesn't ship.
+ */
+function generateTrackComponents(
+  modelPrefix: string,
+  recvVideo: TrackSchema[],
+  sendVideo: TrackSchema[],
+): string {
+  const parts: string[] = [];
+
+  for (const track of recvVideo) {
+    const pascal = toPascalCase(track.name);
+    const componentName = `${modelPrefix}${pascal}View`;
+    const propsName = `${componentName}Props`;
+    parts.push(
+      `export interface ${propsName} extends Omit<ReactorViewProps, "track"> {}
+
+${generateJsDoc(
+  [
+    `Render the model's "${track.name}" recvonly video track in a \`<video>\` element.`,
+    "",
+    `Thin wrapper around \`<ReactorView>\` with \`track\` pre-bound. Accepts every other \`ReactorViewProps\` (\`audioTrack\`, \`className\`, \`style\`, \`videoObjectFit\`, \`muted\`, …). Must be rendered inside \`<${modelPrefix}Provider>\`.`,
+  ],
+  0,
+)}export function ${componentName}(
+  props: ${propsName},
+): ReactElement {
+  return createElement(ReactorView, {
+    ...props,
+    track: ${JSON.stringify(track.name)},
+  });
+}`,
+    );
+  }
+
+  for (const track of sendVideo) {
+    const pascal = toPascalCase(track.name);
+    const componentName = `${modelPrefix}${pascal}View`;
+    const propsName = `${componentName}Props`;
+    parts.push(
+      `export interface ${propsName} extends Omit<WebcamStreamProps, "track"> {}
+
+${generateJsDoc(
+  [
+    `Acquire the user's webcam and publish it to the model's "${track.name}" sendonly video channel.`,
+    "",
+    `Thin wrapper around \`<WebcamStream>\` with \`track\` pre-bound. Requests \`getUserMedia()\` on mount, auto-publishes when the connection reaches \`ready\`, cleans up on unmount. Must be rendered inside \`<${modelPrefix}Provider>\`.`,
+  ],
+  0,
+)}export function ${componentName}(
+  props: ${propsName},
+): ReactElement {
+  return createElement(WebcamStream, {
+    ...props,
+    track: ${JSON.stringify(track.name)},
+  });
+}`,
+    );
+  }
+
+  return parts.join("\n\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -877,6 +1205,11 @@ function generateSourceFile(options: CodegenOptions): string {
   if (tracks.length > 0) {
     sections.push("");
     sections.push(generateTrackConstants(modelPrefix, tracks));
+    const trackTypes = generateTrackTypes(modelPrefix, tracks);
+    if (trackTypes) {
+      sections.push("");
+      sections.push(trackTypes);
+    }
   }
 
   for (const event of events) {
@@ -909,7 +1242,7 @@ function generateSourceFile(options: CodegenOptions): string {
     sections.push(UNWRAP_MESSAGE_HELPER);
   }
   sections.push("");
-  sections.push(generateClientClass(modelPrefix, events, messages));
+  sections.push(generateClientClass(modelPrefix, events, messages, tracks));
 
   // Re-export everything the React file defines so consumers only ever
   // import from `@reactor-models/<name>` — no `/react` subpath. The
@@ -1070,6 +1403,11 @@ export const __testing__ = {
   generateMessageInterface,
   generateMessageUnion,
   generateTrackConstants,
+  generateTrackTypes,
+  generateTrackHook,
+  generateTrackComponents,
+  sendonlyTracks,
+  recvonlyTracks,
   generateReactFile,
   stripBuildMetadata,
   formatVersionForHeader,

--- a/packages/codegen/src/readme-emitter.ts
+++ b/packages/codegen/src/readme-emitter.ts
@@ -500,25 +500,141 @@ function generateReadmeMessageSection(
   return out.join("\n");
 }
 
-function generateReadmeTracksSection(tracks: TrackSchema[]): string {
-  if (tracks.length === 0) return "";
+/**
+ * User-facing code example for a single sendonly track: "here's how you
+ * push media into this channel from plain JS vs. React". The generated
+ * class exposes `publish<Track>` / `unpublish<Track>` sugar methods,
+ * and the React file exposes a `<Prefix><Track>View>` component that
+ * wraps `<WebcamStream>` with the name pre-bound. Reference the
+ * declared track name only once, in the heading — every call site
+ * below uses the typed helpers, so a typo is a compile error.
+ */
+function readmeSendTrackSnippets(
+  track: TrackSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+): { js: string; react: string } {
+  const pascal = toPascalCase(track.name);
+  const methodPublish = `publish${pascal}`;
+  const methodUnpublish = `unpublish${pascal}`;
+  const componentName = `${modelPrefix}${pascal}View`;
+  const kindLabel = track.kind === "audio" ? "audio: true" : "video: true";
+
+  const js = [
+    `import { ${modelPrefix}Model } from ${JSON.stringify(packageName)};`,
+    "",
+    `const ${modelName} = new ${modelPrefix}Model();`,
+    `await ${modelName}.connect(jwt);`,
+    "",
+    `const media = await navigator.mediaDevices.getUserMedia({ ${kindLabel} });`,
+    `const ${track.kind === "audio" ? "audioTrack" : "videoTrack"} = media.get${track.kind === "audio" ? "Audio" : "Video"}Tracks()[0];`,
+    `await ${modelName}.${methodPublish}(${track.kind === "audio" ? "audioTrack" : "videoTrack"});`,
+    "",
+    `// later, to stop sending:`,
+    `await ${modelName}.${methodUnpublish}();`,
+  ].join("\n");
+
+  const react = [
+    `"use client";`,
+    `import { ${componentName} } from "${packageName}";`,
+    "",
+    `// Inside a component wrapped by <${modelPrefix}Provider>:`,
+    `export function Example() {`,
+    `  return <${componentName} />;`,
+    `}`,
+  ].join("\n");
+
+  return { js, react };
+}
+
+/**
+ * User-facing code example for a single recvonly track: "here's how
+ * you subscribe to media from this channel". The generated class
+ * exposes an `on<Track>` subscription; the React file exposes
+ * `use<Prefix>Track(name)` and, for video tracks, a
+ * `<Prefix><Track>View>` component that renders the track in a
+ * `<video>` element with `track` pre-bound.
+ */
+function readmeRecvTrackSnippets(
+  track: TrackSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+): { js: string; react: string } {
+  const pascal = toPascalCase(track.name);
+  const methodOn = `on${pascal}`;
+  const componentName = `${modelPrefix}${pascal}View`;
+  const hookName = `use${modelPrefix}Track`;
+
+  const js = [
+    `import { ${modelPrefix}Model } from ${JSON.stringify(packageName)};`,
+    "",
+    `const ${modelName} = new ${modelPrefix}Model();`,
+    `${modelName}.${methodOn}((track, stream) => {`,
+    `  // attach to a <${track.kind}> element, pipe to a canvas, etc.`,
+    `  videoEl.srcObject = stream;`,
+    `});`,
+    `await ${modelName}.connect(jwt);`,
+  ].join("\n");
+
+  const react =
+    track.kind === "video"
+      ? [
+          `"use client";`,
+          `import { ${componentName} } from "${packageName}";`,
+          "",
+          `// Inside a component wrapped by <${modelPrefix}Provider>:`,
+          `export function Example() {`,
+          `  return <${componentName} className="w-full aspect-video" />;`,
+          `}`,
+        ].join("\n")
+      : [
+          `"use client";`,
+          `import { ${hookName} } from "${packageName}";`,
+          "",
+          `// Inside a component wrapped by <${modelPrefix}Provider>:`,
+          `export function Example() {`,
+          `  const track = ${hookName}(${JSON.stringify(track.name)});`,
+          `  // attach \`track\` to an <${track.kind}> element via a ref + srcObject.`,
+          `  return null;`,
+          `}`,
+        ].join("\n");
+
+  return { js, react };
+}
+
+function generateReadmeTrackSection(
+  track: TrackSchema,
+  modelName: string,
+  modelPrefix: string,
+  packageName: string,
+): string {
+  const isSend = track.direction === "in";
+  const snippets = isSend
+    ? readmeSendTrackSnippets(track, modelName, modelPrefix, packageName)
+    : readmeRecvTrackSnippets(track, modelName, modelPrefix, packageName);
+
   const out: string[] = [];
+  out.push(`### \`${track.name}\``);
+  out.push("");
   out.push(
-    "The generated package pre-wires these as `modelTracks` so the SDK prepares the WebRTC offer in parallel with session setup — no client wiring required.",
+    isSend
+      ? `A ${track.kind} channel you push media into (for example, the user's ${track.kind === "audio" ? "microphone" : "webcam"}).`
+      : `A ${track.kind} channel you subscribe to — the model publishes this for your app to render.`,
   );
   out.push("");
-  out.push("| Name | Kind | Direction | Transport |");
-  out.push("|---|---|---|---|");
-  for (const t of tracks) {
-    // Schema direction is from the model's perspective; the transport
-    // (client) direction is the mirror image. Kept inline here so the
-    // README emitter doesn't take a dep on the track-constant rewrite
-    // that lands in a later PR.
-    const transport = t.direction === "in" ? "sendonly" : "recvonly";
-    out.push(
-      `| \`${t.name}\` | ${t.kind} | ${t.direction} | \`${transport}\` |`,
-    );
-  }
+  out.push("#### JavaScript");
+  out.push("");
+  out.push("```typescript");
+  out.push(snippets.js);
+  out.push("```");
+  out.push("");
+  out.push("#### React");
+  out.push("");
+  out.push("```tsx");
+  out.push(snippets.react);
+  out.push("```");
   out.push("");
   return out.join("\n");
 }
@@ -613,7 +729,15 @@ export function generateReadme(options: CodegenOptions): string {
   if (schema.tracks.length > 0) {
     sections.push("## Tracks");
     sections.push("");
-    sections.push(generateReadmeTracksSection(schema.tracks));
+    sections.push(
+      `Named media channels between your app and the ${modelPrefix} model. Use the typed helpers below — \`${modelPrefix}Model.publish<Track>\` / \`on<Track>\` in plain JS, and \`use${modelPrefix}Track\` or the per-track \`<${modelPrefix}<Track>View>\` components in React — so track names are checked at compile time.`,
+    );
+    sections.push("");
+    for (const track of schema.tracks) {
+      sections.push(
+        generateReadmeTrackSection(track, modelName, modelPrefix, packageName),
+      );
+    }
   }
 
   // Trailing blank line keeps the final file POSIX-compliant and avoids

--- a/packages/codegen/tsup.config.ts
+++ b/packages/codegen/tsup.config.ts
@@ -2,10 +2,18 @@
 
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
-  dts: true,
-  sourcemap: true,
-  clean: true,
-});
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+  },
+  {
+    entry: ["src/cli.ts"],
+    format: ["cjs"],
+    sourcemap: true,
+    banner: { js: "#!/usr/bin/env node" },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,13 +19,16 @@ importers:
         version: 20.19.37
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.37)
+        version: 3.2.4(@types/node@20.19.37)(tsx@4.21.0)
 
   packages/create-app:
     dependencies:
@@ -47,7 +50,7 @@ importers:
         version: 22.19.15
       tsup:
         specifier: ^8.0.1
-        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -99,13 +102,13 @@ importers:
         version: 3.8.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@20.19.37)
+        version: 3.2.4(@types/node@20.19.37)(tsx@4.21.0)
 
 packages:
 
@@ -677,6 +680,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -833,6 +839,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -958,6 +967,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -1383,13 +1397,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1567,6 +1581,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   has-flag@4.0.0: {}
 
   iconv-lite@0.7.2:
@@ -1693,11 +1711,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.8):
+  postcss-load-config@6.0.1(postcss@8.5.8)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.8
+      tsx: 4.21.0
 
   postcss@8.5.8:
     dependencies:
@@ -1718,6 +1737,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@3.1.0:
     dependencies:
@@ -1846,7 +1867,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.8)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -1857,7 +1878,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.8)
+      postcss-load-config: 6.0.1(postcss@8.5.8)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -1874,6 +1895,13 @@ snapshots:
       - tsx
       - yaml
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-fest@0.21.3: {}
 
   typescript@5.9.3: {}
@@ -1884,13 +1912,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.37):
+  vite-node@3.2.4(@types/node@20.19.37)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1905,7 +1933,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@20.19.37):
+  vite@7.3.1(@types/node@20.19.37)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1916,12 +1944,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.37
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@20.19.37):
+  vitest@3.2.4(@types/node@20.19.37)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1939,8 +1968,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.19.37)
-      vite-node: 3.2.4(@types/node@20.19.37)
+      vite: 7.3.1(@types/node@20.19.37)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@20.19.37)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37


### PR DESCRIPTION
## Why

Give the codegen a user-facing CLI so downstream tooling (and the CI pipeline in PR 6) can drive it, and turn `<Prefix>Tracks` into a shape the JS SDK can actually use as `modelTracks` — unlocking the WebRTC parallel-SDP fast path from the REA-1654 transport stack for every generated client at zero cost to the developer.

## What changed

**CLI (`src/cli.ts`, bin `reactor-codegen`)**

| Flag | Required | Purpose |
|---|---|---|
| `--schema <path>` | yes | Path to the model's OpenAPI schema JSON |
| `--output <path>` | yes | Output directory (full package) or `.ts` file (`--standalone`) |
| `--sdk-version <semver>` | no | Pin for the generated `@reactor-team/js-sdk` dep. Defaults to committed `defaultSdkVersion`. |
| `--standalone` | no | Emit a single `.ts` file for drop-in use in an existing project. Skips the package scaffold + build. |
| `--react` | no | Also emit `src/react.ts` (provider + hooks). Adds `./react` subpath export + `react` peer dep. |
| `--dry-run` | no | Print every generated file to stdout, write nothing. |
| `--no-build` | no | Skip `pnpm install && pnpm build` after writing source. |

Two tsup entries now ship from the codegen:

- `src/index.ts` → `dist/index.{js,mjs,d.ts}` (library).
- `src/cli.ts` → `dist/cli.js` (CJS with `#!/usr/bin/env node` banner, wired to `"bin"` in `package.json`).

**`modelTracks` transport fast path (emitter)**

- `<Prefix>Tracks` becomes a `readonly` array of SDK-shape track hints (`direction: "sendonly" | "recvonly"`) instead of the schema-shape object map PR 3 emitted.
- Schema direction translated at emit time: `"out"` (model produces) → `"recvonly"`, `"in"` (model consumes) → `"sendonly"`.
- `<Prefix>Model`'s constructor passes `modelTracks: [...<Prefix>Tracks]` into `new Reactor({...})` when the schema declares any tracks; track-less schemas fall through to the sequential warm-up.

**Committed `defaultSdkVersion`**

- `--sdk-version` is now optional. When omitted, the CLI reads `defaultSdkVersion` from `@reactor-team/codegen`'s own `package.json`.
- Bumping the SDK target becomes a one-field PR in this package, not a change to every caller.

**Full README** — CLI reference, programmatic API, generated-package usage, schema-direction → transport-direction table, OpenAPI schema format.

## Shape of the change

```
packages/codegen/
├── src/
│   ├── cli.ts                   (new: 318 lines)
│   └── emitter.ts               (+55: schemaDirectionToTransport, modelTracks wiring)
├── __tests__/
│   ├── cli.test.ts              (new: 16 tests via spawnSync)
│   └── emitter.test.ts          (+4: direction translation, wiring on/off)
├── tsup.config.ts               (second entry + shebang banner)
├── package.json                 ("bin", defaultSdkVersion, codegen:test script)
└── README.md                    (full CLI + programmatic reference)
```

## Usage (CLI)

```bash
# Full package
reactor-codegen --schema schema.json --output ./out/helios

# Dry-run
reactor-codegen --schema schema.json --output ./out/helios --dry-run

# Drop-in single file, no build
reactor-codegen --schema schema.json --output ./src/helios.ts --standalone

# With React hooks
reactor-codegen --schema schema.json --output ./out/helios --react
```

## Tests

+20 tests (123 total). CLI arg-validation (mutual exclusions, missing args, unknown flags, `--help`), `--dry-run` stdout contract + no filesystem side effects, ENOENT on missing schema, `--no-build` end-to-end verifying `modelTracks: [...HeliosTracks]` + `direction: "recvonly"` in the emitted client, `defaultSdkVersion` fallback, `--standalone` single-file write, `--react` + `--react --standalone` outputs.

## Stack

1. [`[1/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/117) scaffold + IR
2. [`[2/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/118) parser + ingress validation
3. [`[3/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/119) emitter + README + injection defence + version helpers
4. **→ this PR** CLI + modelTracks + defaultSdkVersion
5. [`[5/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/121) coordinator fetch + auth exchange
6. [`[6/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/122) Buildkite publish pipeline

Ref: [REA-1581](https://linear.app/reactor-team/issue/REA-1581)
