### PR TITLE
[REA-1955][REA-1956][3/3] sdk recording: tests

### DIFF
--- a/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
@@ -1,0 +1,364 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+import type { ClipReadyPayload } from "../../src/utils/recording";
+
+const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
+
+const MOCK_INITIAL_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "CREATED",
+};
+
+const MOCK_FULL_SESSION_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "ACTIVE",
+  selected_transport: { protocol: "webrtc", version: "1.0" },
+  capabilities: {
+    protocol_version: "1.0",
+    tracks: [
+      { name: "main_video", kind: "video", direction: "recvonly" as const },
+    ],
+  },
+};
+
+let transportHandlers: Record<string, (...args: any[]) => void> = {};
+let mockTransportClient: any;
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn().mockImplementation(() => ({
+    createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+    pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    getSessionId: vi.fn().mockReturnValue(MOCK_SESSION_ID),
+  })),
+}));
+
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
+    createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+    pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn().mockImplementation(() => {
+    transportHandlers = {};
+    mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        transportHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue(undefined),
+      getTransportTimings: vi.fn().mockReturnValue(undefined),
+      abort: vi.fn(),
+    };
+    return mockTransportClient;
+  }),
+}));
+
+/**
+ * Drive the Reactor to "ready" state via its mocked transport so the
+ * recording API guards pass.
+ */
+async function connectedReactor(local = false): Promise<Reactor> {
+  const r = new Reactor({ modelName: "echo", local });
+  if (local) {
+    await r.connect();
+  } else {
+    await r.connect("jwt-token");
+  }
+  // Drive the transport to "connected" so status flips to "ready".
+  transportHandlers["statusChanged"]?.("connected");
+  return r;
+}
+
+function emitRuntimeMessage(message: unknown): void {
+  // Mirrors WebRTCTransportClient.onmessage: emits ("message", inner, scope)
+  transportHandlers["message"]?.(message, "runtime");
+}
+
+function buildClipReady(overrides: Partial<ClipReadyPayload> = {}): {
+  type: string;
+  data: ClipReadyPayload;
+} {
+  return {
+    type: "clipReady",
+    data: {
+      session_id: "rec-1",
+      kind: "snap",
+      start_marker: 120,
+      end_marker: 150,
+      now_marker: 150,
+      // Far-future epoch so any test that surfaces predictedReadyAtMs
+      // without overriding it doesn't accidentally trip a past-deadline
+      // path inside fetchPlaylist (these tests never go on-network).
+      predicted_ready_at_ms: 9_999_999_999_999,
+      playlist_url:
+        "https://api.reactor.inc/clips?session_id=rec-1&start=120&end=150",
+      ...overrides,
+    },
+  };
+}
+
+describe("Reactor recording API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transportHandlers = {};
+    mockTransportClient = undefined;
+  });
+
+  // ── Pre-flight guards ──────────────────────────────────────────────────
+
+  describe("requestClip()", () => {
+    it("rejects with INVALID_DURATION on zero", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(0)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on negative", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(-5)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on NaN", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(Number.NaN)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on Infinity", async () => {
+      const r = await connectedReactor();
+      await expect(
+        r.requestClip(Number.POSITIVE_INFINITY)
+      ).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with DISCONNECTED before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(r.requestClip(30)).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+    });
+
+    it("sends a runtime requestClip message", async () => {
+      const r = await connectedReactor();
+      // Don't await — would hang waiting for clipReady.
+      const promise = r.requestClip(30);
+      expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
+        "requestClip",
+        { duration_seconds: 30 },
+        "runtime",
+        undefined
+      );
+      // Resolve so the test cleans up.
+      emitRuntimeMessage(buildClipReady());
+      await promise;
+      await r.disconnect();
+    });
+
+    it("resolves with a Clip when clipReady arrives", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(buildClipReady());
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      expect(clip.kind).toBe("snap");
+      expect(clip.startMarker).toBe(120);
+      expect(clip.endMarker).toBe(150);
+      expect(clip.nowMarker).toBe(150);
+      expect(clip.predictedReadyAtMs).toBe(9_999_999_999_999);
+      expect(clip.playlistUrl).toContain("session_id=rec-1");
+      await r.disconnect();
+    });
+
+    it("rejects with RECORDER_DISABLED on clipFailed { reason: 'recorder disabled' }", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "recorder disabled" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "RECORDER_DISABLED",
+        reason: "recorder disabled",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INTERNAL_ERROR on unrecognized clipFailed reason", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "internal error: boom" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+        reason: "internal error: boom",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INTERNAL_ERROR on malformed clipReady", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipReady",
+        data: { session_id: "rec-1" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+      });
+      await r.disconnect();
+    });
+  });
+
+  describe("requestRecording()", () => {
+    it("sends a runtime requestRecording message with empty body", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestRecording();
+      expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
+        "requestRecording",
+        {},
+        "runtime",
+        undefined
+      );
+      emitRuntimeMessage(
+        buildClipReady({
+          kind: "recording",
+          start_marker: 0,
+          end_marker: 60,
+          now_marker: 60,
+        })
+      );
+      const clip = await promise;
+      expect(clip.kind).toBe("recording");
+      expect(clip.startMarker).toBe(0);
+      await r.disconnect();
+    });
+
+    it("rejects with DISCONNECTED before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(r.requestRecording()).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+    });
+  });
+
+  // ── FIFO correlation ──────────────────────────────────────────────────
+
+  describe("FIFO correlator", () => {
+    it("matches two concurrent requests in receipt order", async () => {
+      const r = await connectedReactor();
+      const p1 = r.requestClip(10);
+      const p2 = r.requestClip(20);
+
+      emitRuntimeMessage(buildClipReady({ session_id: "first" }));
+      emitRuntimeMessage(buildClipReady({ session_id: "second" }));
+
+      const [clip1, clip2] = await Promise.all([p1, p2]);
+      expect(clip1.sessionId).toBe("first");
+      expect(clip2.sessionId).toBe("second");
+      await r.disconnect();
+    });
+
+    it("ignores extra clipReady envelopes when no requests are pending", async () => {
+      const r = await connectedReactor();
+      // Should not throw.
+      emitRuntimeMessage(buildClipReady());
+      await r.disconnect();
+    });
+
+    it("does not interfere with non-clip runtime messages", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+
+      // Random platform message should be ignored by the correlator.
+      emitRuntimeMessage({ type: "modelCapabilities", data: {} });
+
+      // Now resolve the actual request.
+      emitRuntimeMessage(buildClipReady());
+      await promise;
+      await r.disconnect();
+    });
+  });
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────
+
+  describe("lifecycle", () => {
+    it("rejects pending requests with DISCONNECTED on disconnect", async () => {
+      const r = await connectedReactor();
+      const p1 = r.requestClip(10);
+      const p2 = r.requestRecording();
+
+      await r.disconnect();
+
+      await expect(p1).rejects.toMatchObject({ code: "DISCONNECTED" });
+      await expect(p2).rejects.toMatchObject({ code: "DISCONNECTED" });
+    });
+  });
+
+  // ── URL rewrite for local mode ────────────────────────────────────────
+
+  describe("local mode", () => {
+    it("rewrites playlist URL to the configured coordinator URL", async () => {
+      const r = await connectedReactor(true);
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "http://0.0.0.0:8080/clips?session_id=rec-1&start=0&end=30",
+        })
+      );
+      const clip = await promise;
+      // LOCAL_COORDINATOR_URL is http://localhost:8080.
+      expect(clip.playlistUrl).toBe(
+        "http://localhost:8080/clips?session_id=rec-1&start=0&end=30"
+      );
+      await r.disconnect();
+    });
+
+    it("does NOT rewrite playlist URL in remote mode", async () => {
+      const r = await connectedReactor(false);
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "https://api.reactor.inc/clips?session_id=rec-1&start=0&end=30",
+        })
+      );
+      const clip = await promise;
+      expect(clip.playlistUrl).toBe(
+        "https://api.reactor.inc/clips?session_id=rec-1&start=0&end=30"
+      );
+      await r.disconnect();
+    });
+  });
+});

