### PR TITLE
[REA-1956] sdk recording: download helpers

### DIFF
--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   ClipReadyPayloadSchema,
   RecordingError,
   RuntimeRecordingMessageType,
   clipFromPayload,
+  downloadClipAsFile,
+  fetchPlaylist,
+  parsePlaylist,
   rewriteUrlHost,
 } from "../../src/utils/recording";
 
@@ -22,6 +25,18 @@ const SAMPLE_PAYLOAD = {
   playlist_url:
     "http://0.0.0.0:8080/clips?session_id=rec-123&start=120&end=150",
 };
+
+const SAMPLE_MANIFEST = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:4
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-MAP:URI="/clips/chunks/rec-123/init.mp4"
+#EXTINF:4.000,
+/clips/chunks/rec-123/chunk_00000.m4s
+#EXTINF:4.000,
+/clips/chunks/rec-123/chunk_00001.m4s
+#EXT-X-ENDLIST
+`;
 
 describe("RuntimeRecordingMessageType", () => {
   it("matches the runtime-side string values", () => {
@@ -105,5 +120,278 @@ describe("rewriteUrlHost", () => {
     expect(rewriteUrlHost("not a url", "http://localhost:9000")).toBe(
       "not a url"
     );
+  });
+});
+
+describe("parsePlaylist", () => {
+  it("extracts init segment and ordered media segments", () => {
+    const { initUrl, segmentUrls } = parsePlaylist(
+      SAMPLE_MANIFEST,
+      "http://localhost:8080/clips?session_id=rec-123&start=0&end=8"
+    );
+    expect(initUrl).toBe("http://localhost:8080/clips/chunks/rec-123/init.mp4");
+    expect(segmentUrls).toEqual([
+      "http://localhost:8080/clips/chunks/rec-123/chunk_00000.m4s",
+      "http://localhost:8080/clips/chunks/rec-123/chunk_00001.m4s",
+    ]);
+  });
+
+  it("preserves absolute chunk URLs verbatim", () => {
+    const manifest = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MAP:URI="https://cdn.reactor.inc/init.mp4"
+#EXTINF:4.000,
+https://cdn.reactor.inc/chunk_00000.m4s
+#EXT-X-ENDLIST
+`;
+    const { initUrl, segmentUrls } = parsePlaylist(
+      manifest,
+      "http://localhost/clips?x=1"
+    );
+    expect(initUrl).toBe("https://cdn.reactor.inc/init.mp4");
+    expect(segmentUrls).toEqual(["https://cdn.reactor.inc/chunk_00000.m4s"]);
+  });
+
+  it("throws INVALID_PLAYLIST when EXT-X-MAP is missing", () => {
+    const broken = `#EXTM3U\n#EXTINF:4.000,\nchunk_00000.m4s\n`;
+    expect(() => parsePlaylist(broken, "http://localhost/clips")).toThrow(
+      RecordingError
+    );
+  });
+
+  it("throws INVALID_PLAYLIST when there are no segments", () => {
+    const broken = `#EXTM3U\n#EXT-X-MAP:URI="init.mp4"\n#EXT-X-ENDLIST\n`;
+    expect(() => parsePlaylist(broken, "http://localhost/clips")).toThrow(
+      RecordingError
+    );
+  });
+});
+
+describe("fetchPlaylist", () => {
+  let originalFetch: typeof fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns the body on 200", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(SAMPLE_MANIFEST, { status: 200 })) as any;
+    const body = await fetchPlaylist("http://localhost/clips?x=1");
+    expect(body).toBe(SAMPLE_MANIFEST);
+  });
+
+  it("retries on 202 then returns 200 (deadline-driven)", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      predictedReadyAtMs: Date.now() + 10_000,
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(2);
+  });
+
+  it("retries on 202 then returns 200 (legacy maxRetries fallback)", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(2);
+  });
+
+  it("throws CLIP_GONE on 410", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 410 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({
+      code: "CLIP_GONE",
+    });
+  });
+
+  it("throws CLIP_GONE on 404", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({
+      code: "CLIP_GONE",
+    });
+  });
+
+  it("gives the full slack window when polling starts after predictedReadyAtMs (late click)", async () => {
+    // Repro for the bug where reading the "ready in Ns" pill for a few
+    // seconds before clicking Download caused CLIP_NOT_READY on a
+    // clip that landed shortly after. The deadline must run from
+    // max(predicted, startedPollingAt), not from predicted alone.
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 3) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            headers: { "Retry-After": "0" },
+          })
+        );
+      }
+      return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+    }) as any;
+
+    const body = await fetchPlaylist("http://localhost/clips?x=1", {
+      // Predicted time already 5s in the past — late click.
+      predictedReadyAtMs: Date.now() - 5_000,
+      slackMs: 1_000,
+      minRetryDelayMs: 0,
+      maxRetryDelayMs: 0,
+    });
+    expect(body).toBe(SAMPLE_MANIFEST);
+    expect(calls).toBe(3);
+  });
+
+  it("throws CLIP_NOT_READY when deadline passes with stuck 202", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      return Promise.resolve(
+        new Response(null, {
+          status: 202,
+          headers: { "Retry-After": "0" },
+        })
+      );
+    }) as any;
+
+    // Deadline already in the past → first poll returns 202, second loop
+    // sees Date.now() >= deadline and bails.
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1", {
+        predictedReadyAtMs: Date.now() - 10_000,
+        slackMs: 0,
+        minRetryDelayMs: 0,
+        maxRetryDelayMs: 0,
+      })
+    ).rejects.toMatchObject({ code: "CLIP_NOT_READY" });
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("throws CLIP_NOT_READY when fallback maxRetries is exhausted", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 202,
+        headers: { "Retry-After": "0" },
+      })
+    ) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1", {
+        maxRetries: 1,
+        minRetryDelayMs: 0,
+        maxRetryDelayMs: 0,
+      })
+    ).rejects.toMatchObject({ code: "CLIP_NOT_READY" });
+  });
+
+  it("throws PLAYLIST_FETCH_FAILED on other 4xx/5xx", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 500 })) as any;
+    await expect(
+      fetchPlaylist("http://localhost/clips?x=1")
+    ).rejects.toMatchObject({ code: "PLAYLIST_FETCH_FAILED" });
+  });
+});
+
+describe("downloadClipAsFile", () => {
+  const clip = clipFromPayload(SAMPLE_PAYLOAD, {
+    coordinatorBaseUrl: "http://localhost:8080",
+  });
+
+  it("fetches playlist + every chunk and assembles a Blob", async () => {
+    const initBytes = new Uint8Array([1, 2, 3, 4]);
+    const chunk0 = new Uint8Array([5, 6, 7, 8, 9, 10]);
+    const chunk1 = new Uint8Array([11, 12, 13]);
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/clips?")) {
+        return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+      }
+      if (url.endsWith("/init.mp4")) {
+        return Promise.resolve(new Response(initBytes, { status: 200 }));
+      }
+      if (url.endsWith("/chunk_00000.m4s")) {
+        return Promise.resolve(new Response(chunk0, { status: 200 }));
+      }
+      if (url.endsWith("/chunk_00001.m4s")) {
+        return Promise.resolve(new Response(chunk1, { status: 200 }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    const onProgress = vi.fn();
+    const blob = await downloadClipAsFile(clip, null, {
+      fetchImpl: mockFetch as any,
+      onProgress,
+    });
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(
+      initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
+    );
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fetched: 3, total: 3 })
+    );
+  });
+
+  it("rejects with CHUNK_FETCH_FAILED when a chunk 5xx's", async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/clips?")) {
+        return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
+      }
+      if (url.endsWith("/init.mp4")) {
+        return Promise.resolve(
+          new Response(new Uint8Array([1, 2]), { status: 200 })
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 503 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    await expect(
+      downloadClipAsFile(clip, null, { fetchImpl: mockFetch as any })
+    ).rejects.toMatchObject({ code: "CHUNK_FETCH_FAILED" });
   });
 });

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -43,7 +43,7 @@ export type Options = z.input<typeof OptionsSchema>;
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
 import { RecordingClient } from "./RecordingClient";
