### PR TITLE
[REA-1807] sdk: drop ICE candidate error log to debug level

### DIFF
--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -708,7 +708,12 @@ export class WebRTCTransportClient implements TransportClient {
     };
 
     this.peerConnection.onicecandidateerror = (event) => {
-      console.warn("[WebRTCTransport] ICE candidate error:", event);
+      // ICE candidate errors are part of the normal WebRTC lifecycle:
+      // STUN/TURN servers frequently fail to allocate candidates
+      // (host blocked by NAT, server unreachable, auth not yet ready,
+      // etc.) without affecting the final connection.  Log at debug
+      // level so they don't drown out actionable warnings.
+      console.debug("[WebRTCTransport] ICE candidate error:", event);
     };
 
     this.peerConnection.ondatachannel = (event) => {


### PR DESCRIPTION
ICE candidate errors are part of the normal WebRTC lifecycle. Browsers
gather many candidates from each configured STUN/TURN server, and any
of them can fail (host blocked by NAT, server unreachable, TURN auth
not yet ready, etc.) without preventing a successful connection. The
warn-level log was drowning out actionable warnings - observed during
Waypoint connection from the Netherlands after the regional rollout.

Demote to console.debug so the rest of the WebRTC warnings stay
useful, matching how onicecandidate is already logged.

Made-with: Cursor