--- a/packages/js-sdk/__tests__/unit/recording-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording-client.test.ts
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Tests for {@link RecordingClient} in isolation, against a fake
+ * {@link RecordingClientHost}. The reactor-level integration is
+ * exercised separately in `reactor-recording.test.ts`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  RecordingClient,
+  type RecordingClientHost,
+} from "../../src/core/RecordingClient";
+import type { ClipReadyPayload } from "../../src/utils/recording";
+import type { ReactorStatus } from "../../src/types";
+
+interface FakeHostHandles {
+  host: RecordingClientHost;
+  /** Push a runtime message to all subscribers. */
+  emitRuntimeMessage: (msg: unknown) => void;
+  /** Push a status change to all subscribers. */
+  emitStatus: (status: ReactorStatus) => void;
+  /** Spy on outgoing runtime commands. */
+  sendRuntimeCommand: ReturnType<typeof vi.fn>;
+  /** Set the status returned by `getStatus()`. */
+  setStatus: (status: ReactorStatus) => void;
+  /** True once the runtime-message subscription was unsubscribed. */
+  isRuntimeMessageUnsubscribed: () => boolean;
+}
+
+function makeHost(initial: ReactorStatus = "ready"): FakeHostHandles {
+  let status: ReactorStatus = initial;
+  const runtimeListeners = new Set<(msg: unknown) => void>();
+  const statusListeners = new Set<(s: ReactorStatus) => void>();
+  let runtimeMessageUnsubCalled = false;
+  const sendRuntimeCommand = vi.fn().mockResolvedValue(undefined);
+
+  const host: RecordingClientHost = {
+    onRuntimeMessage(handler) {
+      runtimeListeners.add(handler);
+      return () => {
+        runtimeListeners.delete(handler);
+        runtimeMessageUnsubCalled = true;
+      };
+    },
+    onStatusChanged(handler) {
+      statusListeners.add(handler);
+      return () => statusListeners.delete(handler);
+    },
+    sendRuntimeCommand,
+    getStatus: () => status,
+    getLocalCoordinatorBaseUrl: () => undefined,
+  };
+
+  return {
+    host,
+    emitRuntimeMessage: (msg) =>
+      runtimeListeners.forEach((handler) => handler(msg)),
+    emitStatus: (s) => {
+      status = s;
+      statusListeners.forEach((handler) => handler(s));
+    },
+    sendRuntimeCommand,
+    setStatus: (s) => {
+      status = s;
+    },
+    isRuntimeMessageUnsubscribed: () => runtimeMessageUnsubCalled,
+  };
+}
+
+function buildClipReady(overrides: Partial<ClipReadyPayload> = {}): {
+  type: string;
+  data: ClipReadyPayload;
+} {
+  return {
+    type: "clipReady",
+    data: {
+      session_id: "rec-1",
+      kind: "snap",
+      start_marker: 120,
+      end_marker: 150,
+      now_marker: 150,
+      predicted_ready_at_ms: 9_999_999_999_999,
+      playlist_url:
+        "https://api.reactor.inc/clips?session_id=rec-1&start=120&end=150",
+      ...overrides,
+    },
+  };
+}
+
+describe("RecordingClient", () => {
+  describe("requestClip / requestRecording", () => {
+    it("rejects with INVALID_DURATION on non-positive durations", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      await expect(client.requestClip(0)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await expect(client.requestClip(-1)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await expect(client.requestClip(Number.NaN)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      client.destroy();
+    });
+
+    it("rejects with DISCONNECTED when host is not ready", async () => {
+      const fake = makeHost("disconnected");
+      const client = new RecordingClient(fake.host);
+      await expect(client.requestClip(30)).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+      await expect(client.requestRecording()).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+      client.destroy();
+    });
+
+    it("sends requestClip and resolves on clipReady", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      expect(fake.sendRuntimeCommand).toHaveBeenCalledWith("requestClip", {
+        duration_seconds: 30,
+      });
+
+      fake.emitRuntimeMessage(buildClipReady());
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      expect(clip.kind).toBe("snap");
+      client.destroy();
+    });
+
+    it("sends requestRecording with empty body", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestRecording();
+
+      expect(fake.sendRuntimeCommand).toHaveBeenCalledWith(
+        "requestRecording",
+        {}
+      );
+
+      fake.emitRuntimeMessage(buildClipReady({ kind: "recording" }));
+      const clip = await promise;
+      expect(clip.kind).toBe("recording");
+      client.destroy();
+    });
+  });
+
+  describe("FIFO correlator", () => {
+    it("matches concurrent requests in receipt order", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p1 = client.requestClip(10);
+      const p2 = client.requestClip(20);
+
+      fake.emitRuntimeMessage(buildClipReady({ session_id: "first" }));
+      fake.emitRuntimeMessage(buildClipReady({ session_id: "second" }));
+
+      const [c1, c2] = await Promise.all([p1, p2]);
+      expect(c1.sessionId).toBe("first");
+      expect(c2.sessionId).toBe("second");
+      client.destroy();
+    });
+
+    it("ignores non-clip runtime messages", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({ type: "modelCapabilities", data: {} });
+      fake.emitRuntimeMessage({ type: "ping", data: {} });
+      fake.emitRuntimeMessage(buildClipReady());
+
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      client.destroy();
+    });
+
+    it("ignores stray clipReady when no requests are pending", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      // Should not throw; no pending request to resolve.
+      fake.emitRuntimeMessage(buildClipReady());
+      client.destroy();
+    });
+  });
+
+  describe("clipFailed handling", () => {
+    it("maps 'recorder disabled' to RECORDER_DISABLED", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "recorder disabled" },
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        code: "RECORDER_DISABLED",
+        reason: "recorder disabled",
+      });
+      client.destroy();
+    });
+
+    it("maps unknown reasons to INTERNAL_ERROR", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "internal error: boom" },
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+        reason: "internal error: boom",
+      });
+      client.destroy();
+    });
+  });
+
+  describe("local-mode URL rewrite", () => {
+    it("rewrites playlist_url through the host's coordinator base URL", async () => {
+      const fake = makeHost();
+      // Override just the URL hook.
+      const host: RecordingClientHost = {
+        ...fake.host,
+        getLocalCoordinatorBaseUrl: () => "http://localhost:9000",
+      };
+      const client = new RecordingClient(host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "http://0.0.0.0:8080/clips?session_id=rec-1&start=120&end=150",
+        })
+      );
+
+      const clip = await promise;
+      expect(clip.playlistUrl).toBe(
+        "http://localhost:9000/clips?session_id=rec-1&start=120&end=150"
+      );
+      client.destroy();
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("rejects pending requests with DISCONNECTED on disconnect", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p1 = client.requestClip(10);
+      const p2 = client.requestRecording();
+
+      fake.emitStatus("disconnected");
+
+      await expect(p1).rejects.toMatchObject({ code: "DISCONNECTED" });
+      await expect(p2).rejects.toMatchObject({ code: "DISCONNECTED" });
+      client.destroy();
+    });
+
+    it("rejects pending requests with DISCONNECTED on destroy", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p = client.requestClip(10);
+
+      client.destroy();
+      await expect(p).rejects.toMatchObject({ code: "DISCONNECTED" });
+    });
+
+    it("unsubscribes from host events on destroy", () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      expect(fake.isRuntimeMessageUnsubscribed()).toBe(false);
+      client.destroy();
+      expect(fake.isRuntimeMessageUnsubscribed()).toBe(true);
+    });
+
+    it("rejects with REQUEST_TIMEOUT when no response arrives", async () => {
+      vi.useFakeTimers();
+      try {
+        const fake = makeHost();
+        const client = new RecordingClient(fake.host, { requestTimeoutMs: 50 });
+
+        // Attach the rejection assertion *before* advancing timers so
+        // the rejection handler is in place when the timeout fires;
+        // otherwise vitest treats it as an unhandled rejection.
+        const settled = expect(client.requestClip(30)).rejects.toMatchObject({
+          code: "REQUEST_TIMEOUT",
+        });
+
+        await vi.advanceTimersByTimeAsync(60);
+        await settled;
+
+        client.destroy();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -1,0 +1,397 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ClipReadyPayloadSchema,
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  downloadClipAsFile,
+  fetchPlaylist,
+  parsePlaylist,
+  rewriteUrlHost,
+} from "../../src/utils/recording";
+
+/** Predicted ready time well in the future so polling tests don't trip the deadline. */
+const FUTURE_READY_MS = 9_999_999_999_999;
+
+const SAMPLE_PAYLOAD = {
+  session_id: "rec-123",
+  kind: "snap" as const,
+  start_marker: 120.0,
+  end_marker: 150.0,
+  now_marker: 150.0,
+  predicted_ready_at_ms: FUTURE_READY_MS,
+  playlist_url:
+    "http://0.0.0.0:8080/clips?session_id=rec-123&start=120&end=150",
+};
+
+const SAMPLE_MANIFEST = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:4
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-MAP:URI="/clips/chunks/rec-123/init.mp4"
+#EXTINF:4.000,
+/clips/chunks/rec-123/chunk_00000.m4s
+#EXTINF:4.000,
+/clips/chunks/rec-123/chunk_00001.m4s
+#EXT-X-ENDLIST
+`;
+
+describe("RuntimeRecordingMessageType", () => {
+  it("matches the runtime-side string values", () => {
+    expect(RuntimeRecordingMessageType.REQUEST_CLIP).toBe("requestClip");
+    expect(RuntimeRecordingMessageType.REQUEST_RECORDING).toBe(
+      "requestRecording"
+    );
+    expect(RuntimeRecordingMessageType.CLIP_READY).toBe("clipReady");
+    expect(RuntimeRecordingMessageType.CLIP_FAILED).toBe("clipFailed");
+  });
+});
+
+describe("ClipReadyPayloadSchema", () => {
+  it("parses a valid payload", () => {
+    const result = ClipReadyPayloadSchema.safeParse(SAMPLE_PAYLOAD);
+    expect(result.success).toBe(true);
+  });
+
+  it("tolerates extra fields the runtime may add", () => {
+    const result = ClipReadyPayloadSchema.safeParse({
+      ...SAMPLE_PAYLOAD,
+      future_field: "ignored",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects payloads missing required fields", () => {
+    const { kind: _kind, ...withoutKind } = SAMPLE_PAYLOAD;
+    const result = ClipReadyPayloadSchema.safeParse(withoutKind);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown kinds", () => {
+    const result = ClipReadyPayloadSchema.safeParse({
+      ...SAMPLE_PAYLOAD,
+      kind: "highlight",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("clipFromPayload", () => {
+  it("converts snake_case to camelCase", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD);
+    expect(clip.sessionId).toBe("rec-123");
+    expect(clip.kind).toBe("snap");
+    expect(clip.startMarker).toBe(120);
+    expect(clip.endMarker).toBe(150);
+    expect(clip.nowMarker).toBe(150);
+    expect(clip.predictedReadyAtMs).toBe(FUTURE_READY_MS);
+    expect(clip.playlistUrl).toBe(SAMPLE_PAYLOAD.playlist_url);
+  });
+
+  it("rewrites playlist URL when coordinatorBaseUrl is provided", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD, {
+      coordinatorBaseUrl: "http://localhost:9000",
+    });
+    expect(clip.playlistUrl).toBe(
+      "http://localhost:9000/clips?session_id=rec-123&start=120&end=150"
+    );
+  });
+
+  it("leaves URL unchanged when coordinatorBaseUrl is omitted", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD);
+    expect(clip.playlistUrl).toBe(SAMPLE_PAYLOAD.playlist_url);
+  });
+});
+
+describe("rewriteUrlHost", () => {
+  it("preserves path and query", () => {
+    const out = rewriteUrlHost(
+      "http://0.0.0.0:8080/clips?session_id=abc&start=0&end=10",
+      "https://api.reactor.inc"
+    );
+    expect(out).toBe(
+      "https://api.reactor.inc/clips?session_id=abc&start=0&end=10"
+    );
+  });
+
+  it("returns input unchanged on parse failure", () => {
+    expect(rewriteUrlHost("not a url", "http://localhost:9000")).toBe(
+      "not a url"
+    );
+  });
+});
+
+describe("parsePlaylist", () => {
+  it("extracts init segment and ordered media segments", () => {
+    const { initUrl, segmentUrls } = parsePlaylist(
+      SAMPLE_MANIFEST,
+      "http://localhost:8080/clips?session_id=rec-123&start=0&end=8"
+    );
+    expect(initUrl).toBe("http://localhost:8080/clips/chunks/rec-123/init.mp4");
+    expect(segmentUrls).toEqual([
+      "http://localhost:8080/clips/chunks/rec-123/chunk_00000.m4s",
+      "http://localhost:8080/clips/chunks/rec-123/chunk_00001.m4s",
+    ]);
+  });
+
+  it("preserves absolute chunk URLs verbatim", () => {
+    const manifest = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MAP:URI="https://cdn.reactor.inc/init.mp4"
+#EXTINF:4.000,
+https://cdn.reactor.inc/chunk_00000.m4s
+#EXT-X-ENDLIST
+`;
+    const { initUrl, segmentUrls } = parsePlaylist(
+      manifest,
+      "http://localhost/clips?x=1"
+    );
+    expect(initUrl).toBe("https://cdn.reactor.inc/init.mp4");
+    expect(segmentUrls).toEqual(["https://cdn.reactor.inc/chunk_00000.m4s"]);
+  });
+
+  it("throws INVALID_PLAYLIST when EXT-X-MAP is missing", () => {
+    const broken = `#EXTM3U\n#EXTINF:4.000,\nchunk_00000.m4s\n`;
+    expect(() => parsePlaylist(broken, "http://localhost/clips")).toThrow(
+      RecordingError
+    );
+  });
+
+  it("throws INVALID_PLAYLIST when there are no segments", () => {
+    const broken = `#EXTM3U\n#EXT-X-MAP:URI="init.mp4"\n#EXT-X-ENDLIST\n`;
+    expect(() => parsePlaylist(broken, "http://localhost/clips")).toThrow(
+      RecordingError
+    );
+  });
+});
+
+describe("fetchPlaylist", () => {
+  let originalFetch: typeof fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns the body on 200", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(SAMPLE_MANIFEST, { status: 200 })) as any;
+    const body = await fetchPlaylist("http://localhost/clips?x=1");
+    expect(body).toBe(SAMPLE_MANIFEST);
+  });
+
+  it("retries on 202 then returns 200 (deadline-driven)", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      predictedReadyAtMs: Date.now() + 10_000,
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(2);
+  });
+
+  it("retries on 202 then returns 200 (legacy maxRetries fallback)", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(2);
+  });
+
+  it("throws CLIP_GONE on 410", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 410 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({
+      code: "CLIP_GONE",
+    });
+  });
+
+  it("throws CLIP_GONE on 404", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({
+      code: "CLIP_GONE",
+    });
+  });
+
+  it("gives the full slack window when polling starts after predictedReadyAtMs (late click)", async () => {
+    // Repro for the bug where reading the "ready in Ns" pill for a few
+    // seconds before clicking Download caused CLIP_NOT_READY on a
+    // clip that landed shortly after. The deadline must run from
+    // max(predicted, startedPollingAt), not from predicted alone.
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 3) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      // Predicted time already 5s in the past — late click.
+      predictedReadyAtMs: Date.now() - 5_000,
+      slackMs: 1_000,
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(3);
+  });
+
+  it("throws CLIP_NOT_READY when deadline passes with stuck 202", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      return Promise.resolve(
+        new Response(null, {
+          status: 202,
+          headers: { "Retry-After": "0" },
+        })
+      );
+    }) as any;
+
+    // Deadline already in the past → first poll returns 202, second loop
+    // sees Date.now() >= deadline and bails.
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1", {
+        predictedReadyAtMs: Date.now() - 10_000,
+        slackMs: 0,
+        minRetryDelayMs: 0,
+        maxRetryDelayMs: 0,
+      })
+    ).rejects.toMatchObject({ code: "CLIP_NOT_READY" });
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("throws CLIP_NOT_READY when fallback maxRetries is exhausted", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 202,
+        headers: { "Retry-After": "0" },
+      })
+    ) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1", {
+        maxRetries: 1,
+        minRetryDelayMs: 0,
+        maxRetryDelayMs: 0,
+      })
+    ).rejects.toMatchObject({ code: "CLIP_NOT_READY" });
+  });
+
+  it("throws PLAYLIST_FETCH_FAILED on other 4xx/5xx", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 500 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({ code: "PLAYLIST_FETCH_FAILED" });
+  });
+});
+
+describe("downloadClipAsFile", () => {
+  const clip = clipFromPayload(SAMPLE_PAYLOAD, {
+    coordinatorBaseUrl: "http://localhost:8080",
+  });
+
+  it("fetches playlist + every chunk and assembles a Blob", async () => {
+    const initBytes = new Uint8Array([1, 2, 3, 4]);
+    const chunk0 = new Uint8Array([5, 6, 7, 8, 9, 10]);
+    const chunk1 = new Uint8Array([11, 12, 13]);
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/clips?")) {
+        return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+      }
+      if (url.endsWith("/init.mp4")) {
+        return Promise.resolve(new Response(initBytes, { status: 200 }));
+      }
+      if (url.endsWith("/chunk_00000.m4s")) {
+        return Promise.resolve(new Response(chunk0, { status: 200 }));
+      }
+      if (url.endsWith("/chunk_00001.m4s")) {
+        return Promise.resolve(new Response(chunk1, { status: 200 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    const onProgress = vi.fn();
+    const blob = await downloadClipAsFile(clip, null, {
+      fetchImpl: mockFetch as any,
+      onProgress,
+    });
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(
+      initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
+    );
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fetched: 3, total: 3 })
+    );
+  });
+
+  it("rejects with CHUNK_FETCH_FAILED when a chunk 5xx's", async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/clips?")) {
+        return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+      }
+      if (url.endsWith("/init.mp4")) {
+        return Promise.resolve(
+          new Response(new Uint8Array([1, 2]), { status: 200 })
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 503 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    await expect(
+      downloadClipAsFile(clip, null, { fetchImpl: mockFetch as any })
+    ).rejects.toMatchObject({ code: "CHUNK_FETCH_FAILED" });
+  });
+});