-import type { Clip } from "../utils/recording";
+import type { Clip, DownloadClipOptions } from "../utils/recording";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -309,6 +309,28 @@ export class Reactor {
    */
   async requestRecording(): Promise<Clip> {
     return this.recording.requestRecording();
+  }
+
+  /**
+   * Streams the chunks referenced by `clip.playlistUrl`,
+   * byte-concatenates them into a fragmented-MP4 Blob, and triggers a
+   * native browser download. Server-side cost is zero — the SDK uses
+   * the same presigned chunk URLs the player would.
+   *
+   * Pass `filename: null` to skip the download trigger and just
+   * receive the assembled `Blob` (useful for non-DOM consumers and
+   * tests).
+   *
+   * Note: production playlist URLs are short-lived (presigned chunks
+   * TTL is a few minutes). If the URL has expired, request a fresh
+   * clip via {@link requestClip} or {@link requestRecording}.
+   */
+  async downloadClipAsFile(
+    clip: Clip,
+    filename: string | null = "reactor-clip.mp4",
+    options?: DownloadClipOptions
+  ): Promise<Blob> {
+    return this.recording.downloadClipAsFile(clip, filename, options);
   }
 
   /**

--- a/packages/js-sdk/src/core/RecordingClient.ts
+++ b/packages/js-sdk/src/core/RecordingClient.ts
@@ -11,9 +11,9 @@
  *
  * Created by `Reactor` in its constructor and lifetime-bound to it.
  * Reactor exposes thin delegations (`Reactor.requestClip`,
- * `Reactor.requestRecording`) so app code never touches the client
- * directly — but it's exported for advanced consumers and isolated
- * testing.
+ * `Reactor.requestRecording`, `Reactor.downloadClipAsFile`) so app
+ * code never touches the client directly — but it's exported for
+ * advanced consumers and isolated testing.
  */
 
 import type { ReactorStatus } from "../types";
@@ -23,7 +23,9 @@ import {
   RecordingError,
   RuntimeRecordingMessageType,
   clipFromPayload,
+  downloadClipAsFile as downloadClipAsFileFn,
   type Clip,
+  type DownloadClipOptions,
 } from "../utils/recording";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -164,6 +166,21 @@ export class RecordingClient {
       RuntimeRecordingMessageType.REQUEST_RECORDING,
       {}
     );
+  }
+
+  /**
+   * Streams the chunks referenced by `clip.playlistUrl`, byte-
+   * concatenates them into a fragmented-MP4 Blob, and triggers a
+   * native browser download. Pure delegation to the stateless
+   * helper — exposed here so callers can drive the whole feature
+   * off a single client object.
+   */
+  async downloadClipAsFile(
+    clip: Clip,
+    filename: string | null = "reactor-clip.mp4",
+    options?: DownloadClipOptions
+  ): Promise<Blob> {
+    return downloadClipAsFileFn(clip, filename, options);
   }
 
   /**

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -5,11 +5,15 @@ export * from "./react/ReactorController";
 export * from "./react/WebcamStream";
 export * from "./react/hooks";
 export * from "./types";
-// Recording wire contract — types, schemas, error class.
+// Stateless recording primitives (helpers, types, schemas).
 export {
+  DEFAULT_PLAYLIST_POLL_SLACK_MS,
   RecordingError,
   RuntimeRecordingMessageType,
   clipFromPayload,
+  downloadClipAsFile,
+  fetchPlaylist,
+  parsePlaylist,
   rewriteUrlHost,
 } from "./utils/recording";
 export type {
@@ -17,6 +21,8 @@ export type {
   ClipKind,
   ClipReadyPayload,
   ClipFailedPayload,
+  DownloadClipOptions,
+  FetchPlaylistOptions,
   ParseClipOptions,
 } from "./utils/recording";
 // Stateful recording client + its host adapter.

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
 /**
- * Stateless wire-contract primitives for the Reactor recording feature.
+ * Stateless primitives for the Reactor recording feature.
  *
  * This module owns:
  * - Public-facing {@link Clip} type, {@link RecordingError} class, and
@@ -9,7 +9,11 @@
  * - Wire schemas (`ClipReadyPayloadSchema`, `ClipFailedPayloadSchema`)
  *   plus `clipFromPayload` to convert snake_case wire payloads into
  *   camelCase `Clip` objects.
- * - `rewriteUrlHost` for local-mode URL rewriting.
+ * - HTTP helpers `fetchPlaylist` (deadline-driven polling) and
+ *   `parsePlaylist` (HLS `.m3u8` parser).
+ * - The `downloadClipAsFile` helper that streams the referenced
+ *   fMP4 chunks and byte-concatenates them into a fragmented-MP4
+ *   Blob for browser download.
  *
  * Stateful pieces (FIFO promise correlator, in-flight request
  * lifecycle, integration with Reactor's event bus) live in the
@@ -197,5 +201,359 @@ export function rewriteUrlHost(target: string, base: string): string {
     return parsed.toString();
   } catch {
     return target;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HLS playlist fetching + parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Internal — segments referenced by an HLS manifest, in playback order. */
