### PR TITLE
[REA-1955] sdk recording: wire contract + RecordingClient

### DIFF
--- a/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
@@ -1,0 +1,364 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+import type { ClipReadyPayload } from "../../src/utils/recording";
+
+const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
+
+const MOCK_INITIAL_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "CREATED",
+};
+
+const MOCK_FULL_SESSION_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "ACTIVE",
+  selected_transport: { protocol: "webrtc", version: "1.0" },
+  capabilities: {
+    protocol_version: "1.0",
+    tracks: [
+      { name: "main_video", kind: "video", direction: "recvonly" as const },
+    ],
+  },
+};
+
+let transportHandlers: Record<string, (...args: any[]) => void> = {};
+let mockTransportClient: any;
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn().mockImplementation(() => ({
+    createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+    pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    getSessionId: vi.fn().mockReturnValue(MOCK_SESSION_ID),
+  })),
+}));
+
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn().mockImplementation(() => ({
+    createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+    pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+    terminateSession: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn().mockImplementation(() => {
+    transportHandlers = {};
+    mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        transportHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue(undefined),
+      getTransportTimings: vi.fn().mockReturnValue(undefined),
+      abort: vi.fn(),
+    };
+    return mockTransportClient;
+  }),
+}));
+
+/**
+ * Drive the Reactor to "ready" state via its mocked transport so the
+ * recording API guards pass.
+ */
+async function connectedReactor(local = false): Promise<Reactor> {
+  const r = new Reactor({ modelName: "echo", local });
+  if (local) {
+    await r.connect();
+  } else {
+    await r.connect("jwt-token");
+  }
+  // Drive the transport to "connected" so status flips to "ready".
+  transportHandlers["statusChanged"]?.("connected");
+  return r;
+}
+
+function emitRuntimeMessage(message: unknown): void {
+  // Mirrors WebRTCTransportClient.onmessage: emits ("message", inner, scope)
+  transportHandlers["message"]?.(message, "runtime");
+}
+
+function buildClipReady(overrides: Partial<ClipReadyPayload> = {}): {
+  type: string;
+  data: ClipReadyPayload;
+} {
+  return {
+    type: "clipReady",
+    data: {
+      session_id: "rec-1",
+      kind: "snap",
+      start_marker: 120,
+      end_marker: 150,
+      now_marker: 150,
+      // Far-future epoch so any test that surfaces predictedReadyAtMs
+      // without overriding it doesn't accidentally trip a past-deadline
+      // path inside fetchPlaylist (these tests never go on-network).
+      predicted_ready_at_ms: 9_999_999_999_999,
+      playlist_url:
+        "https://api.reactor.inc/clips?session_id=rec-1&start=120&end=150",
+      ...overrides,
+    },
+  };
+}
+
+describe("Reactor recording API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transportHandlers = {};
+    mockTransportClient = undefined;
+  });
+
+  // ── Pre-flight guards ──────────────────────────────────────────────────
+
+  describe("requestClip()", () => {
+    it("rejects with INVALID_DURATION on zero", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(0)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on negative", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(-5)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on NaN", async () => {
+      const r = await connectedReactor();
+      await expect(r.requestClip(Number.NaN)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INVALID_DURATION on Infinity", async () => {
+      const r = await connectedReactor();
+      await expect(
+        r.requestClip(Number.POSITIVE_INFINITY)
+      ).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with DISCONNECTED before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(r.requestClip(30)).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+    });
+
+    it("sends a runtime requestClip message", async () => {
+      const r = await connectedReactor();
+      // Don't await — would hang waiting for clipReady.
+      const promise = r.requestClip(30);
+      expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
+        "requestClip",
+        { duration_seconds: 30 },
+        "runtime",
+        undefined
+      );
+      // Resolve so the test cleans up.
+      emitRuntimeMessage(buildClipReady());
+      await promise;
+      await r.disconnect();
+    });
+
+    it("resolves with a Clip when clipReady arrives", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(buildClipReady());
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      expect(clip.kind).toBe("snap");
+      expect(clip.startMarker).toBe(120);
+      expect(clip.endMarker).toBe(150);
+      expect(clip.nowMarker).toBe(150);
+      expect(clip.predictedReadyAtMs).toBe(9_999_999_999_999);
+      expect(clip.playlistUrl).toContain("session_id=rec-1");
+      await r.disconnect();
+    });
+
+    it("rejects with RECORDER_DISABLED on clipFailed { reason: 'recorder disabled' }", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "recorder disabled" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "RECORDER_DISABLED",
+        reason: "recorder disabled",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INTERNAL_ERROR on unrecognized clipFailed reason", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "internal error: boom" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+        reason: "internal error: boom",
+      });
+      await r.disconnect();
+    });
+
+    it("rejects with INTERNAL_ERROR on malformed clipReady", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+      emitRuntimeMessage({
+        type: "clipReady",
+        data: { session_id: "rec-1" },
+      });
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+      });
+      await r.disconnect();
+    });
+  });
+
+  describe("requestRecording()", () => {
+    it("sends a runtime requestRecording message with empty body", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestRecording();
+      expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
+        "requestRecording",
+        {},
+        "runtime",
+        undefined
+      );
+      emitRuntimeMessage(
+        buildClipReady({
+          kind: "recording",
+          start_marker: 0,
+          end_marker: 60,
+          now_marker: 60,
+        })
+      );
+      const clip = await promise;
+      expect(clip.kind).toBe("recording");
+      expect(clip.startMarker).toBe(0);
+      await r.disconnect();
+    });
+
+    it("rejects with DISCONNECTED before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(r.requestRecording()).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+    });
+  });
+
+  // ── FIFO correlation ──────────────────────────────────────────────────
+
+  describe("FIFO correlator", () => {
+    it("matches two concurrent requests in receipt order", async () => {
+      const r = await connectedReactor();
+      const p1 = r.requestClip(10);
+      const p2 = r.requestClip(20);
+
+      emitRuntimeMessage(buildClipReady({ session_id: "first" }));
+      emitRuntimeMessage(buildClipReady({ session_id: "second" }));
+
+      const [clip1, clip2] = await Promise.all([p1, p2]);
+      expect(clip1.sessionId).toBe("first");
+      expect(clip2.sessionId).toBe("second");
+      await r.disconnect();
+    });
+
+    it("ignores extra clipReady envelopes when no requests are pending", async () => {
+      const r = await connectedReactor();
+      // Should not throw.
+      emitRuntimeMessage(buildClipReady());
+      await r.disconnect();
+    });
+
+    it("does not interfere with non-clip runtime messages", async () => {
+      const r = await connectedReactor();
+      const promise = r.requestClip(30);
+
+      // Random platform message should be ignored by the correlator.
+      emitRuntimeMessage({ type: "modelCapabilities", data: {} });
+
+      // Now resolve the actual request.
+      emitRuntimeMessage(buildClipReady());
+      await promise;
+      await r.disconnect();
+    });
+  });
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────
+
+  describe("lifecycle", () => {
+    it("rejects pending requests with DISCONNECTED on disconnect", async () => {
+      const r = await connectedReactor();
+      const p1 = r.requestClip(10);
+      const p2 = r.requestRecording();
+
+      await r.disconnect();
+
+      await expect(p1).rejects.toMatchObject({ code: "DISCONNECTED" });
+      await expect(p2).rejects.toMatchObject({ code: "DISCONNECTED" });
+    });
+  });
+
+  // ── URL rewrite for local mode ────────────────────────────────────────
+
+  describe("local mode", () => {
+    it("rewrites playlist URL to the configured coordinator URL", async () => {
+      const r = await connectedReactor(true);
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "http://0.0.0.0:8080/clips?session_id=rec-1&start=0&end=30",
+        })
+      );
+      const clip = await promise;
+      // LOCAL_COORDINATOR_URL is http://localhost:8080.
+      expect(clip.playlistUrl).toBe(
+        "http://localhost:8080/clips?session_id=rec-1&start=0&end=30"
+      );
+      await r.disconnect();
+    });
+
+    it("does NOT rewrite playlist URL in remote mode", async () => {
+      const r = await connectedReactor(false);
+      const promise = r.requestClip(30);
+      emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "https://api.reactor.inc/clips?session_id=rec-1&start=0&end=30",
+        })
+      );
+      const clip = await promise;
+      expect(clip.playlistUrl).toBe(
+        "https://api.reactor.inc/clips?session_id=rec-1&start=0&end=30"
+      );
+      await r.disconnect();
+    });
+  });
+});