### PR DESCRIPTION
## Why

Lock the wire contract from PR 1/3 and the Reactor delegations from
PR 2/3 behind unit tests so future refactors can't silently break
clients.  Three test files mirror the three layers of the
implementation: stateless primitives, stateful client, and Reactor
integration.

Together: 1 068 lines of tests covering ~70 cases.  Run with
`pnpm test:unit`.

## What Changed

* **`__tests__/unit/recording.test.ts`** — stateless primitives and
  helpers from `utils/recording.ts`:
  * `clipFromPayload` happy path + local-mode URL rewrite via
    `coordinatorBaseUrl`.
  * `rewriteUrlHost` edge cases (HTTP/HTTPS, with/without port,
    pathless base, relative target).
  * Zod schemas — required vs optional fields, `.passthrough()`
    tolerance for unknown keys, malformed input rejection.
  * `RecordingError` `code` enum + serialised message format.
  * `fetchPlaylist`: 200 returns body; 202 retries until 200;
    honors `Retry-After`; aborts on `signal`; rejects with
    `CLIP_NOT_READY` after `predictedReadyAtMs + slack`; 410
    surfaces as `CLIP_GONE`; network errors surface as
    `PLAYLIST_FETCH_FAILED`.
  * `parsePlaylist`: extracts `init.mp4` URL from `#EXT-X-MAP`,
    chunk URLs from `#EXTINF` blocks; rejects malformed
    manifests with `INVALID_PLAYLIST`.
  * `downloadClipAsFile`: produces a Blob whose byte size is
    `init.length + sum(chunk.length)`; default download handler
    creates an `<a download>` and clicks it; injectable
    `downloadHandler` for tests; passes through chunk-fetch
    errors as `CHUNK_FETCH_FAILED`; honors `signal`.