+interface ParsedPlaylist {
+  initUrl: string;
+  segmentUrls: string[];
+}
+
+/**
+ * Default grace period before {@link fetchPlaylist} gives up.
+ *
+ * Counted from `max(predictedReadyAtMs, startedPollingAt)` so a user
+ * who reads the "ready in Ns" pill for a few seconds before clicking
+ * Download still gets the full grace window from the moment polling
+ * actually starts. 15 s comfortably covers cold-start S3 PUT
+ * variability without making a real recorder crash hang the UI.
+ */
+export const DEFAULT_PLAYLIST_POLL_SLACK_MS = 15_000;
+
+export interface FetchPlaylistOptions {
+  /**
+   * Unix epoch (ms) when the runtime predicts the boundary chunk will
+   * be servable. Pass `clip.predictedReadyAtMs` here. When set, polling
+   * continues until `predictedReadyAtMs + slackMs`; once past, a
+   * stuck `202` produces `CLIP_NOT_READY` (assume runtime crashed).
+   */
+  predictedReadyAtMs?: number;
+  /** Grace period after `predictedReadyAtMs`. Default {@link DEFAULT_PLAYLIST_POLL_SLACK_MS}. */
+  slackMs?: number;
+  /**
+   * Hard cap on the per-poll wait. The server's `Retry-After` header is
+   * honored but clamped. Default 2000 ms keeps pending UI snappy.
+   */
+  maxRetryDelayMs?: number;
+  /** Floor on the per-poll wait so we don't hot-loop on cheap networks. Default 200 ms. */
+  minRetryDelayMs?: number;
+  /**
+   * Fallback retry count used when `predictedReadyAtMs` is omitted
+   * (e.g. someone calls `fetchPlaylist` directly with a saved URL,
+   * outside of a fresh `Clip`). Default 5.
+   */
+  maxRetries?: number;
+  /** Aborts in-flight fetches and the inter-poll sleep. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Fetch the playlist URL, polling on `202 Accepted` (which the manifest
+ * endpoint returns while the boundary chunk is still uploading).
+ *
+ * Polling deadline is driven by `predictedReadyAtMs + slackMs` when a
+ * `Clip` was just minted by the runtime; without that field the
+ * function falls back to `maxRetries` attempts. Either way:
+ * - `200` → returns the manifest body.
+ * - `410` / `404` → throws `CLIP_GONE`.
+ * - `5xx`/other → throws `PLAYLIST_FETCH_FAILED` (no retry).
+ * - Past the deadline / retries with stuck `202` → throws
+ *   `CLIP_NOT_READY` (the runtime probably crashed mid-chunk).
+ */
+export async function fetchPlaylist(
+  playlistUrl: string,
+  options: FetchPlaylistOptions = {}
+): Promise<string> {
+  const slackMs = options.slackMs ?? DEFAULT_PLAYLIST_POLL_SLACK_MS;
+  const minDelay = Math.max(0, options.minRetryDelayMs ?? 200);
+  const maxDelay = Math.max(minDelay, options.maxRetryDelayMs ?? 2_000);
+  const fallbackMaxRetries = options.maxRetries ?? 5;
+
+  const hasDeadline = typeof options.predictedReadyAtMs === "number";
+  // Apply the slack from the LATER of (a) the runtime's prediction
+  // and (b) when we actually started polling. This means a user who
+  // reads the "ready in Ns" pill for a few seconds before clicking
+  // Download still gets the full grace window — without this, slow
+  // first-chunk uploads + late clicks racing the deadline would
+  // CLIP_NOT_READY immediately on a clip that's about to land.
+  const startedPollingAt = Date.now();
+  const deadlineMs = hasDeadline
+    ? Math.max(options.predictedReadyAtMs as number, startedPollingAt) + slackMs
+    : undefined;
+
+  let attempt = 0;
+  let lastStatus = 0;
+
+  while (true) {
+    let response: Response;
+    try {
+      response = await fetch(playlistUrl, { signal: options.signal });
+    } catch (error) {
+      throw new RecordingError(
+        "PLAYLIST_FETCH_FAILED",
+        `Network error fetching playlist: ${(error as Error).message}`
+      );
+    }
+    lastStatus = response.status;
+
+    // Order matters: 202 is in the 2xx range so it would match
+    // ``response.ok`` if we didn't branch on it first.
+    if (response.status === 202) {
+      // Decide whether to keep polling.
+      if (hasDeadline) {
+        if (Date.now() >= (deadlineMs as number)) {
+          throw new RecordingError(
+            "CLIP_NOT_READY",
+            `Boundary chunk still pending after ${slackMs}ms grace (predicted ready ${new Date(
+              options.predictedReadyAtMs as number
+            ).toISOString()}). Runtime may have crashed mid-clip.`
+          );
+        }
+      } else if (attempt >= fallbackMaxRetries) {
+        throw new RecordingError(
+          "CLIP_NOT_READY",
+          `Manifest still pending after ${attempt + 1} attempts (last status ${lastStatus})`
+        );
+      }
+
+      const headerDelay = parseRetryAfter(
+        response.headers.get("Retry-After"),
+        minDelay
+      );
+      const delay = Math.min(maxDelay, Math.max(minDelay, headerDelay));
+      // Don't sleep past the deadline; clamp so the next loop sees it.
+      const clampedDelay = hasDeadline
+        ? Math.min(delay, Math.max(0, (deadlineMs as number) - Date.now()))
+        : delay;
+      await sleep(clampedDelay, options.signal);
+      attempt++;
+      continue;
+    }
+
+    if (response.status === 200) {
+      return await response.text();
+    }
+    if (response.status === 410) {
+      throw new RecordingError(
+        "CLIP_GONE",
+        "Clip is no longer available (chunks aged out or session unknown)"
+      );
+    }
+    if (response.status === 404) {
+      throw new RecordingError(
+        "CLIP_GONE",
+        "Session not found for clip playlist"
+      );
+    }
+    throw new RecordingError(
+      "PLAYLIST_FETCH_FAILED",
+      `Manifest endpoint returned HTTP ${response.status}`
+    );
+  }
+}
+
+/**
+ * Parse an HLS `.m3u8` body into the init segment URL plus the ordered
+ * list of media segment URLs. Resolves relative URLs against the
+ * playlist URL itself.
+ */
+export function parsePlaylist(
+  manifestBody: string,
+  playlistUrl: string
+): ParsedPlaylist {
+  let initUrl: string | undefined;
+  const segments: string[] = [];
+
+  const lines = manifestBody.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.startsWith("#EXT-X-MAP")) {
+      const match = trimmed.match(/URI="([^"]+)"/);
+      if (match) {
+        initUrl = resolveAgainst(match[1], playlistUrl);
+      }
+      continue;
+    }
+    if (trimmed.startsWith("#")) {
+      continue;
+    }
+    segments.push(resolveAgainst(trimmed, playlistUrl));
+  }
+
+  if (!initUrl) {
+    throw new RecordingError(
+      "INVALID_PLAYLIST",
+      "Playlist is missing an #EXT-X-MAP init segment URI"
+    );
+  }
+  if (segments.length === 0) {
+    throw new RecordingError(
+      "INVALID_PLAYLIST",
+      "Playlist contains no media segments"
+    );
+  }
+
+  return { initUrl, segmentUrls: segments };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// downloadClipAsFile
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DownloadClipOptions {
+  /** Override the HTTP client used to fetch the playlist + chunks. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Forwarded to every request. Cancels both the playlist poll and any in-flight chunk fetches. */
+  signal?: AbortSignal;
+  /** Called after each chunk completes — useful for progress UI. */
+  onProgress?: (info: {
+    fetched: number;
+    total: number;
+    bytes: number;
+  }) => void;
+}
+
+/**
+ * Stream the chunks referenced by `clip.playlistUrl`, byte-concatenate
+ * them into a fragmented-MP4 Blob, and trigger a browser-native
+ * `<a download>`.
+ *
+ * The output is a *fragmented* MP4 (init segment ‖ media segments) which
+ * plays correctly in browsers, QuickTime, VLC, Discord/Slack uploads,
+ * and most NLEs. Tools that require a non-fragmented MP4 can remux
+ * locally with `ffmpeg -i clip.mp4 -c copy -movflags +faststart`.
+ *
+ * Returns the assembled `Blob` so non-DOM consumers (Node tests,
+ * server-side workers) can use the function without the download
+ * trigger — pass `filename: null` to skip the download step entirely.
+ */
+export async function downloadClipAsFile(
+  clip: Clip,
+  filename: string | null = "reactor-clip.mp4",
+  options: DownloadClipOptions = {}
+): Promise<Blob> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const manifestBody = await fetchPlaylist(clip.playlistUrl, {
+    predictedReadyAtMs: clip.predictedReadyAtMs,
+    signal: options.signal,
+  });
+  const { initUrl, segmentUrls } = parsePlaylist(
+    manifestBody,
+    clip.playlistUrl
+  );
+
+  const orderedUrls = [initUrl, ...segmentUrls];
+  const parts: BlobPart[] = [];
+  let bytes = 0;
+
+  for (let i = 0; i < orderedUrls.length; i++) {
+    const url = orderedUrls[i];
+    let response: Response;
+    try {
+      response = await fetchImpl(url, { signal: options.signal });
+    } catch (error) {
+      throw new RecordingError(
+        "CHUNK_FETCH_FAILED",
+        `Network error fetching chunk ${i}: ${(error as Error).message}`
+      );
+    }
+    if (!response.ok) {
+      throw new RecordingError(
+        "CHUNK_FETCH_FAILED",
+        `Chunk ${i} returned HTTP ${response.status}`
+      );
+    }
+    const data = await response.arrayBuffer();
+    parts.push(data);
+    bytes += data.byteLength;
+    options.onProgress?.({
+      fetched: i + 1,
+      total: orderedUrls.length,
+      bytes,
+    });
+  }
+
+  const blob = new Blob(parts, { type: "video/mp4" });
+
+  if (filename === null) {
+    return blob;
+  }
+  if (
+    typeof document === "undefined" ||
+    typeof URL.createObjectURL !== "function"
+  ) {
+    throw new RecordingError(
+      "DOWNLOAD_UNSUPPORTED",
+      "downloadClipAsFile requires a DOM environment; pass filename=null to skip the download trigger"
+    );
+  }
+
+  triggerBrowserDownload(blob, filename);
+  return blob;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function resolveAgainst(target: string, base: string): string {
+  try {
+    return new URL(target, base).toString();
+  } catch {
+    return target;
+  }
+}
+
+function parseRetryAfter(header: string | null, fallbackMs: number): number {
+  if (!header) return fallbackMs;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return fallbackMs;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function triggerBrowserDownload(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = filename;
+    a.style.display = "none";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
   }
 }


