### PR TITLE
[REA-2018] sdk: remove ReactorView state labels + bump to 2.9.2

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -26,7 +26,7 @@ The codegen reads a model's OpenAPI schema (events, messages, tracks) and produc
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output ./out/helios
 ```
 
@@ -92,7 +92,7 @@ Use `--standalone` when you want the typed client as a single `.ts` file inside 
 # Drop a typed Helios client into an existing project's src/ folder.
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output ./src/helios.ts \
   --standalone
 ```
@@ -106,7 +106,7 @@ Pass `--react` to additionally emit a React entry point. In full-package mode th
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output ./out/helios \
   --react
 ```
@@ -253,20 +253,20 @@ The generated `package.json` strips a leading `v` from the schema's `info.versio
 # Run codegen against the test schema (Helios)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output .generated/helios
 
 # Dry-run to preview output without writing files
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output .generated/helios \
   --dry-run
 
 # With React hooks (adds src/react.ts + ./react subpath export)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.1 \
+  --sdk-version 2.9.2 \
   --output .generated/helios \
   --react
 
@@ -310,7 +310,7 @@ const schema = parseSchema(rawSchema);
 const pkg = generateModelSdk({
   modelName: schema.modelName,
   modelVersion: schema.modelVersion,
-  sdkVersion: "2.9.1",
+  sdkVersion: "2.9.2",
   schema,
   outputDir: "./out/helios",
 });

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -71,7 +71,7 @@ describe("reactor-codegen CLI — argument validation", () => {
           "utf-8",
         ),
       );
-      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.1");
+      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.2");
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -25,14 +25,14 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.1 --output .generated/example"
+    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.2 --output .generated/example"
   },
   "keywords": [
     "reactor",
     "codegen",
     "sdk"
   ],
-  "defaultSdkVersion": "2.9.1",
+  "defaultSdkVersion": "2.9.2",
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "devDependencies": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -39,10 +39,9 @@ export function ReactorView({
   videoObjectFit = "contain",
   muted = true,
 }: ReactorViewProps) {
-  const { videoMediaTrack, audioMediaTrack, status } = useReactor((state) => ({
+  const { videoMediaTrack, audioMediaTrack } = useReactor((state) => ({
     videoMediaTrack: state.tracks[track] ?? null,
     audioMediaTrack: audioTrack ? (state.tracks[audioTrack] ?? null) : null,
-    status: state.status,
   }));
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -86,8 +85,6 @@ export function ReactorView({
     }
   }, [mediaStream]);
 
-  const showPlaceholder = !videoMediaTrack;
-
   return (
     <div
       style={{
@@ -105,33 +102,11 @@ export function ReactorView({
           width: "100%",
           height: "100%",
           objectFit: videoObjectFit,
-          display: showPlaceholder ? "none" : "block",
+          display: videoMediaTrack ? "block" : "none",
         }}
         muted={muted}
         playsInline
       />
-      {showPlaceholder && (
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-            color: "#fff",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: "16px",
-            fontFamily: "monospace",
-            textAlign: "center",
-            padding: "20px",
-            boxSizing: "border-box",
-          }}
-        >
-          {status}
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Why
- Closes REA-2018. The shipped ReactorView React component overlaid
  the connection status string ("connecting" / "waiting" / etc.) on
  top of the black placeholder background while no video track was
  attached. Product feedback is that this leaks an internal
  state-machine concept onto the UI of every consumer; embedders can
  render their own loading UI from useReactor().status if they want
  one.

What changed
- packages/js-sdk/src/react/ReactorView.tsx: drop the
  absolutely-positioned text overlay and stop selecting status from
  the store. The black background is still rendered by the wrapper
  div, and the <video> element is still hidden via display:none until
  a track attaches, so the visual is now just a clean black surface
  that swaps to live video once main_video arrives.
- packages/js-sdk/package.json: 2.9.1 -> 2.9.2 (patch bump for the
  visual change).
- packages/codegen/package.json: defaultSdkVersion 2.9.1 -> 2.9.2 and
  the codegen:test --sdk-version flag bumped, so generated model SDKs
  pin "@reactor-team/js-sdk": "^2.9.2" by default.
- packages/codegen/__tests__/cli.test.ts: the one assertion that
  exercises the defaultSdkVersion fallback path now expects ^2.9.2.
  The other 2.9.1 string literals in the codegen tests are explicit
  pass-through inputs (caller passes a version, asserts it is echoed)
  and are unrelated to the team's committed default.
- packages/codegen/README.md: --sdk-version examples and the
  programmatic sdkVersion example bumped to 2.9.2.

Tests
- pnpm test:unit in packages/js-sdk: 260/260 pass.
- pnpm test in packages/codegen: 229/229 pass.

Co-authored-by: Cursor <cursoragent@cursor.com>