### PR TITLE
[REA-1955][REA-1956][2/3] sdk recording: Reactor integration + exports

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -42,6 +42,8 @@ export type Options = z.input<typeof OptionsSchema>;
 
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
+import { RecordingClient } from "./RecordingClient";
+import type { Clip, DownloadClipOptions } from "../utils/recording";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -63,6 +65,18 @@ export class Reactor {
   private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
 
+  /**
+   * Per-Reactor recording client. Owns the FIFO promise correlator
+   * for `requestClip` / `requestRecording` round-trips and the
+   * `downloadClipAsFile` helper. Subscribes to this Reactor's
+   * `runtimeMessage` and `statusChanged` events on construction.
+   *
+   * App code typically uses the convenience methods
+   * ({@link Reactor.requestClip} etc.) but advanced consumers can
+   * drive the feature directly off this field.
+   */
+  readonly recording: RecordingClient;
+
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
     this.coordinatorUrl = validatedOptions.apiUrl;
@@ -74,6 +88,27 @@ export class Reactor {
     if (validatedOptions.modelTracks) {
       this.presetTracks = validatedOptions.modelTracks;
     }
+
+    // Recording client. Subscribes to `runtimeMessage` /
+    // `statusChanged` via the standard event-bus pattern (no direct
+    // method calls), so app code that listens to `runtimeMessage`
+    // continues to receive `clipReady` / `clipFailed` envelopes
+    // alongside the recording client's own correlator.
+    this.recording = new RecordingClient({
+      onRuntimeMessage: (handler) => {
+        this.on("runtimeMessage", handler);
+        return () => this.off("runtimeMessage", handler);
+      },
+      onStatusChanged: (handler) => {
+        this.on("statusChanged", handler);
+        return () => this.off("statusChanged", handler);
+      },
+      sendRuntimeCommand: (command, data) =>
+        this.sendCommand(command, data, "runtime"),
+      getStatus: () => this.status,
+      getLocalCoordinatorBaseUrl: () =>
+        this.local ? this.coordinatorUrl : undefined,
+    });
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
@@ -232,6 +267,70 @@ export class Reactor {
     });
 
     return new FileRef(slot.presigned_id, name, mimeType, size);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Recording — thin delegations to `this.recording` (RecordingClient).
+  // The recording subsystem owns its own state and lifecycle; these
+  // methods exist for API ergonomics so app code never needs to
+  // reach into `reactor.recording` for the common case.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Asks the runtime to mint a clip covering the last `durationSeconds`
+   * of the live session.
+   *
+   * Sends a `requestClip` runtime message and resolves with the
+   * matching `clipReady` payload (or rejects on `clipFailed`).
+   * `durationSeconds` is capped server-side at the model's
+   * `recording.clip_max_seconds` (default 5 minutes).
+   *
+   * The returned {@link Clip} carries a `playlistUrl` that can be handed
+   * directly to any HLS-capable video player. To save the clip as a
+   * file, pass it to {@link downloadClipAsFile}.
+   *
+   * Multiple concurrent requests are supported — responses are
+   * matched FIFO with outgoing requests.
+   *
+   * @throws {RecordingError} on invalid input, transport failure,
+   *   timeout, runtime-side `clipFailed`, or disconnect mid-request.
+   */
+  async requestClip(durationSeconds: number): Promise<Clip> {
+    return this.recording.requestClip(durationSeconds);
+  }
+
+  /**
+   * Asks the runtime to mint a clip covering the entire session up to
+   * "now" (the latest fully-uploaded chunk). Mechanically identical to
+   * {@link requestClip} with `start = 0`; only the resolved
+   * {@link Clip.kind} discriminator differs (`"recording"` vs `"snap"`).
+   *
+   * @throws {RecordingError} same conditions as {@link requestClip}.
+   */
+  async requestRecording(): Promise<Clip> {
+    return this.recording.requestRecording();
+  }
+
+  /**
+   * Streams the chunks referenced by `clip.playlistUrl`,
+   * byte-concatenates them into a fragmented-MP4 Blob, and triggers a
+   * native browser download. Server-side cost is zero — the SDK uses
+   * the same presigned chunk URLs the player would.
+   *
+   * Pass `filename: null` to skip the download trigger and just
+   * receive the assembled `Blob` (useful for non-DOM consumers and
+   * tests).
+   *
+   * Note: production playlist URLs are short-lived (presigned chunks
+   * TTL is a few minutes). If the URL has expired, request a fresh
+   * clip via {@link requestClip} or {@link requestRecording}.
+   */
+  async downloadClipAsFile(
+    clip: Clip,
+    filename: string | null = "reactor-clip.mp4",
+    options?: DownloadClipOptions
+  ): Promise<Blob> {
+    return this.recording.downloadClipAsFile(clip, filename, options);
   }
 
   /**
@@ -462,6 +561,8 @@ export class Reactor {
       if (scope === "application") {
         this.emit("message", message);
       } else if (scope === "runtime") {
+        // Just emit — `RecordingClient` and any app-level
+        // `runtimeMessage` listeners are subscribers via `on()`.
         this.emit("runtimeMessage", message);
       }
     });

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -5,4 +5,30 @@ export * from "./react/ReactorController";
 export * from "./react/WebcamStream";
 export * from "./react/hooks";
 export * from "./types";
+// Stateless recording primitives (helpers, types, schemas).
+export {
+  DEFAULT_PLAYLIST_POLL_SLACK_MS,
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  downloadClipAsFile,
+  fetchPlaylist,
+  parsePlaylist,
+  rewriteUrlHost,
+} from "./utils/recording";
+export type {
+  Clip,
+  ClipKind,
+  ClipReadyPayload,
+  ClipFailedPayload,
+  DownloadClipOptions,
+  FetchPlaylistOptions,
+  ParseClipOptions,
+} from "./utils/recording";
+// Stateful recording client + its host adapter.
+export {
+  DEFAULT_CLIP_REQUEST_TIMEOUT_MS,
+  RecordingClient,
+} from "./core/RecordingClient";
+export type { RecordingClientHost } from "./core/RecordingClient";
 export type { ReactorStore } from "./core/store";


### PR DESCRIPTION
## Why

PR 1/3 landed the recording subsystem (`utils/recording.ts` + `core/RecordingClient.ts`)
as a self-contained unit not yet reachable by consumers.  This PR
makes it the canonical SDK API: every Reactor instance owns a
`RecordingClient`, and `Reactor` exposes thin one-liner delegations
for the three top-of-funnel calls so app code never has to wire its
own host adapter for the common case.

This is the layer apps actually consume — the standalone subsystem
in PR 1 stays usable by advanced callers, but the 99% path goes
through the methods added here.

## What Changed

* **`src/core/Reactor.ts`**:
  * New `recording: RecordingClient` field — constructed in
    `Reactor`'s constructor with a host adapter that wires
    `runtimeMessage` / `statusChanged` / `sendCommand` / `status` /
    `local`-mode coordinator URL through to the client.
  * Three thin delegations on `Reactor`:
    * `requestClip(durationSeconds)` → `recording.requestClip(...)`
    * `requestRecording()`           → `recording.requestRecording()`
    * `downloadClipAsFile(clip, …)`  → `recording.downloadClipAsFile(...)`
  * Local-mode URL rewrite: when `reactor.local` is true, the host
    adapter returns the coordinator base URL so `clipFromPayload`
    rewrites `playlist_url` from the runtime's `0.0.0.0` bind to the
    URL the SDK is actually talking to.

* **`src/index.ts`** — public re-exports:
  * `RecordingError`, `RuntimeRecordingMessageType`,
    `clipFromPayload`, `rewriteUrlHost`,
    `fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`.
  * Types: `Clip`, `ClipKind`, `ClipReadyPayload`, `ClipFailedPayload`,
    `DownloadClipOptions`, `FetchPlaylistOptions`, `ParseClipOptions`.
  * `RecordingClient` + `DEFAULT_CLIP_REQUEST_TIMEOUT_MS` for
    advanced consumers (testing, custom hosts).
  * `RecordingClientHost` type for the same.
  * `DEFAULT_PLAYLIST_POLL_SLACK_MS` constant.

## API

JS — the canonical, single-import flow:

```ts
import { Reactor, RecordingError } from "@reactor-team/js-sdk";

const reactor = new Reactor({ /* …your usual config… */ });
await reactor.connect();

