### PR TITLE
[REA-1955] sdk recording: wire contract + RecordingClient

### DIFF
--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -42,6 +42,8 @@ export type Options = z.input<typeof OptionsSchema>;
 
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
+import { RecordingClient } from "./RecordingClient";
+import type { Clip } from "../utils/recording";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -63,6 +65,9 @@ export class Reactor {
   private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
 
+  /** Per-Reactor recording client. See {@link RecordingClient}. */
+  readonly recording: RecordingClient;
+
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
     this.coordinatorUrl = validatedOptions.apiUrl;
@@ -74,6 +79,21 @@ export class Reactor {
     if (validatedOptions.modelTracks) {
       this.presetTracks = validatedOptions.modelTracks;
     }
+
+    this.recording = new RecordingClient({
+      onRuntimeMessage: (handler) => {
+        this.on("runtimeMessage", handler);
+        return () => this.off("runtimeMessage", handler);
+      },
+      onStatusChanged: (handler) => {
+        this.on("statusChanged", handler);
+        return () => this.off("statusChanged", handler);
+      },
+      sendRuntimeCommand: (command, data) =>
+        this.sendCommand(command, data, "runtime"),
+      getStatus: () => this.status,
+      getCoordinatorBaseUrl: () => this.coordinatorUrl,
+    });
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
@@ -232,6 +252,28 @@ export class Reactor {
     });
 
     return new FileRef(slot.presigned_id, name, mimeType, size);
+  }
+
+  /**
+   * Request a clip covering the last `durationSeconds` of the live
+   * session. Capped server-side at `recording.clip_max_seconds`
+   * (default 5 minutes). Resolves with a {@link Clip} whose
+   * `playlistUrl` can be handed to any HLS-capable player.
+   *
+   * @throws {RecordingError} on invalid input, transport failure,
+   *   timeout, runtime-side `clipFailed`, or disconnect mid-request.
+   */
+  async requestClip(durationSeconds: number): Promise<Clip> {
+    return this.recording.requestClip(durationSeconds);
+  }
+
+  /**
+   * Request a clip covering the entire session up to "now". Same
+   * mechanics as {@link requestClip} with `start = 0`; only the
+   * resolved {@link Clip.kind} discriminator differs.
+   */
+  async requestRecording(): Promise<Clip> {
+    return this.recording.requestRecording();
   }
 
   /**
@@ -462,6 +504,8 @@ export class Reactor {
       if (scope === "application") {
         this.emit("message", message);
       } else if (scope === "runtime") {
+        // Just emit — `RecordingClient` and any app-level
+        // `runtimeMessage` listeners are subscribers via `on()`.
         this.emit("runtimeMessage", message);
       }
     });

--- a/packages/js-sdk/src/core/RecordingClient.ts
+++ b/packages/js-sdk/src/core/RecordingClient.ts
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Per-Reactor recording client.  Owns the FIFO promise correlator for
+ * inbound `clipReady` / `clipFailed` runtime messages and the
+ * lifecycle hooks (subscribe on construct, reject pending requests
+ * on disconnect).  Reactor exposes thin delegations for the common
+ * case; this class is exported for advanced consumers and isolated
+ * testing.
+ */
+
+import type { ReactorStatus } from "../types";
+import {
+  ClipFailedPayloadSchema,
+  ClipReadyPayloadSchema,
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  type Clip,
+} from "../utils/recording";
+
+/** Default per-request timeout for `clipReady` / `clipFailed`. */
+export const DEFAULT_CLIP_REQUEST_TIMEOUT_MS = 10_000;
+
+/** Slim adapter the {@link RecordingClient} requires from its host. */
+export interface RecordingClientHost {
+  /**
+   * Subscribe to runtime-scoped messages on the data channel.
+   * Returns an unsubscribe function. Mirrors the
+   * `reactor.on("runtimeMessage", …)` pattern.
+   */
+  onRuntimeMessage: (handler: (message: unknown) => void) => () => void;
+  /**
+   * Subscribe to status changes (so the client can reject pending
+   * requests on disconnect). Returns an unsubscribe function.
+   */
+  onStatusChanged: (handler: (status: ReactorStatus) => void) => () => void;
+  /**
+   * Send a runtime-scoped command on the data channel. The
+   * `RecordingClient` uses this to fire `requestClip` /
+   * `requestRecording`.
+   */
+  sendRuntimeCommand: (
+    command: string,
+    data: Record<string, unknown>
+  ) => Promise<void>;
+  /** Current connection status — guards `requestClip` before it goes on the wire. */
+  getStatus: () => ReactorStatus;
+  /**
+   * Coordinator base URL used to resolve `clip.playlistUrl` against.
+   *
+   * The runtime now emits a path-only ``playlist_url`` (e.g.
+   * ``/clips?session_id=…``) so the SDK is the absolute-origin owner
+   * for both local-dev (HttpRuntime on the SDK's ``apiUrl``) and
+   * production (Coordinator on the SDK's ``apiUrl``).  We always
+   * resolve against the ``Reactor``'s coordinator URL — there is no
+   * remote-vs-local divergence on the read path.
+   *
+   * For backwards-compat with older runtimes that emitted absolute
+   * URLs (scheme + host bound to the runtime's own listener,
+   * e.g. ``http://0.0.0.0:8080/clips?…``), the same URL is also used
+   * to rewrite the host onto the coordinator — see
+   * ``rewriteUrlHost`` in ``utils/recording.ts``.
+   */
+  getCoordinatorBaseUrl: () => string | undefined;
+}
+
+/** Internal — one entry per in-flight `requestClip` / `requestRecording`. */
+type PendingClipRequest = {
+  resolve: (clip: Clip) => void;
+  reject: (error: RecordingError) => void;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+};
+
+export class RecordingClient {
+  // FIFO queue: the runtime processes requests in receipt order and
+  // `clipFailed` carries no discriminator, so FIFO matching is the
+  // simplest correct correlator.
+  private pendingClipRequests: PendingClipRequest[] = [];
+
+  /** Timeout applied per request; configurable for tests. */
+  private readonly requestTimeoutMs: number;
+
+  /** Cleanup handles for the host event subscriptions. */
+  private readonly unsubscribers: Array<() => void> = [];
+
+  constructor(
+    private readonly host: RecordingClientHost,
+    options: { requestTimeoutMs?: number } = {}
+  ) {
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_CLIP_REQUEST_TIMEOUT_MS;
+
+    this.unsubscribers.push(
+      this.host.onRuntimeMessage((message) => this.onRuntimeMessage(message))
+    );
+    this.unsubscribers.push(
+      this.host.onStatusChanged((status) => this.onStatusChanged(status))
+    );
+  }
+
+  /**
+   * Request a clip covering the last `durationSeconds` of the live
+   * session.  See {@link Reactor.requestClip}.
+   */
+  async requestClip(durationSeconds: number): Promise<Clip> {
+    if (
+      typeof durationSeconds !== "number" ||
+      !Number.isFinite(durationSeconds) ||
+      durationSeconds <= 0
+    ) {
+      throw new RecordingError(
+        "INVALID_DURATION",
+        "durationSeconds must be a positive finite number"
+      );
+    }
+    const status = this.host.getStatus();
+    if (status !== "ready") {
+      throw new RecordingError(
+        "DISCONNECTED",
+        `Cannot request clip while status is "${status}"`
+      );
+    }
+    return this.dispatchClipRequest(RuntimeRecordingMessageType.REQUEST_CLIP, {
+      duration_seconds: durationSeconds,
+    });
+  }
+
+  /**
+   * Request a clip covering the entire session up to "now".  See
+   * {@link Reactor.requestRecording}.
+   */
+  async requestRecording(): Promise<Clip> {
+    const status = this.host.getStatus();
+    if (status !== "ready") {
+      throw new RecordingError(
+        "DISCONNECTED",
+        `Cannot request recording while status is "${status}"`
+      );
+    }
+    return this.dispatchClipRequest(
+      RuntimeRecordingMessageType.REQUEST_RECORDING,
+      {}
+    );
+  }
+
+  /**
+   * Drop every pending request and unsubscribe from host events.
+   * Safe to call multiple times; further `requestClip` /
+   * `requestRecording` calls after `destroy()` will hang waiting for
+   * a response that will never arrive — host should not call into
+   * the client after destroy.
+   */
+  destroy(): void {
+    this.rejectPending("RecordingClient destroyed");
+    while (this.unsubscribers.length > 0) {
+      const off = this.unsubscribers.pop();
+      try {
+        off?.();
+      } catch {
+        // Best-effort cleanup — ignore handler removal errors.
+      }
+    }
+  }
+
+  /**
+   * Register a pending FIFO entry, send the runtime message via
+   * the host, and resolve when the next `clipReady` / `clipFailed`
+   * arrives.
+   */
+  private dispatchClipRequest(
+    messageType:
+      | typeof RuntimeRecordingMessageType.REQUEST_CLIP
+      | typeof RuntimeRecordingMessageType.REQUEST_RECORDING,
+    payload: Record<string, unknown>
+  ): Promise<Clip> {
+    return new Promise<Clip>((resolve, reject) => {
+      const pending: PendingClipRequest = { resolve, reject };
+      pending.timeoutHandle = setTimeout(() => {
+        const idx = this.pendingClipRequests.indexOf(pending);
+        if (idx === -1) return;
+        this.pendingClipRequests.splice(idx, 1);
+        reject(
+          new RecordingError(
+            "REQUEST_TIMEOUT",
+            `No clipReady/clipFailed within ${this.requestTimeoutMs}ms`
+          )
+        );
+      }, this.requestTimeoutMs);
+
+      this.pendingClipRequests.push(pending);
+
+      try {
+        void this.host.sendRuntimeCommand(messageType, payload);
+      } catch (error) {
+        const idx = this.pendingClipRequests.indexOf(pending);
+        if (idx !== -1) this.pendingClipRequests.splice(idx, 1);
+        if (pending.timeoutHandle) clearTimeout(pending.timeoutHandle);
+        reject(
+          new RecordingError(
+            "INTERNAL_ERROR",
+            `Failed to send ${messageType}: ${(error as Error).message}`
+          )
+        );
+      }
+    });
+  }
+
+  /**
+   * Match inbound `clipReady` / `clipFailed` to the next pending
+   * request FIFO; ignore every other runtime message type.
+   */
+  private onRuntimeMessage(message: unknown): void {
+    if (!message || typeof message !== "object") return;
+    const msg = message as { type?: unknown; data?: unknown };
+    const type = msg.type;
+    if (
+      type !== RuntimeRecordingMessageType.CLIP_READY &&
+      type !== RuntimeRecordingMessageType.CLIP_FAILED
+    ) {
+      return;
+    }
+    const pending = this.pendingClipRequests.shift();
+    if (!pending) {
+      console.warn("[Reactor] Received", type, "with no pending request");
+      return;
+    }
+    if (pending.timeoutHandle) clearTimeout(pending.timeoutHandle);
+
+    if (type === RuntimeRecordingMessageType.CLIP_READY) {
+      const parsed = ClipReadyPayloadSchema.safeParse(msg.data);
+      if (!parsed.success) {
+        pending.reject(
+          new RecordingError(
+            "INTERNAL_ERROR",
+            `Malformed clipReady payload: ${parsed.error.message}`
+          )
+        );
+        return;
+      }
+      pending.resolve(
+        clipFromPayload(parsed.data, {
+          coordinatorBaseUrl: this.host.getCoordinatorBaseUrl(),
+        })
+      );
+      return;
+    }
+
+    const parsedFail = ClipFailedPayloadSchema.safeParse(msg.data ?? {});
+    const reason = parsedFail.success ? parsedFail.data.reason : "unknown";
+    pending.reject(
+      new RecordingError(
+        reason === "recorder disabled" ||
+          reason === "recorder disabled or encoder crashed"
+          ? "RECORDER_DISABLED"
+          : "INTERNAL_ERROR",
+        reason
+      )
+    );
+  }
+
+  private onStatusChanged(status: ReactorStatus): void {
+    if (status === "disconnected") {
+      this.rejectPending("Reactor disconnected");
+    }
+  }
+
+  /** Reject every in-flight request with a typed disconnect error. */
+  private rejectPending(reason: string): void {
+    if (this.pendingClipRequests.length === 0) return;
+    const pending = this.pendingClipRequests;
+    this.pendingClipRequests = [];
+    for (const entry of pending) {
+      if (entry.timeoutHandle) clearTimeout(entry.timeoutHandle);
+      entry.reject(new RecordingError("DISCONNECTED", reason));
+    }
+  }
+}

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -5,4 +5,24 @@ export * from "./react/ReactorController";
 export * from "./react/WebcamStream";
 export * from "./react/hooks";
 export * from "./types";