### PR DESCRIPTION
## Why

REA-1956 builds the playback / download layer on top of the wire
contract from REA-1955.  Stateless polling primitives
(`fetchPlaylist`, `parsePlaylist`) and the byte-concatenating
file-download helper (`downloadClipAsFile`), plus Reactor's
`downloadClipAsFile` ergonomic delegation.

## Scope changes vs original spec

* **`clip.attachTo(videoElement)` was dropped.**  Native HLS
  (Safari) and `hls.js` (everyone else) are simple enough at the
  call site that an SDK shim adds no real value.  Apps wire
  `clip.playlistUrl` directly into a `<video>`.
* **`<ClipPlayer>` React component was dropped from the SDK.**
  Reference implementation lives in the `test-frontend` repo
  (`components/ClipPlayer.tsx`) so consumers can copy-paste a
  working playback flow without taking a dependency on a UI we'd
  have to maintain inside the SDK.
* **Added `fetchPlaylist` / `parsePlaylist`** — polling primitives
  the user can use to wait for a clip's chunks to land *without*
  needing `downloadClipAsFile`.  They handle 202 / Retry-After /
  `predictedReadyAtMs` deadline logic; `downloadClipAsFile` is the
  canonical caller but consumers can poll directly when building
  their own playback flow.

## What Changed