try {
  // Snap the last 30 seconds.
  const clip = await reactor.requestClip(30);
  // → { sessionId, kind: "snap", startMarker, endMarker, nowMarker,
  //     predictedReadyAtMs, playlistUrl }

  // Save it to disk (waits for the in-progress chunk under the hood).
  await reactor.downloadClipAsFile(clip, "snap.mp4");

  // Or play inline — pass clip.playlistUrl to hls.js / native HLS.
  const Hls = (await import("hls.js")).default;
  if (Hls.isSupported()) {
    const hls = new Hls();
    hls.loadSource(clip.playlistUrl);
    hls.attachMedia(videoEl);
  } else {
    videoEl.src = clip.playlistUrl;  // Safari / iOS native HLS
  }

  // Full session recording (start = 0, end = now).
  const fullRecording = await reactor.requestRecording();
  await reactor.downloadClipAsFile(fullRecording, "session.mp4");
} catch (err) {
  if (err instanceof RecordingError) {
    // err.code: RECORDER_DISABLED | INVALID_DURATION | REQUEST_TIMEOUT
    //         | DISCONNECTED | CLIP_GONE | CLIP_NOT_READY | …
    console.warn(err.code, err.reason);
  }
}
```

React — same surface from inside a hook:

```tsx
import { useState } from "react";
import { useReactor, RecordingError, type Clip } from "@reactor-team/js-sdk";

export function CaptureButton() {
  const reactor = useReactor((s) => s.internal.reactor);
  const [clip, setClip] = useState<Clip | null>(null);
  const [error, setError] = useState<string | null>(null);

  const onSnap = async () => {
    setError(null);
    try {
      setClip(await reactor.requestClip(30));
    } catch (err) {
      setError(err instanceof RecordingError ? err.code : String(err));
    }
  };

  return (
    <>
      <button onClick={onSnap}>Snap last 30s</button>
      {clip && <a href={clip.playlistUrl} target="_blank" rel="noreferrer">
        play ({(clip.endMarker - clip.startMarker).toFixed(1)}s)
      </a>}
      {error && <span className="error">{error}</span>}
    </>
  );
}
```

The `predictedReadyAtMs` field returned with every clip is a Unix
epoch in ms — clients can detect "runtime crashed mid-clip" by
checking `Date.now() > clip.predictedReadyAtMs + slack` before
deciding whether to keep polling or surface a failure.

Linear: REA-1955, REA-1956