### PR TITLE
ci: don't clobber schedule-provided MODELS_SYNC/DRY via pipeline env

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,15 +51,21 @@ env:
   # scheduled run (or an ad-hoc REST trigger) can override this to
   # point at a dev/staging coordinator.
   COORDINATOR_URL: "https://api.reactor.inc"
-  # Normal per-push CI is the default path. The hourly Buildkite
-  # schedule sets `MODELS_SYNC=true` in its env block to enter the
-  # publish flow; anything else (manual builds, per-push runs) falls
-  # through to the regular build / format / test groups.
-  MODELS_SYNC: "false"
-  # `DRY=true` rehearses the publish flow end-to-end without actually
-  # pushing to npm. Defaults off so the scheduled sync publishes for
-  # real — rehearsals are opt-in per trigger.
-  DRY: "false"
+  #
+  # Deliberately NOT declared here:
+  #
+  #   MODELS_SYNC — trigger-scoped flag. The hourly Buildkite schedule
+  #                 sets this to "true" in its env block to enter the
+  #                 publish flow; every other trigger (per-push, manual
+  #                 build) leaves it unset and falls through to normal
+  #                 CI. Pipeline-level env in Buildkite OUTRANKS build-
+  #                 level env (incl. schedule / REST trigger env), so
+  #                 declaring `MODELS_SYNC: "false"` here would silently
+  #                 clobber what the schedule set. `build.env("MODELS_SYNC")`
+  #                 returns an empty string when the var is unset, which
+  #                 the `if: ... == "true"` gate below already handles.
+  #
+  #   DRY         — same reasoning. Opt-in per trigger when rehearsing.
 
 definitions:
   - &node_docker


### PR DESCRIPTION
## Why

The hourly models-sync schedule fired correctly, the bootstrap step uploaded `pipeline.yml`, but the `generate-publish-pipeline` step was dropped and no follow-up got emitted. From the schedule's env dump we know `MODELS_SYNC="true"` was set at build level, yet `build.env("MODELS_SYNC") == "true"` evaluated false.

Cause: pipeline-level `env:` declarations in `pipeline.yml` override build-level env (set by schedules, REST triggers, the UI). We had `MODELS_SYNC: "false"` declared at pipeline level "as a default", which silently clobbered what the schedule was passing in. `DRY` was declared the same way and had the same bug — it only happened to be silent because `"false"` is the behaviour we wanted when `MODELS_SYNC` was (erroneously) off.

## What changed

- Removed `MODELS_SYNC` and `DRY` from `env:` in `.buildkite/pipeline.yml`.
- `build.env("VAR")` returns `""` when the var is unset, which the existing `if: build.env("MODELS_SYNC") == "true"` gate treats as false — the exact behaviour we wanted defaults to express.
- Left a block comment in place of the old entries explaining the precedence trap so the next person doesn't re-introduce them.
- `COORDINATOR_URL` stays at pipeline level. It's a stable default that every trigger wants; no trigger currently tries to override it.

## Shape of the change

```diff
 env:
   COORDINATOR_URL: "https://api.reactor.inc"
-  MODELS_SYNC: "false"
-  DRY: "false"
+  # Deliberately NOT declared here:
+  #   MODELS_SYNC — pipeline-level env outranks build-level env, so
+  #                 declaring a default would clobber what the schedule
+  #                 / REST trigger passes in. `build.env(...)` returns
+  #                 "" when unset, which the `== "true"` gate handles.
+  #   DRY         — same reasoning.
```

## Verification

- [x] `pnpm format:check` clean.
- [ ] Next scheduled run (or manual rebuild of a scheduled build) should now flow through to `generate-publish-pipeline` → upload follow-up → `check-<MODEL>`. Confirm on the next hourly fire.