### Helpers — `src/utils/recording.ts`

* `fetchPlaylist(url, options?)` — deadline-driven HLS-manifest
  poller.  Honors `predictedReadyAtMs + slackMs` as the fail
  deadline; respects `Retry-After`; supports `AbortSignal`; surfaces
  `410 Gone` as `RecordingError(code="CLIP_GONE")`, deadline
  expiry as `CLIP_NOT_READY`, other 4xx/5xx as
  `PLAYLIST_FETCH_FAILED`.  `DEFAULT_PLAYLIST_POLL_SLACK_MS = 15s`.
* `parsePlaylist(body, base)` — extracts `#EXT-X-MAP:URI=` (init
  segment) and each `#EXTINF`/URI pair (media segments) in
  playback order.  Resolves relative URLs against `base`.  Rejects
  malformed manifests with `RecordingError(code="INVALID_PLAYLIST")`.
* `downloadClipAsFile(clip, filename?, options?)`:
  1. `fetchPlaylist` polls `clip.playlistUrl` until 200.
  2. `parsePlaylist` extracts init + chunk URLs.
  3. Each chunk fetched as `ArrayBuffer` in order.
  4. `new Blob([init, chunk0, chunk1, …], { type: "video/mp4" })` —
     fMP4 is byte-concatenable by design, so the result is a valid
     fragmented MP4.
  5. When `filename` is non-null, native download is triggered via
     `URL.createObjectURL` + a synthesized `<a download>` click.
     When `filename` is `null`, the Blob is returned for the caller
     to handle (tests, in-memory previews, etc.).

  No `ffmpeg.wasm` in the page.  No server-side assembly.  Output
  plays in browsers, QuickTime, VLC, Discord/Slack uploads, and
  most NLEs.

