### PR TITLE
[REA-1581][5/6] feat: fetch schema from coordinator + POST /tokens auth exchange

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -34,15 +34,55 @@ The model name and version are read directly from the schema's `info.title` and 
 
 ### Options
 
-| Flag                     | Required | Description                                                                                                                                                                          |
-| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--schema <path>`        | Yes      | Path to the model's OpenAPI schema JSON                                                                                                                                              |
-| `--sdk-version <semver>` | No       | `@reactor-team/js-sdk` version to pin as a dependency. Defaults to the `defaultSdkVersion` field in this package's `package.json` when omitted                                       |
-| `--output <path>`        | Yes      | Output directory for the generated package, or a `.ts` file path when `--standalone`                                                                                                 |
-| `--standalone`           | No       | Emit only the typed source file (no `package.json` / `tsup.config.ts` / `tsconfig.json`). Drop-in use in an existing project; skips build                                            |
-| `--react`                | No       | Also emit a React entry point: `<Prefix>Provider`, `use<Prefix>()`, one hook per message. Full-package mode adds a `./react` subpath export; standalone writes a sibling `.react.ts` |
-| `--dry-run`              | No       | Print generated files to stdout without writing to disk                                                                                                                              |
-| `--no-build`             | No       | Skip `pnpm install` + `tsup` build (just generate source)                                                                                                                            |
+The schema can come from **one of two sources**, picked by passing either `--schema` (file on disk) or `--coordinator-url` (live fetch from the control plane). Exactly one of the two is required.
+
+| Flag                      | Required                         | Description                                                                                                                                                                          |
+| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--schema <path>`         | If not using `--coordinator-url` | Path to the model's OpenAPI schema JSON                                                                                                                                              |
+| `--coordinator-url <url>` | If not using `--schema`          | Base URL of the Reactor coordinator (e.g. `https://api.reactor.inc`). Pair with `--model-id`; optionally `--release` and `--api-key`                                                 |
+| `--model-id <uuid>`       | With `--coordinator-url`         | Model UUID (`{id}` in `/admin/models/{id}/schemas`)                                                                                                                                  |
+| `--release <semver>`      | No                               | Semver-prefix release selector (e.g. `v1.0.5`). If omitted, the most recently registered schema is fetched                                                                           |
+| `--api-key <key>`         | Only for private models          | Bearer token forwarded as `Authorization: Bearer <key>`. Falls back to the `REACTOR_API_KEY` environment variable. Public models read anonymously                                    |
+| `--sdk-version <semver>`  | No                               | `@reactor-team/js-sdk` version to pin as a dependency. Defaults to the `defaultSdkVersion` field in this package's `package.json` when omitted                                       |
+| `--output <path>`         | Yes                              | Output directory for the generated package, or a `.ts` file path when `--standalone`                                                                                                 |
+| `--standalone`            | No                               | Emit only the typed source file (no `package.json` / `tsup.config.ts` / `tsconfig.json`). Drop-in use in an existing project; skips build                                            |
+| `--react`                 | No                               | Also emit a React entry point: `<Prefix>Provider`, `use<Prefix>()`, one hook per message. Full-package mode adds a `./react` subpath export; standalone writes a sibling `.react.ts` |
+| `--dry-run`               | No                               | Print generated files to stdout without writing to disk                                                                                                                              |
+| `--no-build`              | No                               | Skip `pnpm install` + `tsup` build (just generate source)                                                                                                                            |
+
+### Fetching from the coordinator
+
+Instead of keeping a `schema.json` committed or side-loading it into CI, point the codegen at a coordinator and let it pull the schema registered against a given model release:
+
+```bash
+# Release-scoped — semver-prefix match on the server side, newest wins
+reactor-codegen \
+  --coordinator-url https://api.reactor.inc \
+  --model-id 7b3f1bc2-a4e5-4d78-b9c1-123456789abc \
+  --release v1.0.5 \
+  --output ./out/helios
+
+# No --release: list the registered schemas and fetch the most recent one
+reactor-codegen \
+  --coordinator-url https://api.reactor.inc \
+  --model-id 7b3f1bc2-a4e5-4d78-b9c1-123456789abc \
+  --output ./out/helios
+
+# Private model — use an admin bearer token
+REACTOR_API_KEY=rk_... reactor-codegen \
+  --coordinator-url https://api.reactor.inc \
+  --model-id 7b3f1bc2-a4e5-4d78-b9c1-123456789abc \
+  --release v1.0.5 \
+  --output ./out/helios
+```
+
+Behavior notes:
+
+- **Release selection.** With `--release`, the CLI hits `GET /admin/models/{id}/schemas?release=<release>` once and the coordinator returns the single matching record (semver-prefix match, newest wins when multiple records share a prefix). Without `--release`, the CLI first `GET`s the list, picks the most recent summary, then fetches the full record by ID.
+- **Public vs. private models.** Public models are readable without `--api-key`. Private models return `404` (never `403`) to unauthenticated callers so their existence is never leaked — if you expect the request to succeed and see `404`, the most likely cause is a missing `--api-key` / `REACTOR_API_KEY`.
+- **Env fallback.** `REACTOR_API_KEY` is consulted when `--api-key` is absent. The explicit flag always wins.
+- **SDK version default.** `--sdk-version` is optional; when omitted, the CLI reads `defaultSdkVersion` out of `@reactor-team/codegen`'s own `package.json`. CI pipelines that publish periodic releases typically rely on the committed default so bumping the SDK target is a one-field PR in this package rather than a per-call flag change.
+- **Downstream is unchanged.** Both input modes funnel through the same `parseSchema` → emitter pipeline, so `--standalone`, `--react`, `--dry-run`, and `--no-build` behave identically whether the schema came off disk or over HTTP.
 
 ### Standalone mode
 
