### PR TITLE
[REA-1801] codegen: prefer OpenAPI `description` and render multi-paragraph docs

### DIFF
--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -27,6 +27,9 @@ const {
   formatVersionForModelConstant,
   sanitizeJsDocLine,
   enumValueToTs,
+  descriptionToJsDocLines,
+  descriptionSummary,
+  generateJsDoc,
 } = __testing__;
 
 // ---------------------------------------------------------------------------
@@ -81,6 +84,96 @@ describe("sanitizeJsDocLine", () => {
   it("leaves plain prose untouched", () => {
     expect(sanitizeJsDocLine("Set and encode the scene prompt.")).toBe(
       "Set and encode the scene prompt.",
+    );
+  });
+});
+
+describe("descriptionToJsDocLines", () => {
+  it("returns an empty array when the description is empty", () => {
+    expect(descriptionToJsDocLines("")).toEqual([]);
+    expect(descriptionToJsDocLines(undefined as unknown as string)).toEqual([]);
+  });
+
+  it("returns a single line for a single-paragraph description", () => {
+    expect(descriptionToJsDocLines("Set the scene prompt.")).toEqual([
+      "Set the scene prompt.",
+    ]);
+  });
+
+  it("inserts a blank entry between paragraphs so JSDoc renders proper paragraph breaks", () => {
+    // The blank "" entry is the contract `generateJsDoc` consumes to
+    // emit a bare ` *` separator line. Without it, multi-paragraph
+    // ModelMessage docstrings (REA-1801) would collapse onto one line.
+    expect(
+      descriptionToJsDocLines("Summary line.\n\nLonger body explanation."),
+    ).toEqual(["Summary line.", "", "Longer body explanation."]);
+  });
+
+  it("treats runs of three-or-more newlines as a single paragraph break", () => {
+    expect(descriptionToJsDocLines("A.\n\n\n\nB.")).toEqual(["A.", "", "B."]);
+  });
+
+  it("does not split on a single newline (intra-paragraph wrapping is preserved for sanitiser)", () => {
+    // A single `\n` is intra-paragraph code-style line wrapping — we
+    // leave it to `sanitizeJsDocLine` to flatten into a space, so the
+    // paragraph still renders as one logical line.
+    expect(descriptionToJsDocLines("wrapped\nover lines")).toEqual([
+      "wrapped\nover lines",
+    ]);
+  });
+});
+
+describe("descriptionSummary", () => {
+  it("returns the first paragraph for a multi-paragraph description", () => {
+    expect(descriptionSummary("Summary.\n\nBody.")).toBe("Summary.");
+  });
+
+  it("returns the full text when the description has only one paragraph", () => {
+    expect(descriptionSummary("Just one sentence.")).toBe("Just one sentence.");
+  });
+
+  it("returns an empty string for an empty description", () => {
+    expect(descriptionSummary("")).toBe("");
+  });
+});
+
+describe("generateJsDoc — multi-paragraph rendering", () => {
+  it("renders a single-line description as a one-line JSDoc comment", () => {
+    expect(generateJsDoc(["Hello."])).toBe("/** Hello. */\n");
+  });
+
+  it("renders a blank entry as a bare ` *` paragraph-separator line", () => {
+    // This is the JSDoc-idiomatic paragraph break — TypeDoc, VS Code
+    // hovers, and TSDoc all render the gap as a paragraph boundary.
+    const out = generateJsDoc(["Summary.", "", "Body."]);
+    expect(out).toBe(
+      ["/**", " * Summary.", " *", " * Body.", " */", ""].join("\n"),
+    );
+  });
+
+  it("end-to-end: a multi-paragraph event description splits into paragraphs in the param interface", () => {
+    const event: EventSchema = {
+      name: "set_prompt",
+      description: "Set the scene prompt.\n\nApplied next iteration.",
+      fields: { prompt: { type: "string", default: "" } },
+    };
+    const out = generateParamInterface("Helios", event);
+    // Multi-line JSDoc with a bare ` *` between the two paragraphs.
+    expect(out).toContain(
+      "/**\n * Set the scene prompt.\n *\n * Applied next iteration.\n */",
+    );
+  });
+
+  it("end-to-end: a multi-paragraph message description splits into paragraphs in the message interface", () => {
+    const message: MessageSchema = {
+      name: "generation_reset",
+      description:
+        "Emitted after `reset` clears session state.\n\nThe model is back in the waiting state.",
+      fields: {},
+    };
+    const out = generateMessageInterface("Helios", message);
+    expect(out).toContain(
+      "/**\n * Emitted after `reset` clears session state.\n *\n * The model is back in the waiting state.\n */",
     );
   });
 });