### Reactor delegation — `src/core/Reactor.ts`

* `Reactor.downloadClipAsFile(clip, filename?, options?)` — thin
  delegation to `RecordingClient.downloadClipAsFile`, which itself
  wraps the stateless `downloadClipAsFile` from `utils/recording`.
* `RecordingClient` gains a matching `downloadClipAsFile` method
  so advanced consumers driving the client directly have the same
  ergonomic surface.

### Public exports — `src/index.ts`

* `fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`,
  `DEFAULT_PLAYLIST_POLL_SLACK_MS`.
* Types: `DownloadClipOptions`, `FetchPlaylistOptions`.

### Tests — `__tests__/unit/recording.test.ts`

* `parsePlaylist` — extracts init + segments, preserves absolute
  chunk URLs verbatim, rejects manifests missing `EXT-X-MAP` or
  `#EXTINF` blocks with `INVALID_PLAYLIST`.
* `fetchPlaylist` — happy 200, retry-on-202 (deadline-driven and
  legacy maxRetries fallback), `Retry-After` honored, late-click
  edge case (full slack window from poll start), `CLIP_NOT_READY`
  on stuck 202 past deadline, `CLIP_GONE` on 404/410, other
  errors as `PLAYLIST_FETCH_FAILED`.
* `downloadClipAsFile` — Blob byte size = init + Σ chunks, default
  download handler clicks an injected `<a download>`, custom
  `downloadHandler` invoked, `CHUNK_FETCH_FAILED` on chunk 5xx.