--- a/packages/js-sdk/__tests__/unit/recording-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording-client.test.ts
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Tests for {@link RecordingClient} in isolation, against a fake
+ * {@link RecordingClientHost}. The reactor-level integration is
+ * exercised separately in `reactor-recording.test.ts`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  RecordingClient,
+  type RecordingClientHost,
+} from "../../src/core/RecordingClient";
+import type { ClipReadyPayload } from "../../src/utils/recording";
+import type { ReactorStatus } from "../../src/types";
+
+interface FakeHostHandles {
+  host: RecordingClientHost;
+  /** Push a runtime message to all subscribers. */
+  emitRuntimeMessage: (msg: unknown) => void;
+  /** Push a status change to all subscribers. */
+  emitStatus: (status: ReactorStatus) => void;
+  /** Spy on outgoing runtime commands. */
+  sendRuntimeCommand: ReturnType<typeof vi.fn>;
+  /** Set the status returned by `getStatus()`. */
+  setStatus: (status: ReactorStatus) => void;
+  /** True once the runtime-message subscription was unsubscribed. */
+  isRuntimeMessageUnsubscribed: () => boolean;
+}
+
+function makeHost(initial: ReactorStatus = "ready"): FakeHostHandles {
+  let status: ReactorStatus = initial;
+  const runtimeListeners = new Set<(msg: unknown) => void>();
+  const statusListeners = new Set<(s: ReactorStatus) => void>();
+  let runtimeMessageUnsubCalled = false;
+  const sendRuntimeCommand = vi.fn().mockResolvedValue(undefined);
+
+  const host: RecordingClientHost = {
+    onRuntimeMessage(handler) {
+      runtimeListeners.add(handler);
+      return () => {
+        runtimeListeners.delete(handler);
+        runtimeMessageUnsubCalled = true;
+      };
+    },
+    onStatusChanged(handler) {
+      statusListeners.add(handler);
+      return () => statusListeners.delete(handler);
+    },
+    sendRuntimeCommand,
+    getStatus: () => status,
+    getLocalCoordinatorBaseUrl: () => undefined,
+  };
+
+  return {
+    host,
+    emitRuntimeMessage: (msg) =>
+      runtimeListeners.forEach((handler) => handler(msg)),
+    emitStatus: (s) => {
+      status = s;
+      statusListeners.forEach((handler) => handler(s));
+    },
+    sendRuntimeCommand,
+    setStatus: (s) => {
+      status = s;
+    },
+    isRuntimeMessageUnsubscribed: () => runtimeMessageUnsubCalled,
+  };
+}
+
+function buildClipReady(overrides: Partial<ClipReadyPayload> = {}): {
+  type: string;
+  data: ClipReadyPayload;
+} {
+  return {
+    type: "clipReady",
+    data: {
+      session_id: "rec-1",
+      kind: "snap",
+      start_marker: 120,
+      end_marker: 150,
+      now_marker: 150,
+      predicted_ready_at_ms: 9_999_999_999_999,
+      playlist_url:
+        "https://api.reactor.inc/clips?session_id=rec-1&start=120&end=150",
+      ...overrides,
+    },
+  };
+}
+
+describe("RecordingClient", () => {
+  describe("requestClip / requestRecording", () => {
+    it("rejects with INVALID_DURATION on non-positive durations", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      await expect(client.requestClip(0)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await expect(client.requestClip(-1)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      await expect(client.requestClip(Number.NaN)).rejects.toMatchObject({
+        code: "INVALID_DURATION",
+      });
+      client.destroy();
+    });
+
+    it("rejects with DISCONNECTED when host is not ready", async () => {
+      const fake = makeHost("disconnected");
+      const client = new RecordingClient(fake.host);
+      await expect(client.requestClip(30)).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+      await expect(client.requestRecording()).rejects.toMatchObject({
+        code: "DISCONNECTED",
+      });
+      client.destroy();
+    });
+
+    it("sends requestClip and resolves on clipReady", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      expect(fake.sendRuntimeCommand).toHaveBeenCalledWith("requestClip", {
+        duration_seconds: 30,
+      });
+
+      fake.emitRuntimeMessage(buildClipReady());
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      expect(clip.kind).toBe("snap");
+      client.destroy();
+    });
+
+    it("sends requestRecording with empty body", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestRecording();
+
+      expect(fake.sendRuntimeCommand).toHaveBeenCalledWith(
+        "requestRecording",
+        {}
+      );
+
+      fake.emitRuntimeMessage(buildClipReady({ kind: "recording" }));
+      const clip = await promise;
+      expect(clip.kind).toBe("recording");
+      client.destroy();
+    });
+  });
+
+  describe("FIFO correlator", () => {
+    it("matches concurrent requests in receipt order", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p1 = client.requestClip(10);
+      const p2 = client.requestClip(20);
+
+      fake.emitRuntimeMessage(buildClipReady({ session_id: "first" }));
+      fake.emitRuntimeMessage(buildClipReady({ session_id: "second" }));
+
+      const [c1, c2] = await Promise.all([p1, p2]);
+      expect(c1.sessionId).toBe("first");
+      expect(c2.sessionId).toBe("second");
+      client.destroy();
+    });
+
+    it("ignores non-clip runtime messages", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({ type: "modelCapabilities", data: {} });
+      fake.emitRuntimeMessage({ type: "ping", data: {} });
+      fake.emitRuntimeMessage(buildClipReady());
+
+      const clip = await promise;
+      expect(clip.sessionId).toBe("rec-1");
+      client.destroy();
+    });
+
+    it("ignores stray clipReady when no requests are pending", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      // Should not throw; no pending request to resolve.
+      fake.emitRuntimeMessage(buildClipReady());
+      client.destroy();
+    });
+  });
+
+  describe("clipFailed handling", () => {
+    it("maps 'recorder disabled' to RECORDER_DISABLED", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "recorder disabled" },
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        code: "RECORDER_DISABLED",
+        reason: "recorder disabled",
+      });
+      client.destroy();
+    });
+
+    it("maps unknown reasons to INTERNAL_ERROR", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage({
+        type: "clipFailed",
+        data: { reason: "internal error: boom" },
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+        reason: "internal error: boom",
+      });
+      client.destroy();
+    });
+  });
+
+  describe("local-mode URL rewrite", () => {
+    it("rewrites playlist_url through the host's coordinator base URL", async () => {
+      const fake = makeHost();
+      // Override just the URL hook.
+      const host: RecordingClientHost = {
+        ...fake.host,
+        getLocalCoordinatorBaseUrl: () => "http://localhost:9000",
+      };
+      const client = new RecordingClient(host);
+      const promise = client.requestClip(30);
+
+      fake.emitRuntimeMessage(
+        buildClipReady({
+          playlist_url:
+            "http://0.0.0.0:8080/clips?session_id=rec-1&start=120&end=150",
+        })
+      );
+
+      const clip = await promise;
+      expect(clip.playlistUrl).toBe(
+        "http://localhost:9000/clips?session_id=rec-1&start=120&end=150"
+      );
+      client.destroy();
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("rejects pending requests with DISCONNECTED on disconnect", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p1 = client.requestClip(10);
+      const p2 = client.requestRecording();
+
+      fake.emitStatus("disconnected");
+
+      await expect(p1).rejects.toMatchObject({ code: "DISCONNECTED" });
+      await expect(p2).rejects.toMatchObject({ code: "DISCONNECTED" });
+      client.destroy();
+    });
+
+    it("rejects pending requests with DISCONNECTED on destroy", async () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      const p = client.requestClip(10);
+
+      client.destroy();
+      await expect(p).rejects.toMatchObject({ code: "DISCONNECTED" });
+    });
+
+    it("unsubscribes from host events on destroy", () => {
+      const fake = makeHost();
+      const client = new RecordingClient(fake.host);
+      expect(fake.isRuntimeMessageUnsubscribed()).toBe(false);
+      client.destroy();
+      expect(fake.isRuntimeMessageUnsubscribed()).toBe(true);
+    });
+
+    it("rejects with REQUEST_TIMEOUT when no response arrives", async () => {
+      vi.useFakeTimers();
+      try {
+        const fake = makeHost();
+        const client = new RecordingClient(fake.host, { requestTimeoutMs: 50 });
+
+        // Attach the rejection assertion *before* advancing timers so
+        // the rejection handler is in place when the timeout fires;
+        // otherwise vitest treats it as an unhandled rejection.
+        const settled = expect(client.requestClip(30)).rejects.toMatchObject({
+          code: "REQUEST_TIMEOUT",
+        });
+
+        await vi.advanceTimersByTimeAsync(60);
+        await settled;
+
+        client.destroy();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+import { describe, it, expect } from "vitest";
+import {
+  ClipReadyPayloadSchema,
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  rewriteUrlHost,
+} from "../../src/utils/recording";
+
+/** Predicted ready time well in the future so polling tests don't trip the deadline. */
+const FUTURE_READY_MS = 9_999_999_999_999;
+
+const SAMPLE_PAYLOAD = {
+  session_id: "rec-123",
+  kind: "snap" as const,
+  start_marker: 120.0,
+  end_marker: 150.0,
+  now_marker: 150.0,
+  predicted_ready_at_ms: FUTURE_READY_MS,
+  playlist_url:
+    "http://0.0.0.0:8080/clips?session_id=rec-123&start=120&end=150",
+};
+
+describe("RuntimeRecordingMessageType", () => {
+  it("matches the runtime-side string values", () => {
+    expect(RuntimeRecordingMessageType.REQUEST_CLIP).toBe("requestClip");
+    expect(RuntimeRecordingMessageType.REQUEST_RECORDING).toBe(
+      "requestRecording"
+    );
+    expect(RuntimeRecordingMessageType.CLIP_READY).toBe("clipReady");
+    expect(RuntimeRecordingMessageType.CLIP_FAILED).toBe("clipFailed");
+  });
+});
+
+describe("ClipReadyPayloadSchema", () => {
+  it("parses a valid payload", () => {
+    const result = ClipReadyPayloadSchema.safeParse(SAMPLE_PAYLOAD);
+    expect(result.success).toBe(true);
+  });
+
+  it("tolerates extra fields the runtime may add", () => {
+    const result = ClipReadyPayloadSchema.safeParse({
+      ...SAMPLE_PAYLOAD,
+      future_field: "ignored",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects payloads missing required fields", () => {
+    const { kind: _kind, ...withoutKind } = SAMPLE_PAYLOAD;
+    const result = ClipReadyPayloadSchema.safeParse(withoutKind);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown kinds", () => {
+    const result = ClipReadyPayloadSchema.safeParse({
+      ...SAMPLE_PAYLOAD,
+      kind: "highlight",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("clipFromPayload", () => {
+  it("converts snake_case to camelCase", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD);
+    expect(clip.sessionId).toBe("rec-123");
+    expect(clip.kind).toBe("snap");
+    expect(clip.startMarker).toBe(120);
+    expect(clip.endMarker).toBe(150);
+    expect(clip.nowMarker).toBe(150);
+    expect(clip.predictedReadyAtMs).toBe(FUTURE_READY_MS);
+    expect(clip.playlistUrl).toBe(SAMPLE_PAYLOAD.playlist_url);
+  });
+
+  it("rewrites playlist URL when coordinatorBaseUrl is provided", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD, {
+      coordinatorBaseUrl: "http://localhost:9000",
+    });
+    expect(clip.playlistUrl).toBe(
+      "http://localhost:9000/clips?session_id=rec-123&start=120&end=150"
+    );
+  });
+
+  it("leaves URL unchanged when coordinatorBaseUrl is omitted", () => {
+    const clip = clipFromPayload(SAMPLE_PAYLOAD);
+    expect(clip.playlistUrl).toBe(SAMPLE_PAYLOAD.playlist_url);
+  });
+});
+
+describe("rewriteUrlHost", () => {
+  it("preserves path and query", () => {
+    const out = rewriteUrlHost(
+      "http://0.0.0.0:8080/clips?session_id=abc&start=0&end=10",
+      "https://api.reactor.inc"
+    );
+    expect(out).toBe(
+      "https://api.reactor.inc/clips?session_id=abc&start=0&end=10"
+    );
+  });
+
+  it("returns input unchanged on parse failure", () => {
+    expect(rewriteUrlHost("not a url", "http://localhost:9000")).toBe(
+      "not a url"
+    );
+  });
+});

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -42,6 +42,8 @@ export type Options = z.input<typeof OptionsSchema>;
 
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
+import { RecordingClient } from "./RecordingClient";
+import type { Clip } from "../utils/recording";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -63,6 +65,18 @@ export class Reactor {
   private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
 
+  /**
+   * Per-Reactor recording client. Owns the FIFO promise correlator
+   * for `requestClip` / `requestRecording` round-trips and the
+   * `downloadClipAsFile` helper. Subscribes to this Reactor's
+   * `runtimeMessage` and `statusChanged` events on construction.
+   *
+   * App code typically uses the convenience methods
+   * ({@link Reactor.requestClip} etc.) but advanced consumers can
+   * drive the feature directly off this field.
+   */
+  readonly recording: RecordingClient;
+
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
     this.coordinatorUrl = validatedOptions.apiUrl;
@@ -74,6 +88,27 @@ export class Reactor {
     if (validatedOptions.modelTracks) {
       this.presetTracks = validatedOptions.modelTracks;
     }
+
+    // Recording client. Subscribes to `runtimeMessage` /
+    // `statusChanged` via the standard event-bus pattern (no direct
+    // method calls), so app code that listens to `runtimeMessage`
+    // continues to receive `clipReady` / `clipFailed` envelopes
+    // alongside the recording client's own correlator.
+    this.recording = new RecordingClient({
+      onRuntimeMessage: (handler) => {
+        this.on("runtimeMessage", handler);
+        return () => this.off("runtimeMessage", handler);
+      },
+      onStatusChanged: (handler) => {
+        this.on("statusChanged", handler);
+        return () => this.off("statusChanged", handler);
+      },
+      sendRuntimeCommand: (command, data) =>
+        this.sendCommand(command, data, "runtime"),
+      getStatus: () => this.status,
+      getLocalCoordinatorBaseUrl: () =>
+        this.local ? this.coordinatorUrl : undefined,
+    });
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
@@ -232,6 +267,48 @@ export class Reactor {
     });
 
     return new FileRef(slot.presigned_id, name, mimeType, size);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Recording — thin delegations to `this.recording` (RecordingClient).
+  // The recording subsystem owns its own state and lifecycle; these
+  // methods exist for API ergonomics so app code never needs to
+  // reach into `reactor.recording` for the common case.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Asks the runtime to mint a clip covering the last `durationSeconds`
+   * of the live session.
+   *
+   * Sends a `requestClip` runtime message and resolves with the
+   * matching `clipReady` payload (or rejects on `clipFailed`).
+   * `durationSeconds` is capped server-side at the model's
+   * `recording.clip_max_seconds` (default 5 minutes).
+   *
+   * The returned {@link Clip} carries a `playlistUrl` that can be handed
+   * directly to any HLS-capable video player. To save the clip as a
+   * file, pass it to {@link downloadClipAsFile}.
+   *
+   * Multiple concurrent requests are supported — responses are
+   * matched FIFO with outgoing requests.
+   *
+   * @throws {RecordingError} on invalid input, transport failure,
+   *   timeout, runtime-side `clipFailed`, or disconnect mid-request.
+   */
+  async requestClip(durationSeconds: number): Promise<Clip> {
+    return this.recording.requestClip(durationSeconds);
+  }
+
+  /**
+   * Asks the runtime to mint a clip covering the entire session up to
+   * "now" (the latest fully-uploaded chunk). Mechanically identical to
+   * {@link requestClip} with `start = 0`; only the resolved
+   * {@link Clip.kind} discriminator differs (`"recording"` vs `"snap"`).
+   *
+   * @throws {RecordingError} same conditions as {@link requestClip}.
+   */
+  async requestRecording(): Promise<Clip> {
+    return this.recording.requestRecording();
   }
 
   /**
@@ -462,6 +539,8 @@ export class Reactor {
       if (scope === "application") {
         this.emit("message", message);
       } else if (scope === "runtime") {
+        // Just emit — `RecordingClient` and any app-level
+        // `runtimeMessage` listeners are subscribers via `on()`.
         this.emit("runtimeMessage", message);
       }
     });

--- a/packages/js-sdk/src/core/RecordingClient.ts
+++ b/packages/js-sdk/src/core/RecordingClient.ts
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * `RecordingClient` — per-Reactor handler for the recording feature.
+ *
+ * Stateful complement to the stateless primitives in
+ * `utils/recording.ts`. Owns the FIFO promise correlator that turns
+ * inbound `clipReady` / `clipFailed` runtime messages into resolved
+ * promises, plus the lifecycle hooks (subscribe to Reactor's event
+ * bus on construct, reject pending requests on disconnect).
+ *
+ * Created by `Reactor` in its constructor and lifetime-bound to it.
+ * Reactor exposes thin delegations (`Reactor.requestClip`,
+ * `Reactor.requestRecording`) so app code never touches the client
+ * directly — but it's exported for advanced consumers and isolated
+ * testing.
+ */
+
+import type { ReactorStatus } from "../types";
+import {
+  ClipFailedPayloadSchema,
+  ClipReadyPayloadSchema,
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  type Clip,
+} from "../utils/recording";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * How long to wait for a `clipReady` / `clipFailed` envelope before
+ * giving up. Marker computation + URL build is sub-ms on the runtime;
+ * 10 s leaves ample headroom for a bad data-channel state without
+ * letting requests hang indefinitely.
+ */
+export const DEFAULT_CLIP_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Slim adapter the {@link RecordingClient} requires from its host
+ * Reactor. Keeps the recording subsystem decoupled from the full
+ * Reactor surface — easy to test in isolation with a fake adapter,
+ * and the only public API surface added to Reactor itself is the
+ * three thin delegation methods.
+ */
+export interface RecordingClientHost {
+  /**
+   * Subscribe to runtime-scoped messages on the data channel.
+   * Returns an unsubscribe function. Mirrors the
+   * `reactor.on("runtimeMessage", …)` pattern.
+   */
+  onRuntimeMessage: (handler: (message: unknown) => void) => () => void;
+  /**
+   * Subscribe to status changes (so the client can reject pending
+   * requests on disconnect). Returns an unsubscribe function.
+   */
+  onStatusChanged: (handler: (status: ReactorStatus) => void) => () => void;
+  /**
+   * Send a runtime-scoped command on the data channel. The
+   * `RecordingClient` uses this to fire `requestClip` /
+   * `requestRecording`.
+   */
+  sendRuntimeCommand: (
+    command: string,
+    data: Record<string, unknown>
+  ) => Promise<void>;
+  /** Current connection status — guards `requestClip` before it goes on the wire. */
+  getStatus: () => ReactorStatus;
+  /**
+   * Coordinator base URL used to rewrite `playlist_url` when the
+   * runtime hands back a URL bound to its own bind address (e.g.
+   * `http://0.0.0.0:8080/clips?…`) in local mode. Returns
+   * `undefined` in remote mode.
+   */
+  getLocalCoordinatorBaseUrl: () => string | undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RecordingClient
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Internal — one entry per in-flight {@link RecordingClient.requestClip} / `.requestRecording`. */
+type PendingClipRequest = {
+  resolve: (clip: Clip) => void;
+  reject: (error: RecordingError) => void;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+};
+
+export class RecordingClient {
+  // FIFO queue of pending recording requests. The runtime processes
+  // `requestClip` / `requestRecording` messages in receipt order on
+  // a single async dispatcher, so we correlate responses by FIFO
+  // without extra request IDs on the wire. `clipFailed` carries no
+  // discriminator, which forces FIFO matching anyway.
+  private pendingClipRequests: PendingClipRequest[] = [];
+
+  /** Timeout applied per request; configurable for tests. */
+  private readonly requestTimeoutMs: number;
+
+  /** Cleanup handles for the host event subscriptions. */
+  private readonly unsubscribers: Array<() => void> = [];
+
+  constructor(
+    private readonly host: RecordingClientHost,
+    options: { requestTimeoutMs?: number } = {}
+  ) {
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_CLIP_REQUEST_TIMEOUT_MS;
+
+    this.unsubscribers.push(
+      this.host.onRuntimeMessage((message) => this.onRuntimeMessage(message))
+    );
+    this.unsubscribers.push(
+      this.host.onStatusChanged((status) => this.onStatusChanged(status))
+    );
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────
+
+  /**
+   * Asks the runtime to mint a clip covering the last `durationSeconds`
+   * of the live session. See {@link Reactor.requestClip} for the
+   * full contract — this is the implementation it delegates to.
+   */
+  async requestClip(durationSeconds: number): Promise<Clip> {
+    if (
+      typeof durationSeconds !== "number" ||
+      !Number.isFinite(durationSeconds) ||
+      durationSeconds <= 0
+    ) {
+      throw new RecordingError(
+        "INVALID_DURATION",
+        "durationSeconds must be a positive finite number"
+      );
+    }
+    const status = this.host.getStatus();
+    if (status !== "ready") {
+      throw new RecordingError(
+        "DISCONNECTED",
+        `Cannot request clip while status is "${status}"`
+      );
+    }
+    return this.dispatchClipRequest(RuntimeRecordingMessageType.REQUEST_CLIP, {
+      duration_seconds: durationSeconds,
+    });
+  }
+
+  /**
+   * Asks the runtime to mint a clip covering the entire session up
+   * to "now". See {@link Reactor.requestRecording} for the full
+   * contract.
+   */
+  async requestRecording(): Promise<Clip> {
+    const status = this.host.getStatus();
+    if (status !== "ready") {
+      throw new RecordingError(
+        "DISCONNECTED",
+        `Cannot request recording while status is "${status}"`
+      );
+    }
+    return this.dispatchClipRequest(
+      RuntimeRecordingMessageType.REQUEST_RECORDING,
+      {}
+    );
+  }
+
+  /**
+   * Drop every pending request and unsubscribe from host events.
+   * Safe to call multiple times; further `requestClip` /
+   * `requestRecording` calls after `destroy()` will hang waiting for
+   * a response that will never arrive — host should not call into
+   * the client after destroy.
+   */
+  destroy(): void {
+    this.rejectPending("RecordingClient destroyed");
+    while (this.unsubscribers.length > 0) {
+      const off = this.unsubscribers.pop();
+      try {
+        off?.();
+      } catch {
+        // Best-effort cleanup — ignore handler removal errors.
+      }
+    }
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────
+
+  /**
+   * Shared core of {@link requestClip} / {@link requestRecording}:
+   * registers a pending FIFO entry, sends the runtime message via
+   * the host, and resolves when the next `clipReady` / `clipFailed`
+   * arrives.
+   */
+  private dispatchClipRequest(
+    messageType:
+      | typeof RuntimeRecordingMessageType.REQUEST_CLIP
+      | typeof RuntimeRecordingMessageType.REQUEST_RECORDING,
+    payload: Record<string, unknown>
+  ): Promise<Clip> {
+    return new Promise<Clip>((resolve, reject) => {
+      const pending: PendingClipRequest = { resolve, reject };
+      pending.timeoutHandle = setTimeout(() => {
+        const idx = this.pendingClipRequests.indexOf(pending);
+        if (idx === -1) return;
+        this.pendingClipRequests.splice(idx, 1);
+        reject(
+          new RecordingError(
+            "REQUEST_TIMEOUT",
+            `No clipReady/clipFailed within ${this.requestTimeoutMs}ms`
+          )
+        );
+      }, this.requestTimeoutMs);
+
+      this.pendingClipRequests.push(pending);
+
+      // Fire-and-forget — host.sendRuntimeCommand is async only
+      // because of the FileRef extraction the underlying sendCommand
+      // does for application messages, neither of which fires for
+      // a runtime-scoped command.
+      try {
+        void this.host.sendRuntimeCommand(messageType, payload);
+      } catch (error) {
+        const idx = this.pendingClipRequests.indexOf(pending);
+        if (idx !== -1) this.pendingClipRequests.splice(idx, 1);
+        if (pending.timeoutHandle) clearTimeout(pending.timeoutHandle);
+        reject(
+          new RecordingError(
+            "INTERNAL_ERROR",
+            `Failed to send ${messageType}: ${(error as Error).message}`
+          )
+        );
+      }
+    });
+  }
+
+  /**
+   * Inbound runtime-message handler. Matches `clipReady` /
+   * `clipFailed` to the next pending request FIFO; ignores every
+   * other type so the runtime channel can grow new platform
+   * messages without breaking existing SDK consumers.
+   */
+  private onRuntimeMessage(message: unknown): void {
+    if (!message || typeof message !== "object") return;
+    const msg = message as { type?: unknown; data?: unknown };
+    const type = msg.type;
+    if (
+      type !== RuntimeRecordingMessageType.CLIP_READY &&
+      type !== RuntimeRecordingMessageType.CLIP_FAILED
+    ) {
+      return;
+    }
+    const pending = this.pendingClipRequests.shift();
+    if (!pending) {
+      console.warn("[Reactor] Received", type, "with no pending request");
+      return;
+    }
+    if (pending.timeoutHandle) clearTimeout(pending.timeoutHandle);
+
+    if (type === RuntimeRecordingMessageType.CLIP_READY) {
+      const parsed = ClipReadyPayloadSchema.safeParse(msg.data);
+      if (!parsed.success) {
+        pending.reject(
+          new RecordingError(
+            "INTERNAL_ERROR",
+            `Malformed clipReady payload: ${parsed.error.message}`
+          )
+        );
+        return;
+      }
+      pending.resolve(
+        clipFromPayload(parsed.data, {
+          coordinatorBaseUrl: this.host.getLocalCoordinatorBaseUrl(),
+        })
+      );
+      return;
+    }
+
+    const parsedFail = ClipFailedPayloadSchema.safeParse(msg.data ?? {});
+    const reason = parsedFail.success ? parsedFail.data.reason : "unknown";
+    pending.reject(
+      new RecordingError(
+        reason === "recorder disabled" ||
+          reason === "recorder disabled or encoder crashed"
+          ? "RECORDER_DISABLED"
+          : "INTERNAL_ERROR",
+        reason
+      )
+    );
+  }
+
+  private onStatusChanged(status: ReactorStatus): void {
+    if (status === "disconnected") {
+      this.rejectPending("Reactor disconnected");
+    }
+  }
+
+  /**
+   * Reject every in-flight request with a typed disconnect error.
+   * Called from {@link destroy} and from the host's status-change
+   * handler so consumers awaiting a clip don't hang forever when
+   * the session goes away.
+   */
+  private rejectPending(reason: string): void {
+    if (this.pendingClipRequests.length === 0) return;
+    const pending = this.pendingClipRequests;
+    this.pendingClipRequests = [];
+    for (const entry of pending) {
+      if (entry.timeoutHandle) clearTimeout(entry.timeoutHandle);
+      entry.reject(new RecordingError("DISCONNECTED", reason));
+    }
+  }
+}

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -5,4 +5,24 @@ export * from "./react/ReactorController";
 export * from "./react/WebcamStream";
 export * from "./react/hooks";
 export * from "./types";
+// Recording wire contract — types, schemas, error class.
+export {
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  rewriteUrlHost,
+} from "./utils/recording";
+export type {
+  Clip,
+  ClipKind,
+  ClipReadyPayload,
+  ClipFailedPayload,
+  ParseClipOptions,
+} from "./utils/recording";
+// Stateful recording client + its host adapter.
+export {
+  DEFAULT_CLIP_REQUEST_TIMEOUT_MS,
+  RecordingClient,
+} from "./core/RecordingClient";
+export type { RecordingClientHost } from "./core/RecordingClient";
 export type { ReactorStore } from "./core/store";

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Stateless wire-contract primitives for the Reactor recording feature.
+ *
+ * This module owns:
+ * - Public-facing {@link Clip} type, {@link RecordingError} class, and
+ *   the `RuntimeRecordingMessageType` enum.
+ * - Wire schemas (`ClipReadyPayloadSchema`, `ClipFailedPayloadSchema`)
+ *   plus `clipFromPayload` to convert snake_case wire payloads into
+ *   camelCase `Clip` objects.
+ * - `rewriteUrlHost` for local-mode URL rewriting.
+ *
+ * Stateful pieces (FIFO promise correlator, in-flight request
+ * lifecycle, integration with Reactor's event bus) live in the
+ * `RecordingClient` class in `core/RecordingClient.ts`.
+ *
+ * Wire contract is documented end-to-end in the *Video Recording
+ * Feature* Notion page; the runtime side ships in
+ * `reactor_runtime/recording/`.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime message types (mirrors RuntimeMessageType in Python)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Names of the runtime-scoped messages used by the recording feature.
+ * Outbound names are sent via `Reactor.sendCommand(name, …, "runtime")`;
+ * inbound names appear as `message.type` on `runtimeMessage` events.
+ */
+export const RuntimeRecordingMessageType = {
+  REQUEST_CLIP: "requestClip",
+  REQUEST_RECORDING: "requestRecording",
+  CLIP_READY: "clipReady",
+  CLIP_FAILED: "clipFailed",
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Discriminator on a {@link Clip}. `"snap"` from `requestClip`, `"recording"` from `requestRecording`. */
+export type ClipKind = "snap" | "recording";
+
+/**
+ * Resolved outcome of a {@link Reactor.requestClip} / {@link Reactor.requestRecording} call.
+ *
+ * The runtime returns immediately on every request — it does *not*
+ * block until the in-progress chunk has been finalised. The response
+ * is a *promise*: `endMarker` reflects wall-clock at request time
+ * and may point inside a chunk ffmpeg is still writing. The
+ * `/clips` manifest endpoint returns `202 Retry-After` while that
+ * chunk is in flight; the SDK polls until `200`.
+ *
+ * - `startMarker` / `endMarker` / `nowMarker` are session-relative
+ *   seconds since recorder start.
+ * - `predictedReadyAtMs` is a **Unix epoch in milliseconds** — the
+ *   runtime's estimate of when the boundary chunk will be servable
+ *   by `/clips`. Compare against `Date.now()` to drive a "ready in
+ *   Ns" indicator. The SDK uses this as the polling deadline: past
+ *   `predictedReadyAtMs + slackMs` and still 202, the SDK fails with
+ *   `CLIP_NOT_READY` on the assumption the runtime crashed.
+ * - `playlistUrl` is short-lived in production (the embedded chunk
+ *   URLs are presigned for a few minutes). Re-issuing the request
+ *   produces a fresh URL with fresh presigning.
+ */
+export interface Clip {
+  sessionId: string;
+  kind: ClipKind;
+  startMarker: number;
+  endMarker: number;
+  nowMarker: number;
+  predictedReadyAtMs: number;
+  playlistUrl: string;
+}
+
+/**
+ * Error thrown when a recording request cannot be served.
+ *
+ * `code` is a stable, machine-readable identifier; `reason` is the
+ * raw string the runtime / manifest endpoint returned (passed through
+ * verbatim from `clipFailed.reason`, the `/clips` HTTP body, or the
+ * SDK's pre-flight check).
+ */
+export class RecordingError extends Error {
+  constructor(
+    public readonly code:
+      | "RECORDER_DISABLED"
+      | "INVALID_DURATION"
+      | "REQUEST_TIMEOUT"
+      | "DISCONNECTED"
+      | "CLIP_GONE"
+      | "CLIP_NOT_READY"
+      | "PLAYLIST_FETCH_FAILED"
+      | "CHUNK_FETCH_FAILED"
+      | "INVALID_PLAYLIST"
+      | "DOWNLOAD_UNSUPPORTED"
+      | "INTERNAL_ERROR",
+    public readonly reason: string
+  ) {
+    super(`${code}: ${reason}`);
+    this.name = "RecordingError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `clipReady.data` payload as serialised by `ClipResult.to_dict()` on
+ * the runtime side. Required fields mirror the Python dataclass; extra
+ * fields are tolerated so the wire can grow without breaking old SDKs.
+ */
+export const ClipReadyPayloadSchema = z
+  .object({
+    session_id: z.string(),
+    kind: z.enum(["snap", "recording"]),
+    start_marker: z.number(),
+    end_marker: z.number(),
+    now_marker: z.number(),
+    predicted_ready_at_ms: z.number(),
+    playlist_url: z.string(),
+  })
+  .passthrough();
+
+export type ClipReadyPayload = z.infer<typeof ClipReadyPayloadSchema>;
+
+/** `clipFailed.data` payload — short reason string from the runtime. */
+export const ClipFailedPayloadSchema = z
+  .object({
+    reason: z.string().default("unknown"),
+  })
+  .passthrough();
+
+export type ClipFailedPayload = z.infer<typeof ClipFailedPayloadSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire → public type conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Optional URL rewrite hook. In local development the runtime fills
+ * `playlist_url` from its own bind address (typically `0.0.0.0:8080`),
+ * which isn't routable from the browser when port-forwarding is in
+ * play. The SDK passes the same coordinator base URL it's already
+ * talking to so the host/port get rewritten in-place. Production URLs
+ * (`https://api.reactor.inc/clips?…`) are passed through unchanged when
+ * `coordinatorBaseUrl` is `undefined`.
+ */
+export interface ParseClipOptions {
+  coordinatorBaseUrl?: string;
+}
+
+/**
+ * Convert a validated {@link ClipReadyPayload} into the public {@link Clip}.
+ * Pure: no IO, no side effects.
+ */
+export function clipFromPayload(
+  payload: ClipReadyPayload,
+  options: ParseClipOptions = {}
+): Clip {
+  const playlistUrl = options.coordinatorBaseUrl
+    ? rewriteUrlHost(payload.playlist_url, options.coordinatorBaseUrl)
+    : payload.playlist_url;
+  return {
+    sessionId: payload.session_id,
+    kind: payload.kind,
+    startMarker: payload.start_marker,
+    endMarker: payload.end_marker,
+    nowMarker: payload.now_marker,
+    predictedReadyAtMs: payload.predicted_ready_at_ms,
+    playlistUrl,
+  };
+}
+
+/**
+ * Replace the scheme + host + port of `target` with the ones from
+ * `base`, preserving path + query + fragment. Used to repoint a
+ * `playlist_url` minted with the runtime's bind address at the SDK's
+ * actual coordinator URL.
+ *
+ * Falls back to the original URL on any parse failure rather than
+ * throwing — the worst case is the request fails on fetch, which is
+ * a louder, more debuggable failure mode than a silent rewrite.
+ */
+export function rewriteUrlHost(target: string, base: string): string {
+  try {
+    const baseUrl = new URL(base);
+    const parsed = new URL(target);
+    parsed.protocol = baseUrl.protocol;
+    parsed.hostname = baseUrl.hostname;
+    parsed.port = baseUrl.port;
+    return parsed.toString();
+  } catch {
+    return target;
+  }
+}


### PR DESCRIPTION
## Why

REA-1955 defines the wire contract for `requestClip` /
`requestRecording` runtime messages and the typed `Clip` shape.
This PR lands every byte of that surface — the typed primitives,
schemas, error class, the per-Reactor stateful `RecordingClient`,
and Reactor's `requestClip` / `requestRecording` delegations —
plus tests for all of it.

Helpers built on top of `Clip.playlistUrl`
(`fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`) are out of
scope here; they land in REA-1956 stacked on this PR.

## What Changed

### Wire contract — `src/utils/recording.ts` (new)

* `Clip` interface, `ClipKind = "snap" | "recording"`.
* `RecordingError` with stable `code` enum
  (`RECORDER_DISABLED` / `INVALID_DURATION` / `REQUEST_TIMEOUT` /
  `DISCONNECTED` / `INTERNAL_ERROR` and the helper-side codes that
  REA-1956 will use, declared up-front so the union doesn't churn
  later).
* `RuntimeRecordingMessageType` constants for the four wire
  messages (`requestClip`, `requestRecording`, `clipReady`,
  `clipFailed`).
* `ClipReadyPayloadSchema` / `ClipFailedPayloadSchema` zod
  validators with `.passthrough()` so the wire can grow without
  breaking old SDKs.
* `clipFromPayload(payload, options?)` — wire-to-public conversion
  (snake_case → camelCase). Accepts `coordinatorBaseUrl` for
  local-mode URL rewriting.
* `rewriteUrlHost(target, base)` — the local-mode helper used by
  `clipFromPayload` (the runtime serves `playlist_url` from its
  `0.0.0.0` bind address; the SDK rewrites it to whatever URL it's
  already talking to).

### Stateful client — `src/core/RecordingClient.ts` (new)

* FIFO queue of in-flight `requestClip` / `requestRecording`
  promises. The runtime processes requests in receipt order on a
  single async dispatcher and `clipFailed` carries no
  discriminator, so FIFO matching is the simplest correct
  correlator.
* Subscribes to its host's `runtimeMessage` and `statusChanged`
  events on construction; rejects all pending promises with
  `RecordingError(code="DISCONNECTED")` on disconnect.
* Per-request timeout
  (`DEFAULT_CLIP_REQUEST_TIMEOUT_MS = 10_000`) so a wedged data
  channel can't hang requests forever.
* `RecordingClientHost` interface — slim adapter the client
  consumes from its host Reactor.

### Reactor integration — `src/core/Reactor.ts`

* New `recording: RecordingClient` field, constructed in
  `Reactor`'s constructor with a host adapter that wires
  `runtimeMessage` / `statusChanged` / `sendCommand` / `status` /
  the local-mode coordinator URL through.
* `requestClip(durationSeconds)` / `requestRecording()` thin
  delegations on `Reactor` so app code never has to wire its own
  host adapter for the common case.

### Public exports — `src/index.ts`

* Wire types (`Clip`, `ClipKind`, `ClipReadyPayload`,
  `ClipFailedPayload`, `ParseClipOptions`).
* Wire helpers (`RecordingError`, `RuntimeRecordingMessageType`,
  `clipFromPayload`, `rewriteUrlHost`).
* `RecordingClient` + `DEFAULT_CLIP_REQUEST_TIMEOUT_MS` for
  advanced consumers.

### Tests

* `__tests__/unit/recording.test.ts` — primitives: schema
  validation (required + passthrough + rejection), `clipFromPayload`
  with and without local-mode rewrite, `rewriteUrlHost` edge cases.
* `__tests__/unit/recording-client.test.ts` — FIFO matching with
  concurrent requests, `clipFailed` rejection, request timeout,
  disconnect-rejects-all, malformed-payload rejection, `destroy()`
  semantics.
* `__tests__/unit/reactor-recording.test.ts` — Reactor delegations
  end-to-end: outbound message shape, inbound `clipReady` resolves
  with a typed `Clip`, local-mode URL rewriting, disconnect
  during a pending request rejects.

## API

### JS

```ts
import { Reactor, RecordingError } from "@reactor-team/js-sdk";

const reactor = new Reactor({ /* ...your usual config... */ });
await reactor.connect();

try {
  // Snap the last 30 seconds.
  const clip = await reactor.requestClip(30);
  // → {
  //     sessionId, kind: "snap",
  //     startMarker, endMarker, nowMarker,
  //     predictedReadyAtMs,    // Unix epoch ms
  //     playlistUrl,           // hand to hls.js / native HLS
  //   }

  // Or full session.
  const recording = await reactor.requestRecording();

  // Hand the URL to any HLS-capable player. Manifest may 202 until
  // the in-progress chunk lands; the player retries.
  const Hls = (await import("hls.js")).default;
  if (Hls.isSupported()) {
    const hls = new Hls();
    hls.loadSource(clip.playlistUrl);
    hls.attachMedia(videoEl);
  } else {
    videoEl.src = clip.playlistUrl;  // Safari / iOS native HLS
  }
} catch (err) {
  if (err instanceof RecordingError) {
    console.warn(err.code, err.reason);
  }
}
```

### React

```tsx
import { useState } from "react";
import { useReactor, RecordingError, type Clip } from "@reactor-team/js-sdk";

export function CaptureButton() {
  const reactor = useReactor((s) => s.internal.reactor);
  const [clip, setClip] = useState<Clip | null>(null);
  const [error, setError] = useState<string | null>(null);

  const onSnap = async () => {
    setError(null);
    try {
      setClip(await reactor.requestClip(30));
    } catch (err) {
      setError(err instanceof RecordingError ? err.code : String(err));
    }
  };

  return (
    <>
      <button onClick={onSnap}>Snap last 30s</button>
      {clip && <video src={clip.playlistUrl} controls />}
      {error && <span className="error">{error}</span>}
    </>
  );
}
```

`predictedReadyAtMs` is a Unix epoch in ms — clients can detect
"runtime crashed mid-clip" by checking
`Date.now() > clip.predictedReadyAtMs + slack` before deciding
whether to keep polling or surface a failure.

Linear: REA-1955
Plan: https://www.notion.so/reactor-technologies/Video-Recording-Feature-350cacd6a39680d8a77ac39eb37561b0