+// Recording wire contract — types, schemas, error class.
+export {
+  RecordingError,
+  RuntimeRecordingMessageType,
+  clipFromPayload,
+  rewriteUrlHost,
+} from "./utils/recording";
+export type {
+  Clip,
+  ClipKind,
+  ClipReadyPayload,
+  ClipFailedPayload,
+  ParseClipOptions,
+} from "./utils/recording";
+// Stateful recording client + its host adapter.
+export {
+  DEFAULT_CLIP_REQUEST_TIMEOUT_MS,
+  RecordingClient,
+} from "./core/RecordingClient";
+export type { RecordingClientHost } from "./core/RecordingClient";
 export type { ReactorStore } from "./core/store";

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+/**
+ * Stateless wire-contract primitives for the Reactor recording feature.
+ *
+ * This module owns:
+ * - Public-facing {@link Clip} type, {@link RecordingError} class, and
+ *   the `RuntimeRecordingMessageType` enum.
+ * - Wire schemas (`ClipReadyPayloadSchema`, `ClipFailedPayloadSchema`)
+ *   plus `clipFromPayload` to convert snake_case wire payloads into
+ *   camelCase `Clip` objects.
+ * - `rewriteUrlHost` for local-mode URL rewriting.
+ *
+ * Stateful pieces (FIFO promise correlator, in-flight request
+ * lifecycle, integration with Reactor's event bus) live in the
+ * `RecordingClient` class in `core/RecordingClient.ts`.
+ *
+ * Wire contract is documented end-to-end in the *Video Recording
+ * Feature* Notion page; the runtime side ships in
+ * `reactor_runtime/recording/`.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime message types (mirrors RuntimeMessageType in Python)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Names of the runtime-scoped messages used by the recording feature.
+ * Outbound names are sent via `Reactor.sendCommand(name, …, "runtime")`;
+ * inbound names appear as `message.type` on `runtimeMessage` events.
+ */
+export const RuntimeRecordingMessageType = {
+  REQUEST_CLIP: "requestClip",
+  REQUEST_RECORDING: "requestRecording",
+  CLIP_READY: "clipReady",
+  CLIP_FAILED: "clipFailed",
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Discriminator on a {@link Clip}. `"snap"` from `requestClip`, `"recording"` from `requestRecording`. */
+export type ClipKind = "snap" | "recording";
+
+/**
+ * Resolved outcome of a {@link Reactor.requestClip} / {@link Reactor.requestRecording} call.
+ *
+ * The runtime returns immediately on every request — it does *not*
+ * block until the in-progress chunk has been finalised. The response
+ * is a *promise*: `endMarker` reflects wall-clock at request time
+ * and may point inside a chunk ffmpeg is still writing. The
+ * `/clips` manifest endpoint returns `202 Retry-After` while that
+ * chunk is in flight; the SDK polls until `200`.
+ *
+ * - `startMarker` / `endMarker` / `nowMarker` are session-relative
+ *   seconds since recorder start.
+ * - `predictedReadyAtMs` is a **Unix epoch in milliseconds** — the
+ *   runtime's estimate of when the boundary chunk will be servable
+ *   by `/clips`. Compare against `Date.now()` to drive a "ready in
+ *   Ns" indicator. The SDK uses this as the polling deadline: past
+ *   `predictedReadyAtMs + slackMs` and still 202, the SDK fails with
+ *   `CLIP_NOT_READY` on the assumption the runtime crashed.
+ * - `playlistUrl` is short-lived in production (the embedded chunk
+ *   URLs are presigned for a few minutes). Re-issuing the request
+ *   produces a fresh URL with fresh presigning.
+ */
+export interface Clip {
+  sessionId: string;
+  kind: ClipKind;
+  startMarker: number;
+  endMarker: number;
+  nowMarker: number;
+  predictedReadyAtMs: number;
+  playlistUrl: string;
+}
+
+/**
+ * Error thrown when a recording request cannot be served.
+ *
+ * `code` is a stable, machine-readable identifier; `reason` is the
+ * raw string the runtime / manifest endpoint returned (passed through
+ * verbatim from `clipFailed.reason`, the `/clips` HTTP body, or the
+ * SDK's pre-flight check).
+ */
+export class RecordingError extends Error {
+  constructor(
+    public readonly code:
+      | "RECORDER_DISABLED"
+      | "INVALID_DURATION"
+      | "REQUEST_TIMEOUT"
+      | "DISCONNECTED"
+      | "CLIP_GONE"
+      | "CLIP_NOT_READY"
+      | "PLAYLIST_FETCH_FAILED"
+      | "CHUNK_FETCH_FAILED"
+      | "INVALID_PLAYLIST"
+      | "DOWNLOAD_UNSUPPORTED"
+      | "INTERNAL_ERROR",
+    public readonly reason: string
+  ) {
+    super(`${code}: ${reason}`);
+    this.name = "RecordingError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** `clipReady.data` payload as serialised by `ClipResult.to_dict()`. */
+export const ClipReadyPayloadSchema = z
+  .object({
+    session_id: z.string(),
+    kind: z.enum(["snap", "recording"]),
+    start_marker: z.number(),
+    end_marker: z.number(),
+    now_marker: z.number(),
+    predicted_ready_at_ms: z.number(),
+    playlist_url: z.string(),
+  })
+  .passthrough();
+
+export type ClipReadyPayload = z.infer<typeof ClipReadyPayloadSchema>;
+
+/** `clipFailed.data` payload — short reason string from the runtime. */
+export const ClipFailedPayloadSchema = z
+  .object({
+    reason: z.string().default("unknown"),
+  })
+  .passthrough();
+
+export type ClipFailedPayload = z.infer<typeof ClipFailedPayloadSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire → public type conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Options for {@link clipFromPayload}. */
+export interface ParseClipOptions {
+  /**
+   * Coordinator base URL.  When set, resolves `payload.playlist_url`
+   * against this base — used to convert the runtime's path-only
+   * playlist URL (``/clips?session_id=…``) into an absolute URL the
+   * browser/SDK can fetch.  Also handles the legacy case where an
+   * older runtime emits an absolute URL bound to its own
+   * ``0.0.0.0`` listener: the host/port are rewritten onto the
+   * coordinator.
+   */
+  coordinatorBaseUrl?: string;
+}
+
+/**
+ * Convert a validated {@link ClipReadyPayload} into the public {@link Clip}.
+ * Pure: no IO, no side effects.
+ */
+export function clipFromPayload(
+  payload: ClipReadyPayload,
+  options: ParseClipOptions = {}
+): Clip {
+  const playlistUrl = options.coordinatorBaseUrl
+    ? rewriteUrlHost(payload.playlist_url, options.coordinatorBaseUrl)
+    : payload.playlist_url;
+  return {
+    sessionId: payload.session_id,
+    kind: payload.kind,
+    startMarker: payload.start_marker,
+    endMarker: payload.end_marker,
+    nowMarker: payload.now_marker,
+    predictedReadyAtMs: payload.predicted_ready_at_ms,
+    playlistUrl,
+  };
+}
+
+/**
+ * Resolve `target` against `base`, returning an absolute URL.
+ *
+ * Two cases:
+ *
+ * * **Path-only / relative target** (no scheme — e.g. the
+ *   runtime's current ``/clips?session_id=…`` shape): joined
+ *   against ``base`` via ``new URL(target, base)``, preserving
+ *   path, query, and fragment.
+ * * **Absolute target** (``http://…`` / ``https://…``, e.g. a legacy
+ *   runtime emitting a URL bound to its own ``0.0.0.0`` listener):
+ *   scheme, hostname, and port are replaced with ``base``'s,
+ *   preserving path, query, and fragment.
+ *
+ * Returns the original ``target`` on any parse failure rather than
+ * throwing — the SDK consumes the URL eagerly and shouldn't break
+ * a session over a malformed clip envelope.
+ */
+export function rewriteUrlHost(target: string, base: string): string {
+  try {
+    // Path-only / scheme-less → resolve against base.
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(target)) {
+      return new URL(target, base).toString();
+    }
+    // Absolute → rewrite scheme/host/port, keep path/query/fragment.
+    const baseUrl = new URL(base);
+    const parsed = new URL(target);
+    parsed.protocol = baseUrl.protocol;
+    parsed.hostname = baseUrl.hostname;
+    parsed.port = baseUrl.port;
+    return parsed.toString();
+  } catch {
+    return target;
+  }
+}


### PR DESCRIPTION
Part 1 of 3 in the recording feature stack (REA-1955 / REA-1956). The
feature lets a client capture a piece of a live Reactor session and replay
it: `requestClip(N)` returns the last N seconds, `requestRecording()`
returns the whole session up to "now". Both resolve with a typed `Clip`
whose `playlistUrl` plays in any HLS-capable player.

This PR lands the wire layer:

- `Clip` / `ClipKind` / `RecordingError` and the zod schemas for the four
  runtime messages (`requestClip`, `requestRecording`, `clipReady`,
  `clipFailed`). Schemas are `.passthrough()` so the wire can grow.
- `RecordingClient` — the per-`Reactor` stateful piece that owns a FIFO
  correlator of in-flight requests and rejects everything on disconnect.
  Sits behind a slim host adapter so it's trivially testable.
- `Reactor.requestClip` / `Reactor.requestRecording` — thin delegations.

The helpers that turn a `Clip` into a playable manifest or an MP4
download live in PR #133. Unit tests for everything are in PR #134.

## How it feels

```ts
const clip = await reactor.requestClip(30);
// → { sessionId, kind: "snap", startMarker, endMarker,
//     predictedReadyAtMs, playlistUrl }

videoEl.src = clip.playlistUrl;   // Safari / iOS native HLS
// (hls.js for everyone else — covered in PR #133's helpers)
```

`requestClip` / `requestRecording` return as soon as the runtime
acknowledges the request, *before* the boundary chunk is fully uploaded.
`predictedReadyAtMs` is the Unix epoch when the manifest is expected to
become servable, so the SDK and apps can drive a "ready in Ns" indicator
and detect "runtime crashed mid-clip" with
`Date.now() > predictedReadyAtMs + slack`.

Linear: REA-1955
Plan: https://www.notion.so/reactor-technologies/Video-Recording-Feature-350cacd6a39680d8a77ac39eb37561b0
