### PR TITLE
[REA-1207] Fix bitrate stats computation in js-sdk

### DIFF
--- a/packages/js-sdk/__tests__/unit/webrtc-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-extended.test.ts
@@ -18,7 +18,7 @@ import {
   transformIceServers,
   sendMessage,
   parseMessage,
-  extractConnectionStats,
+  createRTCStatsExtractor,
   isConnected,
   isClosed,
 } from "../../src/utils/webrtc";
@@ -479,15 +479,21 @@ describe("parseMessage()", () => {
 
 describe("extractConnectionStats() full report", () => {
   it("extracts all fields from a complete report", () => {
+    const baseTimestamp = 1777674503920;
     const entries = new Map<string, any>([
       [
         "cp1",
         {
           type: "candidate-pair",
+          timestamp: baseTimestamp,
           state: "succeeded",
+          nominated: true,
           currentRoundTripTime: 0.025,
           availableOutgoingBitrate: 1_000_000,
+          availableIncomingBitrate: 1_270_000,
           localCandidateId: "lc1",
+          bytesReceived: 1000000,
+          bytesSent: 1025000,
         },
       ],
       ["lc1", { type: "local-candidate", candidateType: "relay" }],
@@ -508,13 +514,17 @@ describe("extractConnectionStats() full report", () => {
       get: (k: string) => entries.get(k),
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBe(25);
     expect(stats.candidateType).toBe("relay");
     expect(stats.availableOutgoingBitrate).toBe(1_000_000);
+    expect(stats.availableIncomingBitrate).toBe(1_270_000);
     expect(stats.framesPerSecond).toBe(30);
     expect(stats.jitter).toBe(0.01);
     expect(stats.packetLossRatio).toBeCloseTo(0.01);
+    expect(stats.outgoingBitrate).toBeUndefined();
+    expect(stats.incomingBitrate).toBeUndefined();
   });
 });
 
@@ -525,10 +535,18 @@ describe("extractConnectionStats() empty report", () => {
       get: () => undefined,
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBeUndefined();
     expect(stats.candidateType).toBeUndefined();
     expect(stats.framesPerSecond).toBeUndefined();
+    expect(stats.outgoingBitrate).toBeUndefined();
+    expect(stats.incomingBitrate).toBeUndefined();
+    expect(stats.availableOutgoingBitrate).toBeUndefined();
+    expect(stats.availableIncomingBitrate).toBeUndefined();
+    expect(stats.packetLossRatio).toBeUndefined();
+    expect(stats.jitter).toBeUndefined();
+    expect(stats.connectionTimings).toBeUndefined();
     expect(stats.timestamp).toBeGreaterThan(0);
   });
 });

--- a/packages/js-sdk/__tests__/unit/webrtc-utils.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-utils.test.ts
@@ -5,7 +5,7 @@ import {
   transformIceServers,
   sendMessage,
   parseMessage,
-  extractConnectionStats,
+  createRTCStatsExtractor,
   isConnected,
   isClosed,
 } from "../../src/utils/webrtc";
@@ -139,6 +139,7 @@ describe("extractConnectionStats()", () => {
         {
           type: "candidate-pair",
           state: "succeeded",
+          nominated: true,
           currentRoundTripTime: 0.025,
           availableOutgoingBitrate: 1_000_000,
           localCandidateId: "lc1",
@@ -163,9 +164,11 @@ describe("extractConnectionStats()", () => {
       get: (k: string) => entries.get(k),
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBe(25);
     expect(stats.candidateType).toBe("host");
+    expect(stats.availableIncomingBitrate).toBeUndefined;
     expect(stats.availableOutgoingBitrate).toBe(1_000_000);
     expect(stats.framesPerSecond).toBe(30);
     expect(stats.jitter).toBe(0.01);
@@ -179,9 +182,11 @@ describe("extractConnectionStats()", () => {
       get: () => undefined,
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBeUndefined();
     expect(stats.candidateType).toBeUndefined();
+    expect(stats.availableIncomingBitrate).toBeUndefined;
     expect(stats.framesPerSecond).toBeUndefined();
     expect(stats.timestamp).toBeGreaterThan(0);
   });
@@ -193,6 +198,7 @@ describe("extractConnectionStats()", () => {
         {
           type: "candidate-pair",
           state: "succeeded",
+          nominated: true,
           availableOutgoingBitrate: 500_000,
           localCandidateId: "lc1",
         },
@@ -204,6 +210,7 @@ describe("extractConnectionStats()", () => {
       get: (k: string) => entries.get(k),
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBeUndefined();
     expect(stats.availableOutgoingBitrate).toBe(500_000);
@@ -217,6 +224,7 @@ describe("extractConnectionStats()", () => {
         {
           type: "candidate-pair",
           state: "succeeded",
+          nominated: true,
           currentRoundTripTime: 0.05,
           localCandidateId: "lc-missing",
         },
@@ -227,9 +235,57 @@ describe("extractConnectionStats()", () => {
       get: () => undefined,
     } as unknown as RTCStatsReport;
 
+    const extractConnectionStats = createRTCStatsExtractor();
     const stats = extractConnectionStats(report);
     expect(stats.rtt).toBe(50);
     expect(stats.candidateType).toBeUndefined();
+  });
+
+  it("computes incomingBitrate and outgoingBitrate from candidate-pair counters between samples", () => {
+    const baseTimestamp = 1777674503920;
+    const makeReport = (
+      timestamp: number,
+      bytesReceived: number,
+      bytesSent: number
+    ) =>
+      ({
+        forEach: (cb: (v: any, k: string) => void) =>
+          new Map<string, any>([
+            [
+              "cp1",
+              {
+                type: "candidate-pair",
+                state: "succeeded",
+                nominated: true,
+                timestamp,
+                bytesReceived,
+                bytesSent,
+                localCandidateId: "lc1",
+              },
+            ],
+            ["lc1", { type: "local-candidate", candidateType: "host" }],
+          ]).forEach(cb),
+        get: (k: string) =>
+          k === "lc1"
+            ? { type: "local-candidate", candidateType: "host" }
+            : undefined,
+      }) as unknown as RTCStatsReport;
+
+    const extractConnectionStats = createRTCStatsExtractor();
+
+    const first = extractConnectionStats(
+      makeReport(baseTimestamp, 1000000, 1025000)
+    );
+    expect(first.incomingBitrate).toBeUndefined();
+    expect(first.outgoingBitrate).toBeUndefined();
+
+    // 1000 ms later: +2000 bytes received, +1000 bytes sent
+    const timeDiffMs = 1600;
+    const second = extractConnectionStats(
+      makeReport(baseTimestamp + timeDiffMs, 1500000, 1725000)
+    );
+    expect(second.incomingBitrate).toBe(2500000);
+    expect(second.outgoingBitrate).toBe(3500000);
   });
 });
 

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -593,11 +593,12 @@ export class WebRTCTransportClient implements TransportClient {
 
   private startStatsPolling(): void {
     this.stopStatsPolling();
+    const statsExtractor = webrtc.createRTCStatsExtractor();
     this.statsInterval = setInterval(async () => {
       if (!this.peerConnection) return;
       try {
         const report = await this.peerConnection.getStats();
-        this.stats = webrtc.extractConnectionStats(report);
+        this.stats = statsExtractor(report);
         this.emit("statsUpdate", this.stats);
       } catch {
         // Connection may be closing

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -87,8 +87,14 @@ export interface ConnectionStats {
   rtt?: number;
   /** ICE candidate type: "host", "srflx", "prflx", or "relay" (TURN) */
   candidateType?: string;
+  /** Estimated available incoming bitrate in bits/second */
+  availableIncomingBitrate?: number;
   /** Estimated available outgoing bitrate in bits/second */
   availableOutgoingBitrate?: number;
+  /** Real-time Incoming bitrate in bits/second */
+  incomingBitrate?: number;
+  /** Real-time Outgoing bitrate in bits/second */
+  outgoingBitrate?: number;
   /** Received video frames per second */
   framesPerSecond?: number;
   /** Ratio of packets lost (0-1) */

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -4,7 +4,7 @@
  * Stateless WebRTC utility functions for SDP exchange and peer connection management.
  */
 
-import type { IceServersResponse } from "../core/types";
+import type { IceServer, IceServersResponse } from "../core/types";
 import type { MessageScope, ConnectionStats } from "../types";
 import { sanitize } from "./sdp";
 
@@ -136,7 +136,7 @@ export function getLocalDescription(pc: RTCPeerConnection): string | undefined {
 export function transformIceServers(
   response: IceServersResponse
 ): RTCIceServer[] {
-  return response.ice_servers.map((server) => {
+  return response.ice_servers.map((server: IceServer) => {
     const rtcServer: RTCIceServer = {
       urls: server.uris,
     };
@@ -324,66 +324,112 @@ export function closePeerConnection(pc: RTCPeerConnection): void {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Extracts ConnectionStats from an RTCStatsReport.
- * Reads candidate-pair, local-candidate, and inbound-rtp (video) reports.
+ * Creates a function with a captured closure over a set of working variables which are
+ * used to compute connection stats from aggregate counters over the sample interval.
+ *
+ * @returns A function that extracts connection stats from an RTCStatsReport.
  */
-export function extractConnectionStats(
-  report: RTCStatsReport
-): ConnectionStats {
-  let rtt: number | undefined;
-  let availableOutgoingBitrate: number | undefined;
-  let localCandidateId: string | undefined;
-  let framesPerSecond: number | undefined;
-  let jitter: number | undefined;
-  let packetLossRatio: number | undefined;
 
-  report.forEach((stat) => {
-    if (stat.type === "candidate-pair" && stat.state === "succeeded") {
-      if (stat.currentRoundTripTime !== undefined) {
-        rtt = stat.currentRoundTripTime * 1000;
-      }
-      if (stat.availableOutgoingBitrate !== undefined) {
-        availableOutgoingBitrate = stat.availableOutgoingBitrate;
-      }
-      localCandidateId = stat.localCandidateId;
-    }
+type RTCStatsExtractor = (report: RTCStatsReport) => ConnectionStats;
 
-    if (stat.type === "inbound-rtp" && stat.kind === "video") {
-      if (stat.framesPerSecond !== undefined) {
-        framesPerSecond = stat.framesPerSecond;
-      }
-      if (stat.jitter !== undefined) {
-        jitter = stat.jitter;
-      }
+export function createRTCStatsExtractor(): RTCStatsExtractor {
+  let lastBytesReceived: number | undefined;
+  let lastBytesSent: number | undefined;
+  let lastCandPairTimestamp: number | undefined;
+
+  return (report: RTCStatsReport) => {
+    let candPairId: string | undefined;
+    let rtt: number | undefined;
+    let availableOutgoingBitrate: number | undefined;
+    let availableIncomingBitrate: number | undefined;
+    let incomingBitrate: number | undefined;
+    let outgoingBitrate: number | undefined;
+    let videoInboundRtpId: string | undefined;
+    let framesPerSecond: number | undefined;
+    let jitter: number | undefined;
+    let packetLossRatio: number | undefined;
+    let candidateType: string | undefined;
+
+    report.forEach((stat) => {
       if (
-        stat.packetsReceived !== undefined &&
-        stat.packetsLost !== undefined &&
-        stat.packetsReceived + stat.packetsLost > 0
+        candPairId === undefined &&
+        stat.type === "candidate-pair" &&
+        stat.state === "succeeded" &&
+        stat.nominated
       ) {
-        packetLossRatio =
-          stat.packetsLost / (stat.packetsReceived + stat.packetsLost);
+        // Extract stats from the first successful candidate-pair found.
+        candPairId = stat.id;
+        if (stat.currentRoundTripTime !== undefined) {
+          rtt = stat.currentRoundTripTime * 1000;
+        }
+        if (stat.availableOutgoingBitrate !== undefined) {
+          availableOutgoingBitrate = stat.availableOutgoingBitrate;
+        }
+        if (stat.availableIncomingBitrate != undefined) {
+          availableIncomingBitrate = stat.availableIncomingBitrate;
+        }
+        const localCandidate = report.get(stat.localCandidateId);
+        if (localCandidate?.candidateType) {
+          candidateType = localCandidate.candidateType;
+        }
+        const timeDiff: number =
+          lastCandPairTimestamp !== undefined
+            ? stat.timestamp - lastCandPairTimestamp
+            : 0;
+        if (stat.bytesReceived !== undefined) {
+          if (lastBytesReceived !== undefined && timeDiff > 0) {
+            incomingBitrate =
+              (((stat.bytesReceived - lastBytesReceived) * 8) / timeDiff) *
+              1000; /* Bits/Second */
+          }
+          lastBytesReceived = stat.bytesReceived;
+        }
+        if (stat.bytesSent !== undefined) {
+          if (lastBytesSent !== undefined && timeDiff > 0) {
+            outgoingBitrate =
+              (((stat.bytesSent - lastBytesSent) * 8) / timeDiff) *
+              1000; /* Bits/Second */
+          }
+          lastBytesSent = stat.bytesSent;
+        }
+        lastCandPairTimestamp = stat.timestamp;
       }
-    }
-  });
 
-  let candidateType: string | undefined;
-  if (localCandidateId) {
-    report.forEach((stat, id) => {
-      if (id === localCandidateId && stat.type === "local-candidate") {
-        const ct = (stat as RTCStats & { candidateType?: string })
-          .candidateType;
-        if (ct) candidateType = ct;
+      // If there is more than one video stream the stats will be from the first one encountered.
+      if (
+        videoInboundRtpId === undefined &&
+        stat.type === "inbound-rtp" &&
+        stat.kind === "video"
+      ) {
+        videoInboundRtpId = stat.id;
+        if (stat.framesPerSecond !== undefined) {
+          framesPerSecond = stat.framesPerSecond;
+        }
+        if (stat.jitter !== undefined) {
+          jitter = stat.jitter;
+        }
+        if (
+          stat.packetsReceived !== undefined &&
+          stat.packetsLost !== undefined &&
+          stat.packetsReceived + stat.packetsLost > 0
+        ) {
+          packetLossRatio =
+            stat.packetsLost / (stat.packetsReceived + stat.packetsLost);
+        }
       }
     });
-  }
 
-  return {
-    rtt,
-    candidateType,
-    availableOutgoingBitrate,
-    framesPerSecond,
-    packetLossRatio,
-    jitter,
-    timestamp: Date.now(),
+    return {
+      rtt,
+      candidateType,
+      availableIncomingBitrate,
+      availableOutgoingBitrate,
+      incomingBitrate,
+      outgoingBitrate,
+      framesPerSecond,
+      packetLossRatio,
+      jitter,
+      timestamp: Date.now(),
+    };
   };
 }


### PR DESCRIPTION
Why
---
Current bitrate reporting is using availableOutgoingBitrate, which is incorrect for this use case.
Compute the estimated current bitrate as (bytesReceived[t] - bytesReceived[t-1]) / time_difference.

What Changed
------------
- Wrapped the ConnectionStats extractor function in a generator function in order to create a
closure over a set of variables used to hold the previous bytes send and received counts along
with the previous timestamp. The generated function is used by the periodic callback to
extract the previous set of stats plus the new calculated stats.

- Calculate a realtime incomingBitrate and outgoingBitrate stats by capturing the bytesReceived
and bytesSent stats from the chosen ICECandidatePair statistics dictionary. At each call to
the stats extracrator the current byte count is subtracted from the previous count and then
divided by the differnce between the current JS time and the previous time to update the
realtime counts.

- The availableOutgoindBitrate property has been kept and the availableIncomingBitrate has been
added as these will become useful stats once the bandwidth estimation functions have been wired
in correctly.