* **`__tests__/unit/recording-client.test.ts`** — `RecordingClient`
  with a fake host:
  * `requestClip` / `requestRecording` send the right outbound
    message shape and resolve with a typed `Clip` on `clipReady`.
  * FIFO matching with concurrent in-flight requests
    (request order ↔ response order regardless of `kind`).
  * `clipFailed` rejects with `RecordingError(code="CLIP_FAILED")`.
  * Per-request timeout rejects with
    `RecordingError(code="REQUEST_TIMEOUT")`.
  * `statusChanged → DISCONNECTED` rejects all pending promises
    with `RecordingError(code="DISCONNECTED")`.
  * Malformed `clipReady` payloads (missing fields, wrong types)
    are rejected at the schema level and surfaced as
    `INTERNAL_ERROR`.
  * `destroy()` unsubscribes the host event listeners and rejects
    pending promises.

* **`__tests__/unit/reactor-recording.test.ts`** — `Reactor`
  delegations integration tests:
  * `reactor.requestClip(durationSeconds)` round-trips a clip
    through a fake transport.
  * `reactor.requestRecording()` returns `kind: "recording"`
    with `startMarker = 0`.
  * `reactor.downloadClipAsFile(clip)` calls the underlying
    helper with the right arguments.
  * Local-mode URL rewriting: when `reactor.local` is true, the
    runtime's `0.0.0.0`-bound `playlist_url` is rewritten to
    the SDK's coordinator URL.
  * Disconnect during a pending request rejects the promise
    with `DISCONNECTED`.

## API

No new API surface — this PR is tests only.  See PR 1/3 and PR 2/3
for the API examples; the tests verify those contracts.

JS — what the suite exercises end-to-end:

```ts
import { Reactor } from "@reactor-team/js-sdk";

const reactor = new Reactor({ /* … */ });
await reactor.connect();

const clip = await reactor.requestClip(30);
const blob = await reactor.downloadClipAsFile(clip, "snap.mp4");
```

React — the same path, exercised via `useReactor`:

```tsx
import { useReactor } from "@reactor-team/js-sdk";

function App() {
  const reactor = useReactor((s) => s.internal.reactor);
  return (
    <button onClick={async () => {
      const clip = await reactor.requestClip(30);
      await reactor.downloadClipAsFile(clip);
    }}>
      Snap last 30s
    </button>
  );
}
```

Linear: REA-1955, REA-1956