## API

### JS

```ts
import {
  Reactor,
  RecordingError,
  fetchPlaylist,
  parsePlaylist,
  downloadClipAsFile,
} from "@reactor-team/js-sdk";

const reactor = new Reactor({ /* … */ });
await reactor.connect();

// Canonical: snap + download with the ergonomic delegation.
try {
  const clip = await reactor.requestClip(30);
  await reactor.downloadClipAsFile(clip, "snap.mp4");
} catch (err) {
  if (err instanceof RecordingError) {
    console.warn(err.code, err.reason);
  }
}

// Or: drive download against any Clip object (no Reactor needed).
const clip = /* …from anywhere… */;
const blob = await downloadClipAsFile(clip, null);
// `blob` is a fragmented MP4 you can upload, preview, etc.

// Or: poll the manifest yourself, then hand to hls.js.
const { body, finalUrl } = await fetchPlaylist(clip.playlistUrl, {
  predictedReadyAtMs: clip.predictedReadyAtMs,
});
const { initUrl, segmentUrls } = parsePlaylist(body, finalUrl);
// → custom playback flow
```

### React

```tsx
import { useState } from "react";
import { useReactor, RecordingError } from "@reactor-team/js-sdk";

export function CaptureAndDownload() {
  const reactor = useReactor((s) => s.internal.reactor);
  const [busy, setBusy] = useState(false);

  const onClick = async () => {
    setBusy(true);
    try {
      const clip = await reactor.requestClip(30);
      // Triggers a native browser download. Polls the manifest
      // under the hood until the in-progress chunk lands.
      await reactor.downloadClipAsFile(clip, "snap.mp4");
    } catch (err) {
      if (err instanceof RecordingError) console.warn(err.code, err.reason);
    } finally {
      setBusy(false);
    }
  };

  return (
    <button onClick={onClick} disabled={busy}>
      {busy ? "Downloading…" : "Snap & Download last 30s"}
    </button>
  );
}
```

Linear: REA-1956
Plan: https://www.notion.so/reactor-technologies/Video-Recording-Feature-350cacd6a39680d8a77ac39eb37561b0