@@ -156,12 +196,23 @@ The codegen can also be used as a library:
 ```typescript
 import {
   loadSchema,
+  fetchSchema,
   parseSchema,
   generateModelSdk,
   writePackage,
 } from "@reactor-team/codegen";
 
+// Either read the raw OpenAPI doc off disk…
 const rawSchema = loadSchema("schema.json");
+
+// …or pull it straight from the coordinator.
+const rawFromApi = await fetchSchema({
+  coordinatorUrl: "https://api.reactor.inc",
+  modelId: "7b3f1bc2-a4e5-4d78-b9c1-123456789abc",
+  release: "v1.0.5", // optional; omit for "most recent"
+  apiKey: process.env.REACTOR_API_KEY, // optional; required for private models
+});
+
 const schema = parseSchema(rawSchema);
 
 const pkg = generateModelSdk({

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const CLI_PATH = path.join(__dirname, "..", "src", "cli.ts");
 const SCHEMA_PATH = path.join(__dirname, "..", "schema.json");
+const FIXTURE_MODEL_ID = "7b3f1bc2-a4e5-4d78-b9c1-123456789abc";
 
 function runCli(args: string[]): SpawnSyncReturns<string> {
   return spawnSync("pnpm", ["tsx", CLI_PATH, ...args], {
@@ -450,5 +451,102 @@ describe("reactor-codegen CLI — --standalone --react", () => {
 
     expect(result.status).toBe(0);
     expect(fs.existsSync(outputFile)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --coordinator-url — argument validation (no network).
+//
+// End-to-end coordinator→CLI→emitter coverage deliberately lives in
+// `coordinator.test.ts` (fetch stubbed in-process, no subprocess spawn).
+// CLI-level tests here only assert that the new flags parse, fail fast on
+// the mutually-exclusive / missing-required cases, and route through to
+// the fetcher — keeping the suite fast and sidestepping the cost of
+// spawning `pnpm tsx` per test against a loopback HTTP server.
+// ---------------------------------------------------------------------------
+
+describe("reactor-codegen CLI — coordinator-mode argument validation", () => {
+  it("rejects --schema and --coordinator-url together", () => {
+    const result = runCli([
+      "--schema",
+      SCHEMA_PATH,
+      "--coordinator-url",
+      "https://api.example.com",
+      "--model-id",
+      FIXTURE_MODEL_ID,
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      "ignored",
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("rejects --coordinator-url without --model or --model-id", () => {
+    const result = runCli([
+      "--coordinator-url",
+      "https://api.example.com",
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      "ignored",
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("rejects --model and --model-id together", () => {
+    // Exactly one must identify the model; supporting both at once would
+    // make it ambiguous which wins on a typo.
+    const result = runCli([
+      "--coordinator-url",
+      "https://api.example.com",
+      "--model",
+      "helios",
+      "--model-id",
+      FIXTURE_MODEL_ID,
+      "--release",
+      "v1.0.5",
+      "--output",
+      "ignored",
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("rejects --coordinator-url with neither --model nor --model-id", () => {
+    const result = runCli([
+      "--coordinator-url",
+      "https://api.example.com",
+      "--output",
+      "ignored",
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("rejects a clearly-malformed --model-id before touching the network", () => {
+    // `fetchSchema`'s pre-IO guard should short-circuit here so the CLI
+    // never attempts a request against a broken ID.
+    const result = runCli([
+      "--coordinator-url",
+      "https://api.example.com",
+      "--model-id",
+      "has/slash",
+      "--release",
+      "v1.0.5",
+      "--sdk-version",
+      "2.9.1",
+      "--output",
+      "ignored",
+      "--dry-run",
+    ]);
+
+    expect(result.status).not.toBe(0);
   });
 });

--- a/packages/codegen/__tests__/coordinator.test.ts
+++ b/packages/codegen/__tests__/coordinator.test.ts
@@ -1,0 +1,813 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  exchangeApiKeyForJwt,
+  fetchSchema,
+  pickLatestRelease,
+  resolveModelIdByName,
+  __testing__,
+} from "../src/coordinator.js";
+import type { OpenApiSchema } from "../src/openapi/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — a minimal hand-rolled fetch stub so each test can assert on
+// the exact URL + headers the coordinator fetcher sent.
+// ---------------------------------------------------------------------------
+
+const VALID_MODEL_ID = "7b3f1bc2-a4e5-4d78-b9c1-123456789abc";
+
+interface Call {
+  url: string;
+  init?: RequestInit;
+}
+
+interface StubResponse {
+  status: number;
+  body: unknown;
+  statusText?: string;
+}
+
+function jsonBody(body: unknown): string {
+  return typeof body === "string" ? body : JSON.stringify(body);
+}
+
+function buildResponse(r: StubResponse): Response {
+  return new Response(jsonBody(r.body), {
+    status: r.status,
+    statusText: r.statusText ?? (r.status === 200 ? "OK" : ""),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Produces a fetch-compatible stub that returns a scripted sequence of
+ * responses. If the test sends more requests than responses scripted it
+ * fails with a clear message rather than returning `undefined`.
+ */
+function makeFetchStub(responses: StubResponse[]): {
+  fetch: typeof fetch;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  let idx = 0;
+  const stub: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    calls.push({ url, init });
+    if (idx >= responses.length) {
+      throw new Error(
+        `fetchStub: no more responses scripted (request #${idx + 1} to ${url})`,
+      );
+    }
+    return buildResponse(responses[idx++]);
+  };
+  return { fetch: stub, calls };
+}
+
+function sampleOpenApi(): OpenApiSchema {
+  return {
+    openapi: "3.1.0",
+    info: { title: "helios", version: "1.0.5" },
+  };
+}
+
+function recordPayload(
+  overrides: Partial<{
+    id: string;
+    model_id: string;
+    release: string;
+    schema: unknown;
+    created_at: number;
+    updated_at: number;
+  }> = {},
+): Record<string, unknown> {
+  return {
+    id: "cf868483-fa9f-4744-a4ce-aa2724e45f0a",
+    model_id: VALID_MODEL_ID,
+    release: "v1.0.5-ge6187a05",
+    schema: sampleOpenApi(),
+    created_at: 1747000000,
+    updated_at: 1747000000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe("internal helpers", () => {
+  it("trimTrailingSlashes strips any number of trailing slashes", () => {
+    const { trimTrailingSlashes } = __testing__;
+    expect(trimTrailingSlashes("https://api.reactor.inc")).toBe(
+      "https://api.reactor.inc",
+    );
+    expect(trimTrailingSlashes("https://api.reactor.inc/")).toBe(
+      "https://api.reactor.inc",
+    );
+    expect(trimTrailingSlashes("https://api.reactor.inc////")).toBe(
+      "https://api.reactor.inc",
+    );
+  });
+
+  it("buildHeaders omits Authorization when no apiKey is supplied", () => {
+    const { buildHeaders } = __testing__;
+    const headers = buildHeaders(undefined);
+    expect(headers.Accept).toBe("application/json");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("buildHeaders sets Authorization: Bearer <jwt> when a bearer token is supplied", () => {
+    // The header takes a JWT, NOT a raw API key — those have different
+    // shapes per REST-API.md (`Reactor-API-Key` vs `Authorization:
+    // Bearer`). The exchange happens upstream in `exchangeApiKeyForJwt`.
+    const { buildHeaders } = __testing__;
+    expect(buildHeaders("eyJhbGciOiJIUzI1NiJ9.test").Authorization).toBe(
+      "Bearer eyJhbGciOiJIUzI1NiJ9.test",
+    );
+  });
+
+  it("buildHeaders pins the Reactor-API-Version header on every call", () => {
+    // `Reactor-API-Version` is mandatory on `/tokens` and `/sessions`
+    // per the REST docs; we send it on every coordinator call so the
+    // header stays compatible if the gate ever widens to /admin/*.
+    const { buildHeaders } = __testing__;
+    expect(buildHeaders(undefined)["Reactor-API-Version"]).toBe("1");
+    expect(buildHeaders("eyJ.x.y")["Reactor-API-Version"]).toBe("1");
+  });
+
+  it("requireUuidLike rejects obviously-broken model IDs", () => {
+    const { requireUuidLike } = __testing__;
+    expect(() => requireUuidLike("")).toThrow(/Invalid --model-id/);
+    expect(() => requireUuidLike(" has space ")).toThrow(/Invalid --model-id/);
+    expect(() => requireUuidLike("foo/bar")).toThrow(/Invalid --model-id/);
+    expect(() => requireUuidLike("http://x")).toThrow(/Invalid --model-id/);
+    // Any opaque token without whitespace/slashes/colons is accepted —
+    // we deliberately don't enforce strict RFC 4122 formatting so the
+    // coordinator remains the source of truth for its own ID format.
+    expect(() => requireUuidLike(VALID_MODEL_ID)).not.toThrow();
+    expect(() => requireUuidLike("not-really-a-uuid")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release-scoped fetch — single request, full record returned.
+// ---------------------------------------------------------------------------
+
+describe("fetchSchema — with --release", () => {
+  it("hits GET /admin/models/{id}/schemas?release=<release> and returns schema.schema", async () => {
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: recordPayload() },
+    ]);
+
+    const schema = await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelId: VALID_MODEL_ID,
+      release: "v1.0.5",
+      fetchImpl: fetch,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(
+      `https://api.reactor.inc/admin/models/${VALID_MODEL_ID}/schemas?release=v1.0.5`,
+    );
+    expect((calls[0].init?.headers as Record<string, string>).Accept).toBe(
+      "application/json",
+    );
+    expect(
+      (calls[0].init?.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
+
+    expect(schema).toEqual(sampleOpenApi());
+  });
+
+  it("URL-encodes the model ID and release query parameter", async () => {
+    // The coordinator's path param is a UUID so encoding is normally a
+    // no-op, but we still pipe it through encodeURIComponent so a caller
+    // who fat-fingers a `+` or `&` gets a clean URL instead of a silent
+    // query-string break.
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: recordPayload() },
+    ]);
+
+    await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc/",
+      modelId: VALID_MODEL_ID,
+      release: "v1.0.5+build.1",
+      fetchImpl: fetch,
+    });
+
+    expect(calls[0].url).toBe(
+      `https://api.reactor.inc/admin/models/${VALID_MODEL_ID}/schemas?release=v1.0.5%2Bbuild.1`,
+    );
+  });
+
+  it("sends Authorization: Bearer <jwt> when a pre-exchanged bearerToken is supplied", async () => {
+    // `bearerToken` skips the `/tokens` exchange entirely. Useful here
+    // (no need to mock two responses to assert one header) and in the
+    // CLI, which exchanges once at the top of resolveSchema and reuses
+    // the JWT across resolveModelIdByName + fetchSchema.
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: recordPayload() },
+    ]);
+
+    await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelId: VALID_MODEL_ID,
+      release: "v1.0.5",
+      bearerToken: "eyJhbGciOiJIUzI1NiJ9.fake.jwt",
+      fetchImpl: fetch,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(
+      (calls[0].init?.headers as Record<string, string>).Authorization,
+    ).toBe("Bearer eyJhbGciOiJIUzI1NiJ9.fake.jwt");
+  });
+
+  it("exchanges --api-key for a JWT before the schema fetch", async () => {
+    // End-to-end of the auth flow we care about: caller hands us the
+    // raw API key, fetcher does POST /tokens with `Reactor-API-Key`,
+    // then sends the resulting JWT as `Authorization: Bearer` on the
+    // schema call. The API key MUST never appear on /admin/*.
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: { jwt: "eyJ.exchanged.jwt" } },
+      { status: 200, body: recordPayload() },
+    ]);
+
+    await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelId: VALID_MODEL_ID,
+      release: "v1.0.5",
+      apiKey: "rk_secret",
+      fetchImpl: fetch,
+    });
+
+    expect(calls).toHaveLength(2);
+
+    // First call: token exchange.
+    expect(calls[0].url).toBe("https://api.reactor.inc/tokens");
+    expect(calls[0].init?.method).toBe("POST");
+    const tokenHeaders = calls[0].init?.headers as Record<string, string>;
+    expect(tokenHeaders["Reactor-API-Key"]).toBe("rk_secret");
+    expect(tokenHeaders.Authorization).toBeUndefined();
+
+    // Second call: schema fetch — JWT, not the API key.
+    const schemaHeaders = calls[1].init?.headers as Record<string, string>;
+    expect(schemaHeaders.Authorization).toBe("Bearer eyJ.exchanged.jwt");
+    expect(schemaHeaders["Reactor-API-Key"]).toBeUndefined();
+  });
+
+  it("strips trailing slashes from the coordinator URL", async () => {
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: recordPayload() },
+    ]);
+
+    await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc///",
+      modelId: VALID_MODEL_ID,
+      release: "v1",
+      fetchImpl: fetch,
+    });
+
+    expect(calls[0].url.startsWith("https://api.reactor.inc/admin/")).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Latest-release resolution helpers.
+//
+// `pickLatestRelease` is intentionally a top-level export, not an
+// internal to `fetchSchema`, because the CI pipeline (and anyone else
+// who wants "what's the newest published schema") should use the same
+// ordering. Tests cover the comparator behaviour in isolation so the
+// rules stay frozen even when the server-side `/releases?latest`
+// endpoint eventually replaces the client-side sort.
+// ---------------------------------------------------------------------------
+
+describe("compareReleaseTags", () => {
+  const { compareReleaseTags } = __testing__;
+
+  it("sorts the major.minor.patch triple numerically (not lexicographically)", () => {
+    // The lexicographic trap: `"v10"` < `"v2"` under string order, but
+    // as a real version it's obviously newer. Numeric parsing catches it.
+    expect(compareReleaseTags("v2.0.0", "v10.0.0")).toBeLessThan(0);
+    expect(compareReleaseTags("v1.9.0", "v1.10.0")).toBeLessThan(0);
+    expect(compareReleaseTags("v1.0.9", "v1.0.10")).toBeLessThan(0);
+  });
+
+  it("breaks ties lexicographically on the full release string", () => {
+    // Same triple → fall through to the full string. This is deliberate
+    // and documented: Reactor's `-g<sha>` suffixes aren't timestamp
+    // ordered, but at least the comparator is *total* and stable.
+    expect(
+      compareReleaseTags("v1.0.5-ge6187a05", "v1.0.5-gfeedface"),
+    ).toBeLessThan(0);
+  });
+
+  it("returns 0 when two tags are identical", () => {
+    expect(compareReleaseTags("v1.2.3", "v1.2.3")).toBe(0);
+  });
+
+  it("accepts a missing `v` prefix on either side", () => {
+    // Both `v1.2.3` and `1.2.3` are valid inputs — PR 6's Buildkite
+    // pipeline wants to plug npm's plain-semver output straight into
+    // the comparator for cross-checking.
+    expect(compareReleaseTags("1.2.3", "v1.2.3")).toBe(0);
+    expect(compareReleaseTags("1.2.3", "v1.2.4")).toBeLessThan(0);
+  });
+
+  it("sorts unparseable tags before any parseable one", () => {
+    // "garbage release" must never beat a valid semver — otherwise a
+    // malformed row in the coordinator could steal the "latest" slot.
+    expect(compareReleaseTags("garbage", "v0.0.1")).toBeLessThan(0);
+    expect(compareReleaseTags("v0.0.1", "garbage")).toBeGreaterThan(0);
+  });
+});
+
+describe("pickLatestRelease", () => {
+  it("returns null for an empty list", () => {
+    expect(pickLatestRelease([])).toBeNull();
+  });
+
+  it("returns the single entry when there's only one", () => {
+    const only = { id: "a", release: "v1.0.0" };
+    expect(pickLatestRelease([only])).toBe(only);
+  });
+
+  it("picks the highest semver regardless of array position", () => {
+    const summaries = [
+      { id: "a", release: "v1.0.4" },
+      { id: "b", release: "v2.3.0" },
+      { id: "c", release: "v1.9.9" },
+      { id: "d", release: "v2.2.9" },
+    ];
+    expect(pickLatestRelease(summaries)?.id).toBe("b");
+  });
+
+  it("prefers a valid semver over an unparseable tag", () => {
+    const summaries = [
+      { id: "valid", release: "v1.0.0" },
+      { id: "junk", release: "nightly" },
+    ];
+    expect(pickLatestRelease(summaries)?.id).toBe("valid");
+  });
+
+  it("handles Reactor's g<sha> suffixes in the tie-break lexicographically", () => {
+    const summaries = [
+      { id: "older", release: "v1.0.5-ge6187a05" },
+      { id: "newer", release: "v1.0.5-gfeedface" },
+    ];
+    // `gfeedface` > `ge6187a05` lexicographically. Documented caveat:
+    // this is stable but not timestamp order. Good enough today.
+    expect(pickLatestRelease(summaries)?.id).toBe("newer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// List + pick-latest-by-semver — two requests, highest semver wins.
+//
+// The picker deliberately doesn't trust list order (the REST contract
+// doesn't promise one), so these tests interleave releases to prove the
+// client-side comparator is what selects the latest.
+// ---------------------------------------------------------------------------
+
+describe("fetchSchema — without --release", () => {
+  it("lists summaries and fetches the entry with the highest semver", async () => {
+    const latestId = "cf868483-fa9f-4744-a4ce-aa2724e45f0a";
+    const { fetch, calls } = makeFetchStub([
+      {
+        status: 200,
+        // Intentional: the "highest" entry is in the middle of the list,
+        // not at index 0. Proves we're sorting, not relying on list order.
+        body: [
+          { id: "b0c6a11d-feed-face-0000-000000000000", release: "v1.0.4" },
+          { id: latestId, release: "v1.0.5-ge6187a05" },
+          { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", release: "v1.0.3" },
+        ],
+      },
+      { status: 200, body: recordPayload({ id: latestId }) },
+    ]);
+
+    const schema = await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelId: VALID_MODEL_ID,
+      fetchImpl: fetch,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe(
+      `https://api.reactor.inc/admin/models/${VALID_MODEL_ID}/schemas`,
+    );
+    expect(calls[1].url).toBe(
+      `https://api.reactor.inc/admin/models/${VALID_MODEL_ID}/schemas/${latestId}`,
+    );
+
+    expect(schema).toEqual(sampleOpenApi());
+  });
+
+  it("throws a helpful error when the list endpoint returns []", async () => {
+    const { fetch } = makeFetchStub([{ status: 200, body: [] }]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/No schemas registered for model/);
+  });
+
+  it("passes the same JWT through on both the list and detail requests", async () => {
+    // We exchange once at the top of fetchSchema; the resulting JWT
+    // must reach BOTH the `/schemas` list call and the
+    // `/schemas/{id}` follow-up. Pre-supplying `bearerToken` skips
+    // the exchange so this test stays focused on the propagation.
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: [{ id: "abc", release: "v1" }] },
+      { status: 200, body: recordPayload({ id: "abc" }) },
+    ]);
+
+    await fetchSchema({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelId: VALID_MODEL_ID,
+      bearerToken: "eyJ.fake.jwt",
+      fetchImpl: fetch,
+    });
+
+    for (const call of calls) {
+      expect((call.init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer eyJ.fake.jwt",
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths — the CLI's user-facing error messages are generated here,
+// so the wording is part of the contract we assert on.
+// ---------------------------------------------------------------------------
+
+describe("fetchSchema — HTTP error surfaces", () => {
+  it("maps 401 to a credentials-hint error", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 401, body: "unauthorized", statusText: "Unauthorized" },
+    ]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v1",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/401.*--api-key.*REACTOR_API_KEY/s);
+  });
+
+  it("maps 403 to a role-hint error", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 403, body: "forbidden", statusText: "Forbidden" },
+    ]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v1",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/403.*lacks the required role/);
+  });
+
+  it("maps 404 to a message that covers both 'unknown model' and 'private model' cases", async () => {
+    // The coordinator deliberately collapses both into 404 (see
+    // REST-API.md § Access Control), so the error message must hint at
+    // both — misleading users toward only one is a support footgun.
+    const { fetch } = makeFetchStub([
+      { status: 404, body: "not found", statusText: "Not Found" },
+    ]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v99",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(
+      /404.*model ID is wrong.*no schema is registered.*private/s,
+    );
+  });
+
+  it("maps 5xx to a generic status-code message with the body snippet", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 503, body: "upstream boom", statusText: "Service Unavailable" },
+    ]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v1",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/503 Service Unavailable.*upstream boom/s);
+  });
+
+  it("wraps network failures with the target URL", async () => {
+    const boom: typeof fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v1",
+        fetchImpl: boom,
+      }),
+    ).rejects.toThrow(/Failed to reach coordinator at.*fetch failed/s);
+  });
+
+  it("rejects a record payload that is missing the schema object", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 200, body: { id: "abc", release: "v1" } },
+    ]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        release: "v1",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/unexpected payload shape/);
+  });
+
+  it("rejects a list payload that is not an array", async () => {
+    const { fetch } = makeFetchStub([{ status: 200, body: { not: "a list" } }]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: VALID_MODEL_ID,
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/expected an array of \{id, release\} summaries/);
+  });
+
+  it("rejects a malformed --model-id before making any request", async () => {
+    const { fetch, calls } = makeFetchStub([]);
+
+    await expect(
+      fetchSchema({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelId: "bad/id",
+        release: "v1",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/Invalid --model-id/);
+
+    // No requests should have gone out — the guard is strictly pre-IO.
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API key → JWT exchange.
+//
+// The standalone counterpart of the apiKey-handling tests above.
+// `POST /tokens` is the only endpoint that consumes a Reactor API key
+// (`Reactor-API-Key: rk_...`); every other endpoint takes a JWT
+// (`Authorization: Bearer eyJ...`). This describe pins the wire shape
+// of that exchange so the rest of the fetcher can keep working in
+// JWTs from here on.
+// ---------------------------------------------------------------------------
+
+describe("exchangeApiKeyForJwt", () => {
+  it("POSTs to /tokens with the Reactor-API-Key header and returns the JWT", async () => {
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: { jwt: "eyJ.fresh.jwt" } },
+    ]);
+
+    const jwt = await exchangeApiKeyForJwt({
+      coordinatorUrl: "https://api.reactor.inc",
+      apiKey: "rk_secret",
+      fetchImpl: fetch,
+    });
+
+    expect(jwt).toBe("eyJ.fresh.jwt");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.reactor.inc/tokens");
+    expect(calls[0].init?.method).toBe("POST");
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers["Reactor-API-Key"]).toBe("rk_secret");
+    // Critically: NEVER use Authorization on /tokens — the API key is
+    // not a JWT, sending it that way would be a category error and
+    // some validators would reject it outright.
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers["Reactor-API-Version"]).toBe("1");
+  });
+
+  it("strips trailing slashes from the coordinator URL", async () => {
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: { jwt: "eyJ.x.y" } },
+    ]);
+
+    await exchangeApiKeyForJwt({
+      coordinatorUrl: "https://api.reactor.inc///",
+      apiKey: "rk_secret",
+      fetchImpl: fetch,
+    });
+
+    expect(calls[0].url).toBe("https://api.reactor.inc/tokens");
+  });
+
+  it("rejects an empty --api-key before making any request", async () => {
+    const { fetch, calls } = makeFetchStub([]);
+
+    await expect(
+      exchangeApiKeyForJwt({
+        coordinatorUrl: "https://api.reactor.inc",
+        apiKey: "",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/Invalid --api-key/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("maps 401 to the same actionable wording as the rest of the fetcher", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 401, body: "bad key", statusText: "Unauthorized" },
+    ]);
+
+    await expect(
+      exchangeApiKeyForJwt({
+        coordinatorUrl: "https://api.reactor.inc",
+        apiKey: "rk_secret",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/401.*--api-key.*REACTOR_API_KEY/s);
+  });
+
+  it("rejects a 200 with a payload missing the `jwt` field", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 200, body: { token: "eyJ.x.y" } },
+    ]);
+
+    await expect(
+      exchangeApiKeyForJwt({
+        coordinatorUrl: "https://api.reactor.inc",
+        apiKey: "rk_secret",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/unexpected \/tokens payload shape/);
+  });
+
+  it("wraps network failures with the target URL", async () => {
+    const boom: typeof fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(
+      exchangeApiKeyForJwt({
+        coordinatorUrl: "https://api.reactor.inc",
+        apiKey: "rk_secret",
+        fetchImpl: boom,
+      }),
+    ).rejects.toThrow(
+      /Failed to reach coordinator at.*\/tokens.*fetch failed/s,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model name → UUID resolution.
+//
+// `GET /admin/models` is admin-only, so this path requires an API key.
+// The resolver exists so the CLI (and periodic CI) can work in model
+// names rather than UUIDs, which humans and committed config files
+// always think in.
+// ---------------------------------------------------------------------------
+
+describe("resolveModelIdByName", () => {
+  it("returns the id of the matching model summary", async () => {
+    // Pre-supplying `bearerToken` keeps this test focused on the
+    // resolver semantics (one /admin/models call → match by name);
+    // the apiKey → JWT exchange is covered in its own test below.
+    const { fetch, calls } = makeFetchStub([
+      {
+        status: 200,
+        body: [
+          { id: "7b3f1bc2-a4e5-4d78-b9c1-123456789abc", name: "helios" },
+          { id: "9e2a3dc4-beef-dead-face-000000000000", name: "morpheus" },
+        ],
+      },
+    ]);
+
+    const id = await resolveModelIdByName({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelName: "morpheus",
+      bearerToken: "eyJ.admin.jwt",
+      fetchImpl: fetch,
+    });
+
+    expect(id).toBe("9e2a3dc4-beef-dead-face-000000000000");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.reactor.inc/admin/models");
+    expect(
+      (calls[0].init?.headers as Record<string, string>).Authorization,
+    ).toBe("Bearer eyJ.admin.jwt");
+  });
+
+  it("exchanges --api-key for a JWT before listing models", async () => {
+    const { fetch, calls } = makeFetchStub([
+      { status: 200, body: { jwt: "eyJ.exchanged.jwt" } },
+      { status: 200, body: [{ id: "7b3f1bc2-…", name: "helios" }] },
+    ]);
+
+    await resolveModelIdByName({
+      coordinatorUrl: "https://api.reactor.inc",
+      modelName: "helios",
+      apiKey: "rk_admin",
+      fetchImpl: fetch,
+    });
+
+    expect(calls).toHaveLength(2);
+    // Step 1: token exchange via the dedicated header.
+    expect(calls[0].url).toBe("https://api.reactor.inc/tokens");
+    const tokenHeaders = calls[0].init?.headers as Record<string, string>;
+    expect(tokenHeaders["Reactor-API-Key"]).toBe("rk_admin");
+    // Step 2: /admin/models with the JWT, no API key.
+    const adminHeaders = calls[1].init?.headers as Record<string, string>;
+    expect(adminHeaders.Authorization).toBe("Bearer eyJ.exchanged.jwt");
+    expect(adminHeaders["Reactor-API-Key"]).toBeUndefined();
+  });
+
+  it("is case-sensitive and does not match on prefix", async () => {
+    // Case-folding or prefix-matching would be surprising and would let
+    // a rename accidentally start republishing under the old slug.
+    const { fetch } = makeFetchStub([
+      {
+        status: 200,
+        body: [{ id: "7b3f1bc2-a4e5-4d78-b9c1-123456789abc", name: "helios" }],
+      },
+    ]);
+
+    await expect(
+      resolveModelIdByName({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelName: "Helios",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/No model named "Helios" registered on the coordinator/);
+  });
+
+  it("surfaces a clear error when no model matches", async () => {
+    const { fetch } = makeFetchStub([
+      { status: 200, body: [{ id: "a", name: "helios" }] },
+    ]);
+
+    await expect(
+      resolveModelIdByName({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelName: "ghost",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/No model named "ghost"/);
+  });
+
+  it("rejects an empty --model string before making any request", async () => {
+    const { fetch, calls } = makeFetchStub([]);
+
+    await expect(
+      resolveModelIdByName({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelName: "",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/Invalid --model/);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces 401 through the same error wording as fetchSchema", async () => {
+    // `/admin/models` is admin-only, so an unauthenticated caller gets
+    // 401 and the resolver must surface the same actionable hint as
+    // the rest of the coordinator fetcher.
+    const { fetch } = makeFetchStub([
+      { status: 401, body: "unauthorized", statusText: "Unauthorized" },
+    ]);
+
+    await expect(
+      resolveModelIdByName({
+        coordinatorUrl: "https://api.reactor.inc",
+        modelName: "helios",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/401.*--api-key.*REACTOR_API_KEY/s);
+  });
+});

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -9,9 +9,20 @@ import {
   generateModelSdk,
   writePackage,
 } from "./codegen.js";
+import {
+  exchangeApiKeyForJwt,
+  fetchSchema,
+  resolveModelIdByName,
+} from "./coordinator.js";
+import type { OpenApiSchema } from "./openapi/index.js";
 
 interface CliArgs {
-  schema: string;
+  schema?: string;
+  coordinatorUrl?: string;
+  modelId?: string;
+  modelName?: string;
+  release?: string;
+  apiKey?: string;
   sdkVersion: string;
   output: string;
   dryRun: boolean;
@@ -52,8 +63,27 @@ function usage(): never {
   console.error(`
 Usage: reactor-codegen [options]
 
-Options:
+Schema source (pick ONE):
   --schema <path>             Path to the model's OpenAPI schema JSON
+  --coordinator-url <url>     Coordinator base URL to fetch the schema from
+                              (pair with --model-id; optionally --release
+                              and --api-key / REACTOR_API_KEY)
+
+Coordinator-mode options (pick ONE of --model or --model-id):
+  --model <name>              Model name on the coordinator. The CLI resolves
+                              it to a UUID via GET /admin/models; requires an
+                              --api-key that can list models.
+  --model-id <uuid>           Model UUID on the coordinator (no admin list
+                              permission needed for public schemas).
+  --release <semver>          Semver-prefix release selector (e.g. v1.0.5).
+                              If omitted, the CLI lists registered schemas
+                              and picks the highest semver.
+  --api-key <key>             Bearer token for private models. Falls back to
+                              the REACTOR_API_KEY environment variable.
+                              Public models are readable without auth, but
+                              --model name resolution always requires auth.
+
+Common options:
   --sdk-version <semver>      JS SDK version to pin as a dependency.
                               Defaults to the \`defaultSdkVersion\` field in
                               @reactor-team/codegen's package.json${
@@ -96,6 +126,21 @@ function parseArgs(argv: string[]): CliArgs {
       case "--schema":
         args.schema = argv[++i];
         break;
+      case "--coordinator-url":
+        args.coordinatorUrl = argv[++i];
+        break;
+      case "--model":
+        args.modelName = argv[++i];
+        break;
+      case "--model-id":
+        args.modelId = argv[++i];
+        break;
+      case "--release":
+        args.release = argv[++i];
+        break;
+      case "--api-key":
+        args.apiKey = argv[++i];
+        break;
       case "--sdk-version":
         args.sdkVersion = argv[++i];
         break;
@@ -124,11 +169,46 @@ function parseArgs(argv: string[]): CliArgs {
     }
   }
 
-  // `sdkVersion` is optional on the CLI: if the user didn't pass one and
-  // the codegen's package.json default is also missing, only then fail.
-  // This keeps "no flag on the command line" the happy path for CI while
-  // still catching a misconfigured install.
-  if (!args.schema || !args.output || !args.sdkVersion) {
+  // Source selection is mutually exclusive; exactly one must be set.
+  const hasFile = !!args.schema;
+  const hasCoordinator = !!args.coordinatorUrl;
+  if (hasFile && hasCoordinator) {
+    console.error(
+      "Error: --schema and --coordinator-url are mutually exclusive.\n",
+    );
+    usage();
+  }
+  if (!hasFile && !hasCoordinator) {
+    console.error("Error: one of --schema or --coordinator-url is required.\n");
+    usage();
+  }
+
+  // Pick exactly one of --model / --model-id alongside --coordinator-url.
+  // Both together is ambiguous; neither leaves the fetcher with no target.
+  const hasModelId = !!args.modelId;
+  const hasModelName = !!args.modelName;
+  if (hasCoordinator && hasModelId && hasModelName) {
+    console.error("Error: --model and --model-id are mutually exclusive.\n");
+    usage();
+  }
+  if (hasCoordinator && !hasModelId && !hasModelName) {
+    console.error("Error: --coordinator-url requires --model or --model-id.\n");
+    usage();
+  }
+
+  // Fall back to REACTOR_API_KEY. Keeps tokens out of shell history / CI
+  // process listings by default, matching the convention used across
+  // the rest of Reactor's tooling.
+  if (hasCoordinator && !args.apiKey && process.env.REACTOR_API_KEY) {
+    args.apiKey = process.env.REACTOR_API_KEY;
+  }
+
+  // `sdkVersion` is optional on the CLI: `parseArgs` pre-seeds it from
+  // the codegen's `defaultSdkVersion` field, and an explicit
+  // `--sdk-version` on the command line overwrites that. Only fail if
+  // both the CLI and the committed default are missing — that's a
+  // misconfigured install, not a user mistake.
+  if (!args.output || !args.sdkVersion) {
     console.error("Error: missing required arguments.\n");
     usage();
   }
@@ -180,16 +260,87 @@ function resolveStandaloneReactPath(standaloneOutput: string): string {
   return standaloneOutput.replace(/\.ts$/, ".react.ts");
 }
 
-function main(): void {
+/**
+ * Load the raw OpenAPI document from whichever source the user pointed
+ * at. Keeps the two input modes (file on disk vs coordinator HTTP) in
+ * one place so the rest of `main()` never branches on source type.
+ */
+async function resolveSchema(
+  args: CliArgs,
+): Promise<{ raw: OpenApiSchema; resolvedModelId?: string }> {
+  if (args.schema) {
+    return { raw: loadSchema(args.schema) };
+  }
+
+  // Per the REST API contract, the API key is only valid on `POST
+  // /tokens`; every other call wants a JWT. Exchange once at the top
+  // of the coordinator flow and reuse the JWT for both the optional
+  // `/admin/models` name lookup and the schema fetch — that's at most
+  // one `/tokens` round-trip per CLI invocation, instead of one per
+  // coordinator request.
+  const bearerToken = args.apiKey
+    ? await exchangeApiKeyForJwt({
+        coordinatorUrl: args.coordinatorUrl!,
+        apiKey: args.apiKey,
+      })
+    : undefined;
+
+  // `args.coordinatorUrl` is guaranteed by parseArgs here. Either
+  // `--model-id` was given directly or `--model <name>` needs to be
+  // resolved through the coordinator first. The name-resolution call is
+  // intentionally serial (it's one extra round-trip, once per invocation)
+  // rather than folded into `fetchSchema` — keeping the public
+  // `fetchSchema` shape UUID-only means callers that already have the ID
+  // don't pay for the extra /admin/models request.
+  let modelId = args.modelId;
+  if (!modelId && args.modelName) {
+    modelId = await resolveModelIdByName({
+      coordinatorUrl: args.coordinatorUrl!,
+      modelName: args.modelName,
+      bearerToken,
+    });
+  }
+
+  const raw = await fetchSchema({
+    coordinatorUrl: args.coordinatorUrl!,
+    modelId: modelId!,
+    release: args.release,
+    bearerToken,
+  });
+
+  if (!raw || typeof raw !== "object" || !("openapi" in raw)) {
+    throw new Error(
+      `Coordinator returned a schema payload that is not an OpenAPI 3.x ` +
+        `document (missing "openapi" field).`,
+    );
+  }
+
+  return { raw: raw as OpenApiSchema, resolvedModelId: modelId };
+}
+
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
-  const rawSchema = loadSchema(args.schema);
+  const { raw: rawSchema, resolvedModelId } = await resolveSchema(args);
   const schema = parseSchema(rawSchema);
 
   console.log(`@reactor-team/codegen`);
   console.log(`  Model:    ${schema.modelName}@${schema.modelVersion}`);
   console.log(`  SDK pin:  @reactor-team/js-sdk@^${args.sdkVersion}`);
-  console.log(`  Schema:   ${args.schema}`);
+  if (args.schema) {
+    console.log(`  Schema:   ${args.schema}`);
+  } else {
+    // Display the resolved UUID whether it came in directly or via the
+    // name-resolution hop — the user always wants to see the ID the
+    // downstream request actually used, for debuggability.
+    const displayId = args.modelId ?? resolvedModelId ?? "(unresolved)";
+    const nameSuffix = args.modelName ? ` name="${args.modelName}"` : "";
+    console.log(
+      `  Schema:   ${args.coordinatorUrl} (model-id=${displayId}${nameSuffix})`,
+    );
+    console.log(`  Release:  ${args.release ?? "<latest>"}`);
+    console.log(`  Auth:     ${args.apiKey ? "bearer token" : "anonymous"}`);
+  }
   console.log(`  Output:   ${args.output}`);
   if (args.standalone) {
     console.log(`  Mode:     standalone (source-only, no package scaffold)`);
@@ -333,4 +484,11 @@ function main(): void {
   }
 }
 
-main();
+// Top-level error wall: any thrown Error (network, 4xx/5xx, bad payload,
+// file-not-found) becomes a single-line stderr message and a non-zero
+// exit. Keeps the CLI's failure surface small and grep-able.
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+});

--- a/packages/codegen/src/coordinator.ts
+++ b/packages/codegen/src/coordinator.ts
@@ -1,0 +1,624 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import type { OpenApiSchema } from "./openapi/index.js";
+
+// ---------------------------------------------------------------------------
+// Coordinator fetcher — pulls an OpenAPI schema straight from the control
+// plane instead of reading it off disk. Keeps the same return type as
+// `loadSchema` so downstream stages (`parseSchema`, the emitter, the CLI)
+// don't need to know where the document came from.
+// ---------------------------------------------------------------------------
+
+export interface FetchSchemaOptions {
+  /**
+   * Coordinator base URL — scheme + host, no trailing slash required.
+   * E.g. `https://api.reactor.inc` or `http://localhost:8080`.
+   */
+  coordinatorUrl: string;
+  /**
+   * Model UUID — the `{id}` path parameter on
+   * `/admin/models/{id}/schemas`. Model names are not accepted by the
+   * coordinator, so the CLI only surfaces UUIDs.
+   */
+  modelId: string;
+  /**
+   * Optional semver-prefix release selector. When supplied we hit
+   * `?release=<release>` and the coordinator returns the single matching
+   * record. When omitted we list and pick the most recently created one
+   * (the default CI workflow: "give me the latest schema").
+   */
+  release?: string;
+  /**
+   * Reactor API key (e.g. `rk_a1b2c3...`). Per the REST API contract an
+   * API key is only valid on `POST /tokens`; everything else expects a
+   * short-lived JWT in `Authorization: Bearer`. If this is set (and
+   * `bearerToken` is not) the function exchanges the key for a JWT via
+   * `/tokens` before issuing any `/admin/*` request.
+   *
+   * Public models are readable without auth; private models return
+   * `404` to unauthenticated callers (the coordinator never leaks
+   * existence via `403`). When both `apiKey` and `bearerToken` are
+   * unset, the request is anonymous.
+   */
+  apiKey?: string;
+  /**
+   * Pre-exchanged JWT. When set, skips the `POST /tokens` round-trip
+   * and uses this verbatim as `Authorization: Bearer <bearerToken>`.
+   * Intended for callers that already hold a JWT (e.g. the CLI, which
+   * exchanges once and reuses across `resolveModelIdByName` +
+   * `fetchSchema`) or for tests that want to bypass the token dance.
+   *
+   * When both `bearerToken` and `apiKey` are set, `bearerToken` wins.
+   */
+  bearerToken?: string;
+  /**
+   * Injection seam for tests. Defaults to the global `fetch` (Node 18+).
+   * Keeps the production code dependency-free while letting us exercise
+   * every status-code branch against a local function.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator response shapes — mirror what the REST API doc promises.
+// Kept `unknown` at the schema payload level so the parser still owns the
+// OpenAPI validation contract.
+// ---------------------------------------------------------------------------
+
+interface CoordinatorSchemaRecord {
+  id: string;
+  model_id: string;
+  release: string;
+  schema: unknown;
+  created_at: number;
+  updated_at: number;
+}
+
+interface CoordinatorSchemaSummary {
+  id: string;
+  release: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function trimTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+// Pin the API version we speak at the protocol level. The coordinator's
+// docs say "`Reactor-API-Version`" is validated on `/tokens` and
+// `/sessions`; adding it everywhere is safe and keeps us compatible if
+// that gate ever widens to `/admin/*`.
+const REACTOR_API_VERSION = "1";
+
+/**
+ * Build request headers for a coordinator call. When `bearerToken` is
+ * set it becomes `Authorization: Bearer <token>`; otherwise the
+ * request goes out anonymous (which only succeeds on public-model
+ * reads — see the 404-on-private note on {@link FetchSchemaOptions}).
+ */
+function buildHeaders(bearerToken: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Reactor-API-Version": REACTOR_API_VERSION,
+  };
+  if (bearerToken) headers.Authorization = `Bearer ${bearerToken}`;
+  return headers;
+}
+
+function requireUuidLike(modelId: string): void {
+  // The coordinator returns `400` for malformed UUIDs, but surfacing the
+  // check client-side gives a clearer error than "400 Bad Request" with
+  // no body. We don't do strict UUID validation — any obviously-broken
+  // value (empty, whitespace, slash, embedded scheme) fails fast.
+  const invalid =
+    modelId.length === 0 ||
+    /\s/.test(modelId) ||
+    modelId.includes("/") ||
+    modelId.includes(":");
+  if (invalid) {
+    throw new Error(
+      `Invalid --model-id: expected a UUID, got ${JSON.stringify(modelId)}`,
+    );
+  }
+}
+
+async function readBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Translate a non-2xx response into a user-facing error. The coordinator
+ * uses `404` for both "model not found" and "private model, caller not
+ * authorised" (see REST-API.md § Access Control), so the message nudges
+ * the user to double-check both.
+ */
+async function responseToError(
+  response: Response,
+  context: string,
+): Promise<Error> {
+  const body = await readBody(response);
+  const suffix = body ? `: ${body}` : "";
+
+  switch (response.status) {
+    case 401:
+      return new Error(
+        `Coordinator rejected credentials (401) while ${context}. ` +
+          `Check --api-key (or REACTOR_API_KEY)${suffix}`,
+      );
+    case 403:
+      return new Error(
+        `Coordinator forbade the request (403) while ${context}. ` +
+          `The provided token lacks the required role${suffix}`,
+      );
+    case 404:
+      return new Error(
+        `Coordinator returned 404 while ${context}. ` +
+          `Either the model ID is wrong, no schema is registered for the ` +
+          `requested release, or the model is private and --api-key was ` +
+          `not supplied${suffix}`,
+      );
+    default:
+      return new Error(
+        `Coordinator responded with ${response.status} ${response.statusText} while ${context}${suffix}`,
+      );
+  }
+}
+
+async function getJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  headers: Record<string, string>,
+  context: string,
+): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, { method: "GET", headers });
+  } catch (err) {
+    // Wrap the underlying network error so the CLI can fail without a
+    // raw `TypeError: fetch failed` / cause chain leaking to the user.
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to reach coordinator at ${url} while ${context}: ${msg}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw await responseToError(response, context);
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Coordinator returned non-JSON body while ${context}: ${msg}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// API key → JWT exchange.
+//
+// Per `docs/REST-API.md`, a Reactor API key is only valid on
+// `POST /tokens` (via `Reactor-API-Key: <key>`); every other endpoint
+// wants `Authorization: Bearer <jwt>`. This helper owns that one-shot
+// exchange so the rest of the fetcher can work in JWTs from here on.
+// ---------------------------------------------------------------------------
+
+export interface ExchangeApiKeyOptions {
+  coordinatorUrl: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+function assertTokenResponse(
+  payload: unknown,
+): asserts payload is { jwt: string } {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    typeof (payload as { jwt?: unknown }).jwt !== "string" ||
+    (payload as { jwt: string }).jwt.length === 0
+  ) {
+    throw new Error(
+      `Coordinator returned an unexpected /tokens payload shape ` +
+        `(expected { "jwt": string })`,
+    );
+  }
+}
+
+/**
+ * Exchange a Reactor API key for a short-lived JWT via `POST /tokens`.
+ * Returns the raw JWT string; the caller is responsible for passing it
+ * as `bearerToken` to {@link fetchSchema} / {@link resolveModelIdByName}
+ * (or for dropping it straight into `Authorization: Bearer`).
+ *
+ * Failure modes match the rest of the coordinator fetcher: network
+ * errors are wrapped with the target URL, non-2xx responses get a
+ * `401`-specific actionable message, and malformed payloads throw.
+ */
+export async function exchangeApiKeyForJwt(
+  options: ExchangeApiKeyOptions,
+): Promise<string> {
+  if (typeof options.apiKey !== "string" || options.apiKey.length === 0) {
+    throw new Error("Invalid --api-key: expected a non-empty string");
+  }
+
+  const base = trimTrailingSlashes(options.coordinatorUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `${base}/tokens`;
+  const context = "exchanging API key for JWT";
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        // `Reactor-API-Key` is the current (non-deprecated) token-
+        // generation header; see REST-API.md § Authentication. We
+        // deliberately don't fall back to `X-API-Key` — the codegen
+        // is new code and shipping the legacy header would just
+        // delay that deprecation.
+        "Reactor-API-Key": options.apiKey,
+        "Reactor-API-Version": REACTOR_API_VERSION,
+      },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to reach coordinator at ${url} while ${context}: ${msg}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw await responseToError(response, context);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Coordinator returned non-JSON body while ${context}: ${msg}`,
+    );
+  }
+  assertTokenResponse(payload);
+  return payload.jwt;
+}
+
+/**
+ * Resolve the bearer token a coordinator request should use. When the
+ * caller hands us a `bearerToken` we use it verbatim; when they hand us
+ * an `apiKey` we exchange via {@link exchangeApiKeyForJwt}; when both
+ * are absent the return is `undefined` (→ anonymous request).
+ */
+async function resolveBearerToken(
+  coordinatorUrl: string,
+  fetchImpl: typeof fetch,
+  bearerToken: string | undefined,
+  apiKey: string | undefined,
+): Promise<string | undefined> {
+  if (bearerToken) return bearerToken;
+  if (!apiKey) return undefined;
+  return exchangeApiKeyForJwt({ coordinatorUrl, apiKey, fetchImpl });
+}
+
+function assertRecord(
+  payload: unknown,
+  context: string,
+): asserts payload is CoordinatorSchemaRecord {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !("schema" in payload) ||
+    typeof (payload as { schema: unknown }).schema !== "object" ||
+    (payload as { schema: unknown }).schema === null
+  ) {
+    throw new Error(
+      `Coordinator returned an unexpected payload shape while ${context} ` +
+        `(expected a schema record with a "schema" object)`,
+    );
+  }
+}
+
+function assertSummaryList(
+  payload: unknown,
+  context: string,
+): asserts payload is CoordinatorSchemaSummary[] {
+  if (!Array.isArray(payload)) {
+    throw new Error(
+      `Coordinator returned an unexpected payload shape while ${context} ` +
+        `(expected an array of {id, release} summaries)`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Latest-release resolution.
+//
+// Today we get the "latest" release by listing /schemas and picking the
+// highest semver client-side. This is isolated in `pickLatestRelease`
+// (not inlined into `fetchSchema`) because the coordinator team plans to
+// expose a dedicated `/releases?latest` endpoint — when that ships, this
+// function becomes a trivial passthrough around that call and every
+// caller gets the benefit without a public API change.
+//
+// Release tag shape in Reactor is `v<MAJOR>.<MINOR>.<PATCH>-g<sha>`.
+// We compare on the numeric triple; tie-breaks fall back to the full
+// release string lexicographically (which covers `-g<sha>` consistently
+// for a given build but is NOT timestamp-ordered across builds — that's
+// the case the server-side endpoint will eventually handle properly).
+// ---------------------------------------------------------------------------
+
+interface ParsedRelease {
+  major: number;
+  minor: number;
+  patch: number;
+  suffix: string;
+}
+
+function parseReleaseTag(tag: string): ParsedRelease | null {
+  // Accept both `v1.2.3` and `1.2.3` so we don't reject a stray tag
+  // style — the comparator just needs the numeric prefix.
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+](.*))?$/.exec(tag);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    suffix: match[4] ?? "",
+  };
+}
+
+/**
+ * Compare two release tags in semver-ish ascending order. Returns
+ * negative if `a` sorts before `b`, positive if after, 0 if equal.
+ * Unparseable tags sort *before* parseable ones so they can't beat a
+ * valid release in a `max` operation.
+ */
+function compareReleaseTags(a: string, b: string): number {
+  const pa = parseReleaseTag(a);
+  const pb = parseReleaseTag(b);
+  if (!pa && !pb) return a.localeCompare(b);
+  if (!pa) return -1;
+  if (!pb) return 1;
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  // Same numeric triple → fall back to a lexicographic compare on the
+  // parsed suffix so cosmetic differences in the *prefix* (`v1.2.3` vs
+  // `1.2.3`) don't leak into ordering. When suffixes also match, the
+  // tags are semantically equal and we return 0.
+  //
+  // Caveat: for Reactor's `-g<sha>` suffixes this is stable but not
+  // timestamp order — if two builds share a triple, the one the
+  // comparator picks isn't meaningfully "newer". Fine for current use
+  // (the team bumps semver on every CI run); the server-side
+  // `/releases?latest` endpoint will supersede this when it lands.
+  return pa.suffix.localeCompare(pb.suffix);
+}
+
+/**
+ * Return the entry in `summaries` with the highest release tag, or
+ * `null` if the list is empty. Exposed as a standalone export so the
+ * CI pipeline (and anyone writing their own client) can reuse the
+ * exact same ordering the codegen uses, and so we can replace the
+ * internals with a `/releases?latest` call without changing callers.
+ */
+export function pickLatestRelease(
+  summaries: CoordinatorSchemaSummary[],
+): CoordinatorSchemaSummary | null {
+  if (summaries.length === 0) return null;
+  let best = summaries[0];
+  for (let i = 1; i < summaries.length; i++) {
+    if (compareReleaseTags(summaries[i].release, best.release) > 0) {
+      best = summaries[i];
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Model UUID resolution by name.
+//
+// The `/admin/models/{id}/schemas` endpoint takes a UUID path param, but
+// CI pipelines (and humans) think in model *names* — "helios", not
+// `7b3f1bc2-…`. Resolving names here keeps the bash around the CLI tiny
+// and centralises the "which ID does this name map to?" logic in one
+// tested place.
+//
+// Caveat: `GET /admin/models` is admin-only, so this path requires a
+// bearer token that can list models. Public schema reads via `--model-id`
+// still work without auth.
+// ---------------------------------------------------------------------------
+
+interface CoordinatorModelSummary {
+  id: string;
+  name: string;
+}
+
+export interface ResolveModelIdOptions {
+  coordinatorUrl: string;
+  modelName: string;
+  /** See {@link FetchSchemaOptions.apiKey}. */
+  apiKey?: string;
+  /** See {@link FetchSchemaOptions.bearerToken}. */
+  bearerToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function assertModelSummaryList(
+  payload: unknown,
+  context: string,
+): asserts payload is CoordinatorModelSummary[] {
+  if (!Array.isArray(payload)) {
+    throw new Error(
+      `Coordinator returned an unexpected payload shape while ${context} ` +
+        `(expected an array of model summaries)`,
+    );
+  }
+}
+
+/**
+ * Look up a model's UUID by name. Calls `GET /admin/models`, finds the
+ * exact-match entry, and returns its `id`. Throws when no match exists
+ * so the CLI can surface a clear "no such model" error instead of
+ * degrading into a misleading 404 later in the fetch flow.
+ */
+export async function resolveModelIdByName(
+  options: ResolveModelIdOptions,
+): Promise<string> {
+  if (typeof options.modelName !== "string" || options.modelName.length === 0) {
+    throw new Error(
+      `Invalid --model: expected a non-empty name, got ${JSON.stringify(options.modelName)}`,
+    );
+  }
+
+  const base = trimTrailingSlashes(options.coordinatorUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  // Exchange the API key for a JWT once per call; every subsequent
+  // coordinator request on this call uses the same JWT.
+  const bearerToken = await resolveBearerToken(
+    base,
+    fetchImpl,
+    options.bearerToken,
+    options.apiKey,
+  );
+  const headers = buildHeaders(bearerToken);
+  const url = `${base}/admin/models`;
+  const context = `resolving model "${options.modelName}" to a UUID`;
+
+  const summaries = await getJson<unknown>(fetchImpl, url, headers, context);
+  assertModelSummaryList(summaries, context);
+
+  const match = summaries.find((m) => m && m.name === options.modelName);
+  if (!match) {
+    throw new Error(
+      `No model named ${JSON.stringify(options.modelName)} registered on the coordinator. ` +
+        `Check the name (it's case-sensitive) or that the --api-key is authorised to list models.`,
+    );
+  }
+  if (typeof match.id !== "string" || match.id.length === 0) {
+    throw new Error(
+      `Coordinator returned a summary for "${options.modelName}" without a usable "id" field.`,
+    );
+  }
+  return match.id;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch an OpenAPI schema registered against a model on the Reactor
+ * coordinator. Returns the raw `OpenApiSchema` document — callers feed it
+ * straight into {@link parseSchema} to produce the codegen IR.
+ *
+ * Release selection:
+ *   - With `release`: hits `GET /admin/models/{id}/schemas?release=<release>`.
+ *     The coordinator does a semver-prefix match (`v1.0.5` matches
+ *     `v1.0.5-ge6187a05` etc.) and returns the most recently created
+ *     record when multiple rows match.
+ *   - Without `release`: lists `(id, release)` pairs, delegates to
+ *     {@link pickLatestRelease} (highest semver, ties broken lexicographically),
+ *     then issues a follow-up `GET /admin/models/{id}/schemas/{schema_id}`
+ *     to fetch the full payload. The "pick highest" step is deliberately
+ *     isolated so it can be replaced with a `/releases?latest` call if
+ *     and when the coordinator exposes one.
+ *
+ * Auth:
+ *   - Public models are readable without `apiKey`.
+ *   - Private models return `404` (not `403`) to unauthenticated callers
+ *     so their existence is never leaked. The raised error wording
+ *     reflects both interpretations.
+ */
+export async function fetchSchema(
+  options: FetchSchemaOptions,
+): Promise<OpenApiSchema> {
+  requireUuidLike(options.modelId);
+
+  const base = trimTrailingSlashes(options.coordinatorUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  // Exchange the API key for a JWT once per call; every subsequent
+  // coordinator request (including the list+detail two-step) shares
+  // that JWT.
+  const bearerToken = await resolveBearerToken(
+    base,
+    fetchImpl,
+    options.bearerToken,
+    options.apiKey,
+  );
+  const headers = buildHeaders(bearerToken);
+  const baseResource = `${base}/admin/models/${encodeURIComponent(options.modelId)}/schemas`;
+
+  // Release-scoped lookup: one request, single full record back.
+  if (options.release) {
+    const url = `${baseResource}?release=${encodeURIComponent(options.release)}`;
+    const context = `fetching schema for release "${options.release}"`;
+    const record = await getJson<unknown>(fetchImpl, url, headers, context);
+    assertRecord(record, context);
+    return record.schema as OpenApiSchema;
+  }
+
+  // No release specified: list + pick-latest-by-semver. The list
+  // endpoint omits the schema payload, so a follow-up by ID is required.
+  // We deliberately don't try to optimise this into a single call (e.g.
+  // `?release=v`) — the coordinator does not guarantee a prefix like `v`
+  // matches everything, and the API contract for "newest wins" only
+  // kicks in when there's more than one match for a given prefix.
+  const listUrl = baseResource;
+  const listContext = "listing registered schemas";
+  const summaries = await getJson<unknown>(
+    fetchImpl,
+    listUrl,
+    headers,
+    listContext,
+  );
+  assertSummaryList(summaries, listContext);
+
+  if (summaries.length === 0) {
+    throw new Error(
+      `No schemas registered for model ${options.modelId}. Pass --release ` +
+        `with a semver prefix once a schema has been published.`,
+    );
+  }
+
+  const latest = pickLatestRelease(summaries);
+  if (!latest || typeof latest.id !== "string") {
+    throw new Error(
+      `Coordinator returned an unexpected summary entry while ${listContext} ` +
+        `(missing "id" field).`,
+    );
+  }
+
+  const detailContext = `fetching schema ${latest.id} (release "${latest.release}")`;
+  const detailUrl = `${baseResource}/${encodeURIComponent(latest.id)}`;
+  const record = await getJson<unknown>(
+    fetchImpl,
+    detailUrl,
+    headers,
+    detailContext,
+  );
+  assertRecord(record, detailContext);
+  return record.schema as OpenApiSchema;
+}
+
+// Re-export internal helpers for targeted unit testing.
+// Public API consumers should only use `fetchSchema`.
+export const __testing__ = {
+  trimTrailingSlashes,
+  buildHeaders,
+  requireUuidLike,
+  compareReleaseTags,
+  parseReleaseTag,
+};

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -6,6 +6,17 @@ export {
   loadSchema,
   parseSchema,
 } from "./codegen.js";
+export {
+  exchangeApiKeyForJwt,
+  fetchSchema,
+  pickLatestRelease,
+  resolveModelIdByName,
+} from "./coordinator.js";
+export type {
+  ExchangeApiKeyOptions,
+  FetchSchemaOptions,
+  ResolveModelIdOptions,
+} from "./coordinator.js";
 export type { OpenApiSchema } from "./openapi/index.js";
 export type {
   CodegenOptions,


### PR DESCRIPTION
## Why

CI and developers shouldn't have to keep a committed `schema.json` or side-load one into the build. They should be able to point the codegen at a coordinator URL and let it pull the right schema for a given model release. This PR adds that second input mode and the REST-spec-compliant auth flow (`POST /tokens` exchange) it requires.

## What changed

**New module `src/coordinator.ts`**

- `fetchSchema({ coordinatorUrl, modelId, release?, apiKey?, bearerToken? })` — two code paths. With `--release`: one call, server-side semver-prefix match. Without: list + fetch-latest (client-side pick via `pickLatestRelease`). Uses Node 18+ built-in `fetch`; `fetchImpl` is a test injection seam.
- `pickLatestRelease(summaries)` — isolated semver sort helper, exported at the top level. When the coordinator ships `/releases?latest`, this collapses to a passthrough with no caller breakage.
- `resolveModelIdByName({ coordinatorUrl, modelName, ... })` — exact-match lookup via `GET /admin/models`. Case-sensitive; pre-IO guard on empty input.
- `exchangeApiKeyForJwt({ coordinatorUrl, apiKey })` — owns the `POST /tokens` + `Reactor-API-Key` exchange. Per REST-API.md, API keys are only valid on `/tokens`; every other endpoint wants a JWT in `Authorization: Bearer`.

**Auth wiring**

- `FetchSchemaOptions` / `ResolveModelIdOptions` each gain `bearerToken?` alongside `apiKey?`.
- Precedence: `bearerToken` (used verbatim) > `apiKey` (exchanged once) > anonymous.
- CLI exchanges **once** at the top of the coordinator flow and reuses the JWT across `resolveModelIdByName` + `fetchSchema`. At most one `/tokens` round-trip per invocation.
- `Reactor-API-Version: 1` pinned on every call.
- 404 on `/admin/*` returns wording that hints at both "not found" and "private model without `--api-key`" since the coordinator deliberately returns 404 (not 403) to unauth'd callers on private models so existence isn't leaked.

**New CLI flags**

| Flag | Required | Purpose |
|---|---|---|
| `--coordinator-url <url>` | if not `--schema` | Coordinator base URL. Mutually exclusive with `--schema`. |
| `--model-id <uuid>` | with `--coordinator-url` | Direct UUID lookup. |
| `--model <name>` | with `--coordinator-url` | Resolves name → UUID via `/admin/models`. Mutually exclusive with `--model-id`. |
| `--release <semver>` | no | Server-side prefix match. Omit to pick the highest semver from the list. |
| `--api-key <key>` | private models | Falls back to `REACTOR_API_KEY` env var. |

## Shape of the change

```
packages/codegen/
├── src/
│   ├── coordinator.ts           (new: 624 lines — fetchSchema, exchangeApiKeyForJwt,
│   │                             resolveModelIdByName, pickLatestRelease)
│   ├── cli.ts                   (+180: flag parsing + resolveSchema unification)
│   └── index.ts                 (+11: 4 new public helpers + 3 option type exports)
├── __tests__/
│   ├── coordinator.test.ts      (new: 43 tests, fetch stubbed in-process)
│   └── cli.test.ts              (+5: coordinator-mode flag parsing)
└── README.md                    (+69: "Fetching from the coordinator" section)
```

## Usage (CLI)

```bash
# Release-scoped (one request, server-side prefix match)
reactor-codegen \
  --coordinator-url https://api.reactor.inc \
  --model helios \
  --release v1.0.5 \
  --output ./out/helios

# Pick highest semver automatically
reactor-codegen \
  --coordinator-url https://api.reactor.inc \
  --model-id 7b3f1bc2-a4e5-4d78-b9c1-123456789abc \
  --output ./out/helios

# Private model — falls back to REACTOR_API_KEY if --api-key is not given
REACTOR_API_KEY=rk_... reactor-codegen \
  --coordinator-url https://api.reactor.inc \
  --model helios \
  --release v1.0.5 \
  --output ./out/helios
```

## Usage (library)

```ts
import { fetchSchema, exchangeApiKeyForJwt, parseSchema, generateModelSdk } from "@reactor-team/codegen";

const bearerToken = await exchangeApiKeyForJwt({
  coordinatorUrl: "https://api.reactor.inc",
  apiKey: process.env.REACTOR_API_KEY!,
});
const raw = await fetchSchema({
  coordinatorUrl: "https://api.reactor.inc",
  modelId: "7b3f1bc2-...",
  release: "v1.0.5",
  bearerToken,
});
const pkg = generateModelSdk({
  modelName: parseSchema(raw).modelName,
  modelVersion: parseSchema(raw).modelVersion,
  sdkVersion: "2.9.1",
  schema: parseSchema(raw),
  outputDir: "./out/helios",
});
```

## Tests

+48 tests (171 total). Helpers (`trimTrailingSlashes`, `buildHeaders`, `requireUuidLike`, `compareReleaseTags`, `pickLatestRelease` — empty list / single entry / highest wins / valid-over-junk / `g<sha>` tie-break); `fetchSchema` release-scoped + list+pick paths with URL shape + query encoding; `resolveModelIdByName` happy path + case-sensitivity + no-match + 401 wording; `exchangeApiKeyForJwt` happy path + trailing-slash trim + empty-key guard + 401 / malformed / network failure surfaces; end-to-end that `fetchSchema` exchanges the API key first and never leaks it in `/admin/*` requests; all error surfaces (401 / 403 / 404 / 5xx / network / malformed payload + pre-IO guards).

## Notes for reviewers

- Previously the fetcher sent `Authorization: Bearer <apiKey>` directly, conflating API keys and JWTs. REST spec says API keys are `Reactor-API-Key:` on `/tokens` only; `/admin/*` needs a JWT. Fixed here — the raw API key never appears in `Authorization`, and integration tests pin that invariant.
- `pickLatestRelease` is exported specifically so it can become a passthrough when the coordinator grows `/releases?latest` without breaking callers.

## Stack

1. [`[1/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/117) scaffold + IR
2. [`[2/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/118) parser + ingress validation
3. [`[3/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/119) emitter + README + injection defence + version helpers
4. [`[4/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/120) CLI + modelTracks + defaultSdkVersion
5. **→ this PR** coordinator fetch + auth exchange
6. [`[6/6]`](https://app.graphite.com/github/pr/reactor-team/js-sdk/122) Buildkite publish pipeline

Ref: [REA-1581](https://linear.app/reactor-team/issue/REA-1581)