--- a/packages/codegen/__tests__/parser.test.ts
+++ b/packages/codegen/__tests__/parser.test.ts
@@ -152,6 +152,67 @@ describe("parseSchema — events (paths → operations)", () => {
     });
   });
 
+  it("prefers `description` over `summary` for the event description", () => {
+    // Current Reactor runtimes (post-REA-1801) emit the full docstring as
+    // OpenAPI `description` and only the first paragraph as `summary`.
+    // The parser must surface the richer `description` to the SDK.
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/set_prompt": {
+            post: {
+              operationId: "set_prompt",
+              summary: "Set the scene prompt.",
+              description:
+                "Set the scene prompt.\n\nApplied on the next inference iteration.",
+              requestBody: {
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events[0].description).toBe(
+      "Set the scene prompt.\n\nApplied on the next inference iteration.",
+    );
+  });
+
+  it("falls back to `summary` when `description` is absent (legacy schemas)", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/set_prompt": {
+            post: {
+              operationId: "set_prompt",
+              summary: "Set the scene prompt",
+              requestBody: {
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events[0].description).toBe("Set the scene prompt");
+  });
+
+  it("returns an empty description when neither field is set", () => {
+    const ir = parseSchema(
+      baseSchema({
+        paths: {
+          "/events/ping": {
+            post: { operationId: "ping" },
+          },
+        },
+      }),
+    );
+
+    expect(ir.events[0].description).toBe("");
+  });
+
   it("falls back to the final path segment when operationId is absent", () => {
     const ir = parseSchema(
       baseSchema({
@@ -288,6 +349,55 @@ describe("parseSchema — messages (webhooks → operations)", () => {
     );
 
     expect(ir.messages[0].name).toBe("generation_started");
+  });
+
+  it("prefers `description` over `summary` for the message description", () => {
+    // Mirror of the events test — same precedence applies on the
+    // webhooks branch so multi-paragraph ModelMessage docstrings
+    // (REA-1801) reach the SDK in full.
+    const ir = parseSchema(
+      baseSchema({
+        webhooks: {
+          generation_reset: {
+            post: {
+              operationId: "generation_reset",
+              summary: "Emitted after `reset` clears session state.",
+              description:
+                "Emitted after `reset` clears session state.\n\nThe model is back in the waiting state.",
+              requestBody: {
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.messages[0].description).toBe(
+      "Emitted after `reset` clears session state.\n\nThe model is back in the waiting state.",
+    );
+  });
+
+  it("falls back to `summary` for messages when `description` is absent (legacy schemas)", () => {
+    const ir = parseSchema(
+      baseSchema({
+        webhooks: {
+          prompt_accepted: {
+            post: {
+              operationId: "prompt_accepted",
+              summary: "A prompt was accepted and scheduled.",
+              requestBody: {
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(ir.messages[0].description).toBe(
+      "A prompt was accepted and scheduled.",
+    );
   });
 });
 

--- a/packages/codegen/__tests__/readme-emitter.test.ts
+++ b/packages/codegen/__tests__/readme-emitter.test.ts
@@ -205,6 +205,43 @@ describe("README emission", () => {
     expect(md).not.toMatch(/parallel with session/);
   });
 
+  it("preserves paragraph breaks in multi-paragraph event descriptions", () => {
+    // Markdown renders `\n\n` natively as a paragraph boundary, so the
+    // README emitter must pass the description through verbatim without
+    // collapsing the blank line — otherwise the new multi-paragraph
+    // ModelMessage docstrings (REA-1801) would render as one squashed
+    // paragraph in the generated README.
+    const md = readmeFor({
+      events: [
+        {
+          name: "set_prompt",
+          description:
+            "Set the scene prompt.\n\nApplied on the next inference iteration.",
+          fields: {},
+        },
+      ],
+    });
+    expect(md).toContain(
+      "Set the scene prompt.\n\nApplied on the next inference iteration.",
+    );
+  });
+
+  it("preserves paragraph breaks in multi-paragraph message descriptions", () => {
+    const md = readmeFor({
+      messages: [
+        {
+          name: "generation_reset",
+          description:
+            "Emitted after `reset` clears session state.\n\nThe model is back in the waiting state.",
+          fields: {},
+        },
+      ],
+    });
+    expect(md).toContain(
+      "Emitted after `reset` clears session state.\n\nThe model is back in the waiting state.",
+    );
+  });
+
   it("cross-links backticked message names in event descriptions", () => {
     const md = readmeFor({
       events: [

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -222,8 +222,39 @@ function generateJsDoc(lines: string[], indentLevel: number = 0): string {
   const pad = "  ".repeat(indentLevel);
   const safe = lines.map(sanitizeJsDocLine);
   if (safe.length === 1) return `${pad}/** ${safe[0]} */\n`;
-  const inner = safe.map((l) => `${pad} * ${l}`).join("\n");
+  // Empty entries render as a bare ` *` line, which is JSDoc's idiomatic
+  // way to separate paragraphs inside a multi-line block — required so
+  // that descriptions split via `descriptionToJsDocLines` show up as
+  // proper paragraph breaks in IDE hovers and TypeDoc output.
+  const inner = safe
+    .map((l) => (l === "" ? `${pad} *` : `${pad} * ${l}`))
+    .join("\n");
   return `${pad}/**\n${inner}\n${pad} */\n`;
+}
+
+// Convert a free-form description (possibly multi-paragraph) into the
+// array of lines that `generateJsDoc` consumes. Paragraph breaks
+// (``\n\n+``) become a blank entry so the rendered JSDoc has a bare
+// ` *` separator line between paragraphs; intra-paragraph wrapping is
+// left alone — `sanitizeJsDocLine` will collapse it into a single
+// space, which matches how the runtime now normalises ModelMessage
+// docstrings (REA-1801).
+function descriptionToJsDocLines(description: string): string[] {
+  if (!description) return [];
+  const paragraphs = description.split(/\n\n+/);
+  const out: string[] = [];
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (i > 0) out.push("");
+    out.push(paragraphs[i]);
+  }
+  return out;
+}
+
+// First paragraph of a description, used for `@param` tags where a
+// terse single sentence beats spilling the full multi-paragraph body
+// onto a tag that consumers see inline at every call site.
+function descriptionSummary(description: string): string {
+  return description.split(/\n\n+/)[0] ?? "";
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +271,7 @@ function generateParamInterface(
   if (fields.length === 0) return "";
 
   const lines: string[] = [];
-  const doc = generateJsDoc(event.description ? [event.description] : [], 0);
+  const doc = generateJsDoc(descriptionToJsDocLines(event.description), 0);
   lines.push(`${doc}export interface ${interfaceName} {`);
 
   for (const [name, field] of fields) {
@@ -277,10 +308,7 @@ function generateMessageInterface(
   const fields = Object.entries(message.fields);
 
   const lines: string[] = [];
-  const doc = generateJsDoc(
-    message.description ? [message.description] : [],
-    0,
-  );
+  const doc = generateJsDoc(descriptionToJsDocLines(message.description), 0);
   lines.push(`${doc}export interface ${interfaceName} {`);
   lines.push(`  type: ${JSON.stringify(message.name)};`);
 
@@ -497,8 +525,17 @@ function generateClientClass(
     lines.push("");
 
     const methodDoc: string[] = [];
-    if (event.description) methodDoc.push(event.description);
-    if (hasParams) methodDoc.push(`@param params - ${event.description}`);
+    if (event.description) {
+      methodDoc.push(...descriptionToJsDocLines(event.description));
+    }
+    if (hasParams && event.description) {
+      // `@param` tags are read inline at every call-site; keep them to
+      // the summary (first paragraph) so consumers don't see the full
+      // multi-paragraph body repeated next to their argument.
+      methodDoc.push(
+        `@param params - ${descriptionSummary(event.description)}`,
+      );
+    }
     lines.push(indent(generateJsDoc(methodDoc), 1));
 
     if (paramType) {
@@ -1415,4 +1452,7 @@ export const __testing__ = {
   formatVersionForModelConstant,
   sanitizeJsDocLine,
   enumValueToTs,
+  descriptionToJsDocLines,
+  descriptionSummary,
+  generateJsDoc,
 };

--- a/packages/codegen/src/openapi/parser.ts
+++ b/packages/codegen/src/openapi/parser.ts
@@ -154,7 +154,14 @@ export function parseSchema(raw: OpenApiSchema): ModelSchema {
 
     events.push({
       name,
-      description: op.summary ?? op.description ?? "",
+      // Prefer `description` (full multi-paragraph docstring as emitted
+      // by current Reactor runtimes) over `summary` (single-line, set by
+      // legacy schemas and as a short title by current runtimes). When
+      // both are present the runtime puts the first paragraph in
+      // `summary` and the full text in `description`, so picking
+      // `description` first gives the SDK the richest copy without
+      // losing legacy schemas that only set `summary`.
+      description: op.description ?? op.summary ?? "",
       fields,
     });
   }
@@ -178,7 +185,11 @@ export function parseSchema(raw: OpenApiSchema): ModelSchema {
 
     messages.push({
       name,
-      description: op.summary ?? op.description ?? "",
+      // See the matching note on the events branch above — same
+      // `description`-then-`summary` precedence so multi-paragraph
+      // ModelMessage docstrings (REA-1801) reach the SDK in full while
+      // legacy schemas that only set `summary` keep working.
+      description: op.description ?? op.summary ?? "",
       fields,
     });
   }

--- a/packages/js-sdk/__tests__/setup.ts
+++ b/packages/js-sdk/__tests__/setup.ts
@@ -4,11 +4,20 @@
 // exercise the SDK against production without a browser.  Unit tests
 // override these with vi.stubGlobal() as needed.
 
+import { wrapPeerConnectionWithSdpPatch } from "./wrtc-sdp-patch";
+
 if (typeof globalThis.RTCPeerConnection === "undefined") {
   try {
     const wrtc = await import("@roamhq/wrtc");
     const mod = (wrtc as any).default ?? wrtc;
-    globalThis.RTCPeerConnection = mod.RTCPeerConnection;
+    // Test-only SDP munge: @roamhq/wrtc's libwebrtc rejects the
+    // FID-grouped multi-ssrc m-sections aiortc emits (no per-ssrc
+    // msid).  Real browsers accept those answers untouched, so the
+    // SDK's runtime path is **not** wrapped — only this Node test
+    // polyfill is.  See wrtc-sdp-patch.ts for the full rationale.
+    globalThis.RTCPeerConnection = wrapPeerConnectionWithSdpPatch(
+      mod.RTCPeerConnection
+    );
     globalThis.RTCSessionDescription = mod.RTCSessionDescription;
     globalThis.RTCIceCandidate = mod.RTCIceCandidate;
     globalThis.MediaStream = mod.MediaStream;

--- a/packages/js-sdk/__tests__/wrtc-sdp-patch.ts
+++ b/packages/js-sdk/__tests__/wrtc-sdp-patch.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * !!! INTEGRATION-TEST-ONLY WORKAROUND — DO NOT IMPORT FROM THE SDK !!!
+ *
+ * This file lives under `__tests__/` on purpose.  Real browser
+ * `RTCPeerConnection`s do not need it, the SDK's runtime path
+ * (`src/core/WebRTCTransportClient.ts`) does not call it, and
+ * production traffic flows through the unmodified SDP answer.  The
+ * only consumer is `__tests__/setup.ts`, which wraps the
+ * `@roamhq/wrtc` polyfill used by the Node-based integration
+ * tests.
+ *
+ * Why it exists
+ * -------------
+ * The Reactor server-side transport (aiortc) emits SDP answers that
+ * group an output track's primary + RTX ssrcs with `a=ssrc-group:FID`
+ * but does **not** add per-ssrc `msid` annotations or an m-section
+ * `a=msid:` line.  Real browsers accept this in production — Chrome,
+ * Safari, Firefox all happily fold the FID-grouped ssrcs into a
+ * single track and the SDK works against `api.reactor.inc` from a
+ * normal browser tab without any patching.
+ *
+ * The libwebrtc vendored into `@roamhq/wrtc` does **not** fold them
+ * — each ssrc becomes its own `StreamParams`, tripping the Unified
+ * Plan check in `pc/sdp_offer_answer.cc`:
+ *
+ *     if (desc.streams().size() > 1u)
+ *       return RTCError(... "Media section has more than one track
+ *                            specified with a=ssrc lines which is not
+ *                            supported with Unified Plan.");
+ *
+ * That check is also present on the latest `@roamhq/wrtc` (0.10.0,
+ * libwebrtc M106), so bumping the dep doesn't help — the difference
+ * must live in upstream Chromium's `StreamParams` construction,
+ * which isn't shipped to userland by `@roamhq/wrtc` regardless of
+ * version.
+ *
+ * Because this is purely a `@roamhq/wrtc` parser quirk we hit only
+ * in Node, the workaround is scoped to the test polyfill: the SDK
+ * itself stays untouched and continues to feed the unmodified answer
+ * to browsers in production.
+ *
+ * What it does
+ * ------------
+ * Rewrites an SDP **answer** (offers and other types pass through
+ * untouched) to add the missing annotations for any audio/video
+ * m-section that has `a=ssrc:` lines but no `msid` info,
+ * synthesising a stable per-section track id derived from the MID
+ * so the same answer always patches the same way.
+ */
+
+const SECTION_KINDS_TO_PATCH = new Set(["audio", "video"]);
+
+interface Section {
+  start: number;
+  end: number;
+  kind: string;
+  mid?: string;
+  hasSsrc: boolean;
+  hasMsid: boolean;
+  ssrcOrder: string[];
+}
+
+export function patchSdpForUnifiedPlan(sdp: string): string {
+  const eol = sdp.includes("\r\n") ? "\r\n" : "\n";
+  const lines = sdp.split(eol);
+
+  const mLineIdxs: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("m=")) mLineIdxs.push(i);
+  }
+  if (mLineIdxs.length === 0) return sdp;
+
+  const sections: Section[] = [];
+  for (let i = 0; i < mLineIdxs.length; i++) {
+    const start = mLineIdxs[i];
+    const end = i + 1 < mLineIdxs.length ? mLineIdxs[i + 1] : lines.length;
+    const kindMatch = /^m=(\S+)/.exec(lines[start]);
+    const sec: Section = {
+      start,
+      end,
+      kind: kindMatch?.[1] ?? "",
+      hasSsrc: false,
+      hasMsid: false,
+      ssrcOrder: [],
+    };
+    const seen = new Set<string>();
+    for (let j = start; j < end; j++) {
+      const line = lines[j];
+      if (line.startsWith("a=mid:")) {
+        sec.mid = line.slice("a=mid:".length).trim();
+      } else if (line.startsWith("a=msid:")) {
+        sec.hasMsid = true;
+      } else if (line.startsWith("a=ssrc:")) {
+        sec.hasSsrc = true;
+        const m = /^a=ssrc:(\d+)\s+(\S+):/.exec(line);
+        if (m) {
+          if (m[2] === "msid") sec.hasMsid = true;
+          if (!seen.has(m[1])) {
+            seen.add(m[1]);
+            sec.ssrcOrder.push(m[1]);
+          }
+        }
+      }
+    }
+    sections.push(sec);
+  }
+
+  const inserts: { afterIdx: number; line: string }[] = [];
+  for (const sec of sections) {
+    if (!SECTION_KINDS_TO_PATCH.has(sec.kind)) continue;
+    if (!sec.hasSsrc || sec.hasMsid) continue;
+
+    const streamId = "-";
+    const trackId = `reactor-track-${sec.mid ?? sec.start}`;
+
+    let lastSsrcIdx = -1;
+    for (let j = sec.start; j < sec.end; j++) {
+      if (lines[j].startsWith("a=ssrc:")) lastSsrcIdx = j;
+    }
+    if (lastSsrcIdx === -1) continue;
+
+    inserts.push({
+      afterIdx: lastSsrcIdx,
+      line: `a=msid:${streamId} ${trackId}`,
+    });
+    for (const ssrc of sec.ssrcOrder) {
+      inserts.push({
+        afterIdx: lastSsrcIdx,
+        line: `a=ssrc:${ssrc} msid:${streamId} ${trackId}`,
+      });
+    }
+  }
+
+  if (inserts.length === 0) return sdp;
+
+  inserts.sort((a, b) => b.afterIdx - a.afterIdx);
+  const out = lines.slice();
+  for (const ins of inserts) {
+    out.splice(ins.afterIdx + 1, 0, ins.line);
+  }
+  return out.join(eol);
+}
+
+/**
+ * Wrap an `RTCPeerConnection` constructor so each instance routes
+ * `setRemoteDescription(answer)` through {@link patchSdpForUnifiedPlan}
+ * before delegating to the underlying implementation.  Offers and
+ * non-answer descriptions pass through unchanged.
+ *
+ * Test-only — `__tests__/setup.ts` is the sole caller, applied to
+ * the `@roamhq/wrtc` polyfill before it lands on `globalThis`.
+ * Browser `RTCPeerConnection`s never see this wrapper.
+ */
+export function wrapPeerConnectionWithSdpPatch<
+  T extends new (...args: any[]) => RTCPeerConnection,
+>(OriginalPeerConnection: T): T {
+  const Wrapped = function (this: RTCPeerConnection, ...args: any[]) {
+    const pc = new OriginalPeerConnection(...args);
+    const original = pc.setRemoteDescription.bind(pc);
+    pc.setRemoteDescription = ((desc: RTCSessionDescriptionInit) => {
+      if (desc?.type === "answer" && typeof desc.sdp === "string") {
+        desc = { ...desc, sdp: patchSdpForUnifiedPlan(desc.sdp) };
+      }
+      return original(desc);
+    }) as RTCPeerConnection["setRemoteDescription"];
+    return pc;
+  } as unknown as T;
+  Wrapped.prototype = OriginalPeerConnection.prototype;
+  return Wrapped;
+}


### PR DESCRIPTION
Why
---
Reactor runtimes now emit each ModelMessage / event docstring as a full
multi-paragraph `description` plus a single-line `summary` (REA-1801),
but the JS SDK codegen was reading `summary` first and feeding it to the
emitter as a single line. The result: every wrapped or multi-paragraph
runt docstring landed in the generated SDK as the short summary only,
so authors couldn't write code-style-compliant multi-line docstrings
without the SDK truncating them. The README emitter had the same issue
at the source even though Markdown itself can render paragraphs.

What Changed
---
- `openapi/parser.ts`: flipped the precedence on event and message
  description extraction from `op.summary ?? op.description` to
  `op.description ?? op.summary`. Legacy schemas that only set
  `summary` keep working via the fallback.
- `emitter.ts`: added `descriptionToJsDocLines()` (splits a description
  on `\n\n+` into the line array `generateJsDoc` consumes) and
  `descriptionSummary()` (first paragraph only, used for `@param`
  tags so they stay terse). Updated `generateJsDoc` to render an
  empty-string entry as a bare ` *` paragraph-separator line — the
  JSDoc-idiomatic way to render paragraph breaks. Wired both helpers
  into `generateParamInterface`, `generateMessageInterface`, and the
  per-event method JSDoc emission, and gated the `@param params -`
  line on a non-empty description so undocumented events no longer
  emit dangling `@param` tags.
- README emitter: no source change required. Section bodies already
  pass descriptions through verbatim and Markdown renders `\n\n` as
  paragraph breaks natively; field-table cells correctly keep
  flattening newlines via `mdEscape`. Added regression tests so the
  contract is locked in for future refactors.
- Tests: added 5 parser tests (precedence + legacy fallback for both
  events and messages, empty-description), 9 emitter tests
  (`descriptionToJsDocLines`, `descriptionSummary`, `generateJsDoc`
  paragraph rendering, end-to-end multi-paragraph round-trip through
  param and message interfaces), and 2 README-emitter tests
  (multi-paragraph event and message section bodies preserve `\n\n`).
  All 229 codegen tests pass; `tsc --noEmit` clean.

topic: REA-1801-codegen-prefer-description-multi-paragraph
reviewers: