### PR TITLE
Fix SDP output order of a= lines

### DIFF
--- a/packages/js-sdk/__tests__/unit/sdp.test.ts
+++ b/packages/js-sdk/__tests__/unit/sdp.test.ts
@@ -21,6 +21,72 @@ describe("sanitize()", () => {
     expect(out).toContain("a=rtpmap:96 opus/48000/2");
   });
 
+  it("preserves attribute line order within an m-section when remapping PTs", () => {
+    const sdp = [
+      "v=0",
+      "m=video 9 UDP/TLS/RTP/SAVPF 8",
+      "a=ice-ufrag:abc",
+      "a=rtpmap:8 VP8/90000",
+    ].join("\r\n");
+    const lines = sanitize(sdp).split("\r\n");
+    const iceIdx = lines.indexOf("a=ice-ufrag:abc");
+    const rtpIdx = lines.findIndex((l) => l.startsWith("a=rtpmap:"));
+    expect(iceIdx).toBeGreaterThan(-1);
+    expect(rtpIdx).toBeGreaterThan(-1);
+    expect(iceIdx).toBeLessThan(rtpIdx);
+  });
+
+  it("preserves rtpmap / rtcp-fb / fmtp interleaving with LF-only line endings", () => {
+    const sdp = [
+      "v=0",
+      "m=video 9 UDP/TLS/RTP/SAVPF 8 9",
+      "a=rtpmap:8 VP8/90000",
+      "a=rtcp-fb:8 nack",
+      "a=fmtp:8 x=y",
+      "a=rtpmap:9 rtx/90000",
+      "a=fmtp:9 apt=8",
+    ].join("\n");
+
+    const kindOrder = (s: string) =>
+      s
+        .split(/\n/)
+        .map((l) => {
+          if (l.startsWith("a=rtpmap:")) return "rtpmap";
+          if (l.startsWith("a=rtcp-fb:")) return "rtcp-fb";
+          if (l.startsWith("a=fmtp:")) return "fmtp";
+          return null;
+        })
+        .filter((x): x is "rtpmap" | "rtcp-fb" | "fmtp" => x !== null);
+
+    const out = sanitize(sdp);
+    expect(kindOrder(out)).toEqual(kindOrder(sdp));
+    expect(out.includes("\r\n")).toBe(false);
+  });
+
+  it("reorders rtpmap / fmtp / rtcp-fb into PT clusters following m= payload order", () => {
+    const sdp = [
+      "v=0",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96 97",
+      "c=IN IP4 0.0.0.0",
+      "a=ice-ufrag:x",
+      // Wrong grouping: all rtpmaps first, then fmtp, then rtcp-fb (like sdp-transform write)
+      "a=rtpmap:96 VP8/90000",
+      "a=rtpmap:97 rtx/90000",
+      "a=fmtp:97 apt=96",
+      "a=rtcp-fb:96 goog-remb",
+      "a=rtcp-fb:96 nack",
+    ].join("\r\n");
+
+    const out = sanitize(sdp);
+    const lines = out.split("\r\n");
+    const start = lines.findIndex((l) => l.startsWith("a=rtpmap:96"));
+    expect(lines[start]).toBe("a=rtpmap:96 VP8/90000");
+    expect(lines[start + 1]).toBe("a=rtcp-fb:96 goog-remb");
+    expect(lines[start + 2]).toBe("a=rtcp-fb:96 nack");
+    expect(lines[start + 3]).toBe("a=rtpmap:97 rtx/90000");
+    expect(lines[start + 4]).toBe("a=fmtp:97 apt=96");
+  });
+
   it("returns the input unchanged for VP8-only video already in the dynamic PT range", () => {
     const sdp = [
       "v=0",
@@ -36,6 +102,18 @@ describe("sanitize()", () => {
       "m=video 9 UDP/TLS/RTP/SAVPF 45",
       "a=rtpmap:45 AV1/90000",
       "a=fmtp:45 profile=0",
+    ].join("\r\n");
+    expect(sanitize(sdp)).toBe(sdp);
+  });
+
+  it("preserves rtx bound to AV1 (apt unchanged)", () => {
+    const sdp = [
+      "v=0",
+      "m=video 9 UDP/TLS/RTP/SAVPF 45 46",
+      "a=rtpmap:45 AV1/90000",
+      "a=fmtp:45 profile=0",
+      "a=rtpmap:46 rtx/90000",
+      "a=fmtp:46 apt=45",
     ].join("\r\n");
     expect(sanitize(sdp)).toBe(sdp);
   });
@@ -237,197 +315,195 @@ describe("sanitize()", () => {
     expect(out).toContain("a=fmtp:98 profile-id=2");
   });
 
-  it("full browser offer: strips telephone-event and relocates all H265 into dynamic range", () => {
-    // SDP from a Chrome offer with 4 m-sections (sendonly video, sendonly audio,
-    // recvonly video, recvonly audio). H265 appears at PT 49 in mid:0 and at PTs
-    // 49+51 in mid:2 — all below 96. Audio sections carry telephone-event at 110+126.
-    const sdp = [
-      "v=0",
-      "o=- 8748351739256011160 2 IN IP4 127.0.0.1",
-      "s=-",
-      "t=0 0",
-      "a=group:BUNDLE 0 1 2 3",
-      "a=extmap-allow-mixed",
-      "a=msid-semantic: WMS",
-      // mid:0 — sendonly video
-      "m=video 9 UDP/TLS/RTP/SAVPF 96 97 103 104 107 108 109 114 115 116 117 118 39 40 45 46 98 99 100 101 119 120 49 50 123 124 125",
-      "c=IN IP4 0.0.0.0",
-      "a=mid:0",
-      "a=sendonly",
-      "a=rtcp-mux",
-      "a=rtpmap:96 VP8/90000",
-      "a=rtpmap:97 rtx/90000",
-      "a=fmtp:97 apt=96",
-      "a=rtpmap:103 H264/90000",
-      "a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
-      "a=rtpmap:104 rtx/90000",
-      "a=fmtp:104 apt=103",
-      "a=rtpmap:107 H264/90000",
-      "a=fmtp:107 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
-      "a=rtpmap:108 rtx/90000",
-      "a=fmtp:108 apt=107",
-      "a=rtpmap:109 H264/90000",
-      "a=fmtp:109 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
-      "a=rtpmap:114 rtx/90000",
-      "a=fmtp:114 apt=109",
-      "a=rtpmap:115 H264/90000",
-      "a=fmtp:115 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
-      "a=rtpmap:116 rtx/90000",
-      "a=fmtp:116 apt=115",
-      "a=rtpmap:117 H264/90000",
-      "a=fmtp:117 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
-      "a=rtpmap:118 rtx/90000",
-      "a=fmtp:118 apt=117",
-      "a=rtpmap:39 H264/90000",
-      "a=fmtp:39 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
-      "a=rtpmap:40 rtx/90000",
-      "a=fmtp:40 apt=39",
-      "a=rtpmap:45 AV1/90000",
-      "a=fmtp:45 level-idx=5;profile=0;tier=0",
-      "a=rtpmap:46 rtx/90000",
-      "a=fmtp:46 apt=45",
-      "a=rtpmap:98 VP9/90000",
-      "a=fmtp:98 profile-id=0",
-      "a=rtpmap:99 rtx/90000",
-      "a=fmtp:99 apt=98",
-      "a=rtpmap:100 VP9/90000",
-      "a=fmtp:100 profile-id=2",
-      "a=rtpmap:101 rtx/90000",
-      "a=fmtp:101 apt=100",
-      "a=rtpmap:119 H264/90000",
-      "a=fmtp:119 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
-      "a=rtpmap:120 rtx/90000",
-      "a=fmtp:120 apt=119",
-      "a=rtpmap:49 H265/90000",
-      "a=fmtp:49 level-id=156;profile-id=1;tier-flag=0;tx-mode=SRST",
-      "a=rtpmap:50 rtx/90000",
-      "a=fmtp:50 apt=49",
-      "a=rtpmap:123 red/90000",
-      "a=rtpmap:124 rtx/90000",
-      "a=fmtp:124 apt=123",
-      "a=rtpmap:125 ulpfec/90000",
-      // mid:1 — sendonly audio (telephone-event at 110 and 126)
-      "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126",
-      "c=IN IP4 0.0.0.0",
-      "a=mid:1",
-      "a=sendonly",
-      "a=rtcp-mux",
-      "a=rtpmap:111 opus/48000/2",
-      "a=fmtp:111 minptime=10;useinbandfec=1",
-      "a=rtpmap:63 red/48000/2",
-      "a=fmtp:63 111/111",
-      "a=rtpmap:9 G722/8000",
-      "a=rtpmap:0 PCMU/8000",
-      "a=rtpmap:8 PCMA/8000",
-      "a=rtpmap:13 CN/8000",
-      "a=rtpmap:110 telephone-event/48000",
-      "a=rtpmap:126 telephone-event/8000",
-      // mid:2 — recvonly video (H265 at 49 and 51, many extras below 96)
-      "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 35 36 37 38 103 104 107 108 109 114 115 116 117 118 39 40 41 42 43 44 45 46 47 48 119 120 121 122 49 50 51 52 123 124 125 53",
-      "c=IN IP4 0.0.0.0",
-      "a=mid:2",
-      "a=recvonly",
-      "a=rtcp-mux",
-      "a=rtpmap:96 VP8/90000",
-      "a=rtpmap:97 rtx/90000",
-      "a=fmtp:97 apt=96",
-      "a=rtpmap:98 VP9/90000",
-      "a=fmtp:98 profile-id=0",
-      "a=rtpmap:99 rtx/90000",
-      "a=fmtp:99 apt=98",
-      "a=rtpmap:100 VP9/90000",
-      "a=fmtp:100 profile-id=2",
-      "a=rtpmap:101 rtx/90000",
-      "a=fmtp:101 apt=100",
-      "a=rtpmap:35 VP9/90000",
-      "a=fmtp:35 profile-id=1",
-      "a=rtpmap:36 rtx/90000",
-      "a=fmtp:36 apt=35",
-      "a=rtpmap:37 VP9/90000",
-      "a=fmtp:37 profile-id=3",
-      "a=rtpmap:38 rtx/90000",
-      "a=fmtp:38 apt=37",
-      "a=rtpmap:103 H264/90000",
-      "a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
-      "a=rtpmap:104 rtx/90000",
-      "a=fmtp:104 apt=103",
-      "a=rtpmap:107 H264/90000",
-      "a=fmtp:107 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
-      "a=rtpmap:108 rtx/90000",
-      "a=fmtp:108 apt=107",
-      "a=rtpmap:109 H264/90000",
-      "a=fmtp:109 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
-      "a=rtpmap:114 rtx/90000",
-      "a=fmtp:114 apt=109",
-      "a=rtpmap:115 H264/90000",
-      "a=fmtp:115 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
-      "a=rtpmap:116 rtx/90000",
-      "a=fmtp:116 apt=115",
-      "a=rtpmap:117 H264/90000",
-      "a=fmtp:117 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
-      "a=rtpmap:118 rtx/90000",
-      "a=fmtp:118 apt=117",
-      "a=rtpmap:39 H264/90000",
-      "a=fmtp:39 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
-      "a=rtpmap:40 rtx/90000",
-      "a=fmtp:40 apt=39",
-      "a=rtpmap:41 H264/90000",
-      "a=fmtp:41 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=f4001f",
-      "a=rtpmap:42 rtx/90000",
-      "a=fmtp:42 apt=41",
-      "a=rtpmap:43 H264/90000",
-      "a=fmtp:43 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=f4001f",
-      "a=rtpmap:44 rtx/90000",
-      "a=fmtp:44 apt=43",
-      "a=rtpmap:45 AV1/90000",
-      "a=fmtp:45 level-idx=5;profile=0;tier=0",
-      "a=rtpmap:46 rtx/90000",
-      "a=fmtp:46 apt=45",
-      "a=rtpmap:47 AV1/90000",
-      "a=fmtp:47 level-idx=5;profile=1;tier=0",
-      "a=rtpmap:48 rtx/90000",
-      "a=fmtp:48 apt=47",
-      "a=rtpmap:119 H264/90000",
-      "a=fmtp:119 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
-      "a=rtpmap:120 rtx/90000",
-      "a=fmtp:120 apt=119",
-      "a=rtpmap:121 H264/90000",
-      "a=fmtp:121 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=64001f",
-      "a=rtpmap:122 rtx/90000",
-      "a=fmtp:122 apt=121",
-      "a=rtpmap:49 H265/90000",
-      "a=fmtp:49 level-id=180;profile-id=1;tier-flag=0;tx-mode=SRST",
-      "a=rtpmap:50 rtx/90000",
-      "a=fmtp:50 apt=49",
-      "a=rtpmap:51 H265/90000",
-      "a=fmtp:51 level-id=180;profile-id=2;tier-flag=0;tx-mode=SRST",
-      "a=rtpmap:52 rtx/90000",
-      "a=fmtp:52 apt=51",
-      "a=rtpmap:123 red/90000",
-      "a=rtpmap:124 rtx/90000",
-      "a=fmtp:124 apt=123",
-      "a=rtpmap:125 ulpfec/90000",
-      "a=rtpmap:53 flexfec-03/90000",
-      "a=fmtp:53 repair-window=10000000",
-      // mid:3 — recvonly audio (telephone-event at 110 and 126)
-      "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126",
-      "c=IN IP4 0.0.0.0",
-      "a=mid:3",
-      "a=recvonly",
-      "a=rtcp-mux",
-      "a=rtpmap:111 opus/48000/2",
-      "a=fmtp:111 minptime=10;useinbandfec=1",
-      "a=rtpmap:63 red/48000/2",
-      "a=fmtp:63 111/111",
-      "a=rtpmap:9 G722/8000",
-      "a=rtpmap:0 PCMU/8000",
-      "a=rtpmap:8 PCMA/8000",
-      "a=rtpmap:13 CN/8000",
-      "a=rtpmap:110 telephone-event/48000",
-      "a=rtpmap:126 telephone-event/8000",
-    ].join("\r\n");
+  // Chrome-like SDP: 4 m-lines; H265 at PT 49 (mid:0) and 49+51 (mid:2); telephone-event on audio.
+  const FULL_BROWSER_QUAD_MSECTION_OFFER = [
+    "v=0",
+    "o=- 8748351739256011160 2 IN IP4 127.0.0.1",
+    "s=-",
+    "t=0 0",
+    "a=group:BUNDLE 0 1 2 3",
+    "a=extmap-allow-mixed",
+    "a=msid-semantic: WMS",
+    // mid:0 — sendonly video
+    "m=video 9 UDP/TLS/RTP/SAVPF 96 97 103 104 107 108 109 114 115 116 117 118 39 40 45 46 98 99 100 101 119 120 49 50 123 124 125",
+    "c=IN IP4 0.0.0.0",
+    "a=mid:0",
+    "a=sendonly",
+    "a=rtcp-mux",
+    "a=rtpmap:96 VP8/90000",
+    "a=rtpmap:97 rtx/90000",
+    "a=fmtp:97 apt=96",
+    "a=rtpmap:103 H264/90000",
+    "a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+    "a=rtpmap:104 rtx/90000",
+    "a=fmtp:104 apt=103",
+    "a=rtpmap:107 H264/90000",
+    "a=fmtp:107 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
+    "a=rtpmap:108 rtx/90000",
+    "a=fmtp:108 apt=107",
+    "a=rtpmap:109 H264/90000",
+    "a=fmtp:109 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+    "a=rtpmap:114 rtx/90000",
+    "a=fmtp:114 apt=109",
+    "a=rtpmap:115 H264/90000",
+    "a=fmtp:115 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
+    "a=rtpmap:116 rtx/90000",
+    "a=fmtp:116 apt=115",
+    "a=rtpmap:117 H264/90000",
+    "a=fmtp:117 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
+    "a=rtpmap:118 rtx/90000",
+    "a=fmtp:118 apt=117",
+    "a=rtpmap:39 H264/90000",
+    "a=fmtp:39 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
+    "a=rtpmap:40 rtx/90000",
+    "a=fmtp:40 apt=39",
+    "a=rtpmap:45 AV1/90000",
+    "a=fmtp:45 level-idx=5;profile=0;tier=0",
+    "a=rtpmap:46 rtx/90000",
+    "a=fmtp:46 apt=45",
+    "a=rtpmap:98 VP9/90000",
+    "a=fmtp:98 profile-id=0",
+    "a=rtpmap:99 rtx/90000",
+    "a=fmtp:99 apt=98",
+    "a=rtpmap:100 VP9/90000",
+    "a=fmtp:100 profile-id=2",
+    "a=rtpmap:101 rtx/90000",
+    "a=fmtp:101 apt=100",
+    "a=rtpmap:119 H264/90000",
+    "a=fmtp:119 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
+    "a=rtpmap:120 rtx/90000",
+    "a=fmtp:120 apt=119",
+    "a=rtpmap:49 H265/90000",
+    "a=fmtp:49 level-id=156;profile-id=1;tier-flag=0;tx-mode=SRST",
+    "a=rtpmap:50 rtx/90000",
+    "a=fmtp:50 apt=49",
+    "a=rtpmap:123 red/90000",
+    "a=rtpmap:124 rtx/90000",
+    "a=fmtp:124 apt=123",
+    "a=rtpmap:125 ulpfec/90000",
+    // mid:1 — sendonly audio (telephone-event at 110 and 126)
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126",
+    "c=IN IP4 0.0.0.0",
+    "a=mid:1",
+    "a=sendonly",
+    "a=rtcp-mux",
+    "a=rtpmap:111 opus/48000/2",
+    "a=fmtp:111 minptime=10;useinbandfec=1",
+    "a=rtpmap:63 red/48000/2",
+    "a=fmtp:63 111/111",
+    "a=rtpmap:9 G722/8000",
+    "a=rtpmap:0 PCMU/8000",
+    "a=rtpmap:8 PCMA/8000",
+    "a=rtpmap:13 CN/8000",
+    "a=rtpmap:110 telephone-event/48000",
+    "a=rtpmap:126 telephone-event/8000",
+    // mid:2 — recvonly video (H265 at 49 and 51, many extras below 96)
+    "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 35 36 37 38 103 104 107 108 109 114 115 116 117 118 39 40 41 42 43 44 45 46 47 48 119 120 121 122 49 50 51 52 123 124 125 53",
+    "c=IN IP4 0.0.0.0",
+    "a=mid:2",
+    "a=recvonly",
+    "a=rtcp-mux",
+    "a=rtpmap:96 VP8/90000",
+    "a=rtpmap:97 rtx/90000",
+    "a=fmtp:97 apt=96",
+    "a=rtpmap:98 VP9/90000",
+    "a=fmtp:98 profile-id=0",
+    "a=rtpmap:99 rtx/90000",
+    "a=fmtp:99 apt=98",
+    "a=rtpmap:100 VP9/90000",
+    "a=fmtp:100 profile-id=2",
+    "a=rtpmap:101 rtx/90000",
+    "a=fmtp:101 apt=100",
+    "a=rtpmap:35 VP9/90000",
+    "a=fmtp:35 profile-id=1",
+    "a=rtpmap:36 rtx/90000",
+    "a=fmtp:36 apt=35",
+    "a=rtpmap:37 VP9/90000",
+    "a=fmtp:37 profile-id=3",
+    "a=rtpmap:38 rtx/90000",
+    "a=fmtp:38 apt=37",
+    "a=rtpmap:103 H264/90000",
+    "a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+    "a=rtpmap:104 rtx/90000",
+    "a=fmtp:104 apt=103",
+    "a=rtpmap:107 H264/90000",
+    "a=fmtp:107 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f",
+    "a=rtpmap:108 rtx/90000",
+    "a=fmtp:108 apt=107",
+    "a=rtpmap:109 H264/90000",
+    "a=fmtp:109 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+    "a=rtpmap:114 rtx/90000",
+    "a=fmtp:114 apt=109",
+    "a=rtpmap:115 H264/90000",
+    "a=fmtp:115 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f",
+    "a=rtpmap:116 rtx/90000",
+    "a=fmtp:116 apt=115",
+    "a=rtpmap:117 H264/90000",
+    "a=fmtp:117 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f",
+    "a=rtpmap:118 rtx/90000",
+    "a=fmtp:118 apt=117",
+    "a=rtpmap:39 H264/90000",
+    "a=fmtp:39 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f",
+    "a=rtpmap:40 rtx/90000",
+    "a=fmtp:40 apt=39",
+    "a=rtpmap:41 H264/90000",
+    "a=fmtp:41 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=f4001f",
+    "a=rtpmap:42 rtx/90000",
+    "a=fmtp:42 apt=41",
+    "a=rtpmap:43 H264/90000",
+    "a=fmtp:43 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=f4001f",
+    "a=rtpmap:44 rtx/90000",
+    "a=fmtp:44 apt=43",
+    "a=rtpmap:45 AV1/90000",
+    "a=fmtp:45 level-idx=5;profile=0;tier=0",
+    "a=rtpmap:46 rtx/90000",
+    "a=fmtp:46 apt=45",
+    "a=rtpmap:47 AV1/90000",
+    "a=fmtp:47 level-idx=5;profile=1;tier=0",
+    "a=rtpmap:48 rtx/90000",
+    "a=fmtp:48 apt=47",
+    "a=rtpmap:119 H264/90000",
+    "a=fmtp:119 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f",
+    "a=rtpmap:120 rtx/90000",
+    "a=fmtp:120 apt=119",
+    "a=rtpmap:121 H264/90000",
+    "a=fmtp:121 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=64001f",
+    "a=rtpmap:122 rtx/90000",
+    "a=fmtp:122 apt=121",
+    "a=rtpmap:49 H265/90000",
+    "a=fmtp:49 level-id=180;profile-id=1;tier-flag=0;tx-mode=SRST",
+    "a=rtpmap:50 rtx/90000",
+    "a=fmtp:50 apt=49",
+    "a=rtpmap:51 H265/90000",
+    "a=fmtp:51 level-id=180;profile-id=2;tier-flag=0;tx-mode=SRST",
+    "a=rtpmap:52 rtx/90000",
+    "a=fmtp:52 apt=51",
+    "a=rtpmap:123 red/90000",
+    "a=rtpmap:124 rtx/90000",
+    "a=fmtp:124 apt=123",
+    "a=rtpmap:125 ulpfec/90000",
+    "a=rtpmap:53 flexfec-03/90000",
+    "a=fmtp:53 repair-window=10000000",
+    // mid:3 — recvonly audio (telephone-event at 110 and 126)
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8 13 110 126",
+    "c=IN IP4 0.0.0.0",
+    "a=mid:3",
+    "a=recvonly",
+    "a=rtcp-mux",
+    "a=rtpmap:111 opus/48000/2",
+    "a=fmtp:111 minptime=10;useinbandfec=1",
+    "a=rtpmap:63 red/48000/2",
+    "a=fmtp:63 111/111",
+    "a=rtpmap:9 G722/8000",
+    "a=rtpmap:0 PCMU/8000",
+    "a=rtpmap:8 PCMA/8000",
+    "a=rtpmap:13 CN/8000",
+    "a=rtpmap:110 telephone-event/48000",
+    "a=rtpmap:126 telephone-event/8000",
+  ].join("\r\n");
 
-    const out = sanitize(sdp);
+  it("full browser offer: strips telephone-event and relocates all H265 into dynamic range", () => {
+    const out = sanitize(FULL_BROWSER_QUAD_MSECTION_OFFER);
     const outLines = out.split("\r\n");
     const mLines = outLines.filter((l) => l.startsWith("m="));
 
@@ -459,6 +535,29 @@ describe("sanitize()", () => {
     );
     expect(out).toContain("a=fmtp:50 apt=106"); // rtx apt= updated in mid:2
     expect(out).toContain("a=fmtp:52 apt=110"); // rtx apt= updated in mid:2
+  });
+
+  it("full browser offer: rtx rtpmaps preserved as a multiset, telephone-event removed, every H265 PT in [96,127]", () => {
+    const sdp = FULL_BROWSER_QUAD_MSECTION_OFFER;
+    const out = sanitize(sdp);
+
+    const rtxRtpmapLines = (s: string) =>
+      s.split("\r\n").filter((line) => /^a=rtpmap:\d+ rtx\/90000$/.test(line));
+
+    expect(rtxRtpmapLines(out).sort()).toEqual(rtxRtpmapLines(sdp).sort());
+
+    expect(out).not.toContain("telephone-event");
+
+    const h265Pts = out
+      .split("\r\n")
+      .map((line) => /^a=rtpmap:(\d+) H265\/90000$/.exec(line))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map((m) => Number(m[1]));
+    expect(h265Pts).toHaveLength(3);
+    for (const pt of h265Pts) {
+      expect(pt).toBeGreaterThanOrEqual(96);
+      expect(pt).toBeLessThanOrEqual(127);
+    }
   });
 
   it("later video m-line avoids PTs already assigned to an earlier video m-line", () => {

--- a/packages/js-sdk/src/utils/sdp.ts
+++ b/packages/js-sdk/src/utils/sdp.ts
@@ -4,12 +4,27 @@
  * SDP offer sanitization:
  * - Removes telephone-event codec entries from all m-sections.
  * - Remaps selected codec PTs that fall outside [96,127] — video: HEVC, VP8, VP9, H.264;
- *   audio: Opus. rtx entries are left at their original PTs; only apt= references are
- *   updated to follow a relocated primary.
+ *   audio: Opus. rtx entries stay at their original PTs; only apt= references are updated
+ *   when a primary is remapped.
+ * - After PT edits, RTP/SAVPF sections are normalized so rtpmap/fmtp/rtcp-fb (per PT) follow
+ *   the payload-type order on the `m=` line (Chrome-style interleaving), not grouped by line type.
+ * - Line breaks are preserved (`\r\n` vs `\n`) using `\r?\n` splits.
  */
 
 import type { MediaDescription } from "sdp-transform";
-import { parse, parsePayloads, write } from "sdp-transform";
+import { parse, parsePayloads } from "sdp-transform";
+
+function sdpLineSeparator(sdp: string): "\r\n" | "\n" {
+  return sdp.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function splitSdpLines(sdp: string): string[] {
+  return sdp.split(/\r?\n/);
+}
+
+function joinSdpLines(lines: readonly string[], sep: "\r\n" | "\n"): string {
+  return lines.join(sep);
+}
 
 /** RTP dynamic payload type range (RFC 3551). */
 const DYNAMIC_PT_MIN = 96;
@@ -119,111 +134,39 @@ function remapFmtpConfigForPayloadMap(
 }
 
 /**
- * Applies a payload-type map on one audio or video m-section (`remap` may be partial).
- */
-function applyPayloadTypeRemap(
-  media: MediaDescription,
-  remap: Map<number, number>
-): void {
-  if (media.type !== "video" && media.type !== "audio") {
-    return;
-  }
-  const mPts = mediaMLinePayloadTypes(media);
-  if (mPts.length === 0 || remap.size === 0) {
-    return;
-  }
-
-  media.payloads = mPts.map((p) => String(remap.get(p) ?? p)).join(" ");
-
-  for (const r of media.rtp ?? []) {
-    const oldP = Number(r.payload);
-    const np = remap.get(oldP);
-    if (np !== undefined) r.payload = np;
-  }
-  for (const f of media.fmtp ?? []) {
-    const oldP = Number(f.payload);
-    const np = remap.get(oldP);
-    if (np !== undefined) {
-      f.payload = np;
-      f.config = remapFmtpConfigForPayloadMap(f.config, remap);
-    } else {
-      f.config = remapFmtpConfigForPayloadMap(f.config, remap);
-    }
-  }
-  for (const f of media.rtcpFb ?? []) {
-    if (f.payload === "*") continue;
-    const oldP = Number(f.payload);
-    const np = remap.get(oldP);
-    if (np !== undefined) f.payload = np;
-  }
-  for (const f of media.rtcpFbTrrInt ?? []) {
-    if (f.payload === "*") continue;
-    const oldP = Number(f.payload);
-    const np = remap.get(oldP);
-    if (np !== undefined) f.payload = np;
-  }
-  for (const ia of media.imageattrs ?? []) {
-    if (ia.pt === "*") continue;
-    const oldP = Number(ia.pt);
-    const np = remap.get(oldP);
-    if (np !== undefined) ia.pt = np;
-  }
-  for (const inv of media.invalid ?? []) {
-    let s = inv.value;
-    const pairs = [...remap.entries()].sort((a, b) => b[0] - a[0]);
-    for (const [oldP, newP] of pairs) {
-      if (oldP === newP) continue;
-      s = s.replace(
-        new RegExp(`^rtpmap:${oldP}([\\s/])`, "i"),
-        `rtpmap:${newP}$1`
-      );
-      s = s.replace(new RegExp(`^fmtp:${oldP}(\\s)`, "i"), `fmtp:${newP}$1`);
-      s = s.replace(
-        new RegExp(`^rtcp-fb:${oldP}(\\s)`, "i"),
-        `rtcp-fb:${newP}$1`
-      );
-      s = s.replace(new RegExp(`apt=${oldP}([^0-9]|$)`, "g"), `apt=${newP}$1`);
-    }
-    inv.value = s;
-  }
-}
-
-/**
  * Remaps sanitized codec payload types (and rtx bound to them) into [96, 127],
  * avoiding `forbidden` and PTs already present in this m-line. Allocation is
  * best-effort: when the dynamic range is nearly full, higher-priority codecs
  * (H265 > H264 > VP9 > VP8 > Opus) are relocated first; any that cannot fit
  * are left at their original payload type rather than throwing.
  */
-function remapSanitizedCodecPayloadTypesMedia(
+function computeCodecRemapForMedia(
   media: MediaDescription,
   forbidden: ReadonlySet<number>
-): void {
+): Map<number, number> {
+  const remap = new Map<number, number>();
   if (media.type !== "video" && media.type !== "audio") {
-    return;
+    return remap;
   }
   const tracked = collectSanitizedCodecPayloadSet(media);
   if (!tracked) {
-    return;
+    return remap;
   }
   const relocate = [...tracked].filter(
     (p) => p < DYNAMIC_PT_MIN || p > DYNAMIC_PT_MAX
   );
   if (relocate.length === 0) {
-    return;
+    return remap;
   }
 
   const rtpmap = collectRtpmap(media);
   const ordered = sortedRelocate(relocate, rtpmap);
 
-  // Forbidden = previous m-lines + this m-line's already-in-range PTs.
-  // Since relocate only contains PTs outside [96,127], those don't overlap.
   const usedPts = new Set(forbidden);
   for (const p of mediaMLinePayloadTypes(media)) {
     if (p >= DYNAMIC_PT_MIN && p <= DYNAMIC_PT_MAX) usedPts.add(p);
   }
 
-  const remap = new Map<number, number>();
   let candidate = DYNAMIC_PT_MIN;
   for (const oldPt of ordered) {
     while (candidate <= DYNAMIC_PT_MAX && usedPts.has(candidate)) candidate++;
@@ -233,74 +176,299 @@ function remapSanitizedCodecPayloadTypesMedia(
     candidate++;
   }
 
-  if (remap.size === 0) {
-    return;
+  return remap;
+}
+
+function rewriteRtpSavpfMPayloads(
+  mLine: string,
+  mapPt: (pt: number) => number
+): string {
+  if (!/\bRTP\/SAVPF\b/.test(mLine)) {
+    return mLine;
   }
-  applyPayloadTypeRemap(media, remap);
+  const tokens = mLine.split(/\s+/);
+  if (tokens.length < 4) {
+    return mLine;
+  }
+  const head = tokens.slice(0, 3).join(" ");
+  const tail = tokens
+    .slice(3)
+    .map((t) => (/^\d+$/.test(t) ? String(mapPt(Number(t))) : t));
+  return `${head} ${tail.join(" ")}`;
+}
+
+function payloadTypesFromSavpfMLine(mLine: string): number[] {
+  const m = /\bRTP\/SAVPF\s+(.+)$/i.exec(mLine);
+  return m ? parsePayloads(m[1]!.trim()) : [];
+}
+
+function payloadTypeFromPtBoundAttributeLine(line: string): number | null {
+  if (line.startsWith("a=rtpmap:")) {
+    const x = /^a=rtpmap:(\d+)/i.exec(line);
+    return x ? Number(x[1]) : null;
+  }
+  if (line.startsWith("a=fmtp:")) {
+    const x = /^a=fmtp:(\d+)/i.exec(line);
+    return x ? Number(x[1]) : null;
+  }
+  if (line.startsWith("a=rtcp-fb:")) {
+    const x = /^a=rtcp-fb:(\*|(\d+))/i.exec(line);
+    if (!x || x[1] === "*") return null;
+    return Number(x[2]);
+  }
+  if (line.startsWith("a=rtcp-fb-trr-int:")) {
+    const x = /^a=rtcp-fb-trr-int:(\*|(\d+))/i.exec(line);
+    if (!x || x[1] === "*") return null;
+    return Number(x[2]);
+  }
+  if (line.startsWith("a=imageattrs:")) {
+    const x = /^a=imageattrs:(\*|(\d+))/i.exec(line);
+    if (!x || x[1] === "*") return null;
+    return Number(x[2]);
+  }
+  return null;
+}
+
+function isPtBoundCodecAttributeLine(line: string): boolean {
+  return payloadTypeFromPtBoundAttributeLine(line) !== null;
 }
 
 /**
- * Removes all telephone-event codec entries (rtpmap, fmtp, rtcp-fb, and the PT from the
- * m= payload list) from every m-section. Returns the input unchanged when no such entries
- * are present.
+ * Within one RTP/SAVPF m-section, reorder rtpmap/fmtp/rtcp-fb lines so each payload type's
+ * attributes are contiguous and ordered by the `m=` payload list (same interleaving style as
+ * Chrome). Non-codec lines before/after the codec block stay fixed.
  */
-function stripTelephoneEvents(sdp: string): string {
+function reorderSingleRtpSavpfSection(sec: string[]): string[] {
+  const mLine = sec[0]!;
+  if (!/\bRTP\/SAVPF\b/.test(mLine)) {
+    return sec;
+  }
+  const body = sec.slice(1);
+  let first = -1;
+  let last = -1;
+  for (let j = 0; j < body.length; j++) {
+    if (isPtBoundCodecAttributeLine(body[j]!)) {
+      if (first === -1) first = j;
+      last = j;
+    }
+  }
+  if (first === -1) {
+    return sec;
+  }
+
+  const prefix = body.slice(0, first);
+  const codecLines = body.slice(first, last + 1);
+  const suffix = body.slice(last + 1);
+
+  const mPts = payloadTypesFromSavpfMLine(mLine);
+  const buckets = new Map<number, string[]>();
+  for (const line of codecLines) {
+    const pt = payloadTypeFromPtBoundAttributeLine(line);
+    if (pt === null) continue;
+    const arr = buckets.get(pt);
+    if (arr) arr.push(line);
+    else buckets.set(pt, [line]);
+  }
+
+  const seenOrder: number[] = [];
+  for (const line of codecLines) {
+    const pt = payloadTypeFromPtBoundAttributeLine(line);
+    if (pt !== null && !seenOrder.includes(pt)) seenOrder.push(pt);
+  }
+
+  const outCodec: string[] = [];
+  for (const pt of mPts) {
+    const arr = buckets.get(pt);
+    if (!arr) continue;
+    outCodec.push(...arr);
+    buckets.delete(pt);
+  }
+  for (const pt of seenOrder) {
+    const arr = buckets.get(pt);
+    if (!arr) continue;
+    outCodec.push(...arr);
+    buckets.delete(pt);
+  }
+  for (const arr of buckets.values()) {
+    outCodec.push(...arr);
+  }
+
+  return [mLine, ...prefix, ...outCodec, ...suffix];
+}
+
+function reorderCodecAttributes(sdp: string): string {
+  const sep = sdpLineSeparator(sdp);
+  const lines = splitSdpLines(sdp);
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (!line.startsWith("m=")) {
+      out.push(line);
+      i++;
+      continue;
+    }
+    const mLine = line;
+    i++;
+    const rest: string[] = [];
+    while (i < lines.length && !lines[i]!.startsWith("m=")) {
+      rest.push(lines[i]!);
+      i++;
+    }
+    out.push(...reorderSingleRtpSavpfSection([mLine, ...rest]));
+  }
+  return joinSdpLines(out, sep);
+}
+
+function applyRemapToMediaAttributeLine(
+  line: string,
+  remap: Map<number, number>
+): string {
+  if (!line.startsWith("a=")) {
+    return line;
+  }
+
+  if (line.startsWith("a=rtpmap:")) {
+    const m = /^a=rtpmap:(\d+)/.exec(line);
+    if (!m) return line;
+    const pt = Number(m[1]);
+    const np = remap.get(pt) ?? pt;
+    return np === pt ? line : line.replace(/^a=rtpmap:\d+/, `a=rtpmap:${np}`);
+  }
+
+  if (line.startsWith("a=fmtp:")) {
+    const m = /^a=fmtp:(\d+)\s(.*)$/.exec(line);
+    if (!m) return line;
+    const pt = Number(m[1]);
+    const np = remap.get(pt) ?? pt;
+    const cfg = remapFmtpConfigForPayloadMap(m[2], remap);
+    return `a=fmtp:${np} ${cfg}`;
+  }
+
+  if (line.startsWith("a=rtcp-fb:")) {
+    const m = /^a=rtcp-fb:(\*|\d+)(\s.*)?$/.exec(line);
+    if (!m || m[1] === "*") return line;
+    const pt = Number(m[1]);
+    const np = remap.get(pt) ?? pt;
+    return np === pt ? line : `a=rtcp-fb:${np}${m[2] ?? ""}`;
+  }
+
+  if (line.startsWith("a=rtcp-fb-trr-int:")) {
+    const m = /^a=rtcp-fb-trr-int:(\*|\d+)(\s.*)?$/.exec(line);
+    if (!m || m[1] === "*") return line;
+    const pt = Number(m[1]);
+    const np = remap.get(pt) ?? pt;
+    return np === pt ? line : `a=rtcp-fb-trr-int:${np}${m[2] ?? ""}`;
+  }
+
+  if (line.startsWith("a=imageattrs:")) {
+    const m = /^a=imageattrs:(\*|\d+)(\s.*)?$/.exec(line);
+    if (!m || m[1] === "*") return line;
+    const pt = Number(m[1]);
+    const np = remap.get(pt) ?? pt;
+    return np === pt ? line : `a=imageattrs:${np}${m[2] ?? ""}`;
+  }
+
+  return line;
+}
+
+function stripTelephoneEventsPreserveOrder(sdp: string): string {
   const session = parse(sdp);
-  let changed = false;
-  for (const media of session.media) {
-    const telPts = new Set<number>();
+  const telPerSection = session.media.map((media) => {
+    const tel = new Set<number>();
     for (const r of media.rtp ?? []) {
-      if (/^telephone-event$/i.test(String(r.codec)))
-        telPts.add(Number(r.payload));
+      if (/^telephone-event$/i.test(String(r.codec))) {
+        tel.add(Number(r.payload));
+      }
     }
-    if (telPts.size === 0) continue;
-    changed = true;
-    media.rtp = (media.rtp ?? []).filter((r) => !telPts.has(Number(r.payload)));
-    media.payloads = mediaMLinePayloadTypes(media)
-      .filter((p) => !telPts.has(p))
-      .join(" ");
-    if (media.fmtp) {
-      media.fmtp = media.fmtp.filter((f) => !telPts.has(Number(f.payload)));
-    }
-    if (media.rtcpFb) {
-      media.rtcpFb = media.rtcpFb.filter(
-        (f) => f.payload === "*" || !telPts.has(Number(f.payload))
-      );
-    }
-    if (media.rtcpFbTrrInt) {
-      media.rtcpFbTrrInt = media.rtcpFbTrrInt.filter(
-        (f) => f.payload === "*" || !telPts.has(Number(f.payload))
-      );
-    }
+    return tel;
+  });
+  if (!telPerSection.some((s) => s.size > 0)) {
+    return sdp;
   }
-  return changed ? write(session) : sdp;
+
+  const sep = sdpLineSeparator(sdp);
+  const lines = splitSdpLines(sdp);
+  let secIdx = -1;
+  const out: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("m=")) {
+      secIdx++;
+      const drop = telPerSection[secIdx];
+      if (!drop || drop.size === 0 || !/\bRTP\/SAVPF\b/.test(line)) {
+        out.push(line);
+        continue;
+      }
+      const tokens = line.split(/\s+/);
+      const head = tokens.slice(0, 3).join(" ");
+      const nums = tokens
+        .slice(3)
+        .filter((t) => /^\d+$/.test(t))
+        .map(Number)
+        .filter((p) => !drop.has(p));
+      out.push(`${head} ${nums.join(" ")}`);
+      continue;
+    }
+    if (secIdx >= 0) {
+      const drop = telPerSection[secIdx];
+      if (drop && drop.size > 0) {
+        const rtp = /^a=rtpmap:(\d+)\s/i.exec(line);
+        if (rtp && drop.has(Number(rtp[1]))) continue;
+        const fmtp = /^a=fmtp:(\d+)\s/i.exec(line);
+        if (fmtp && drop.has(Number(fmtp[1]))) continue;
+        const rfb = /^a=rtcp-fb:(\d+)\s/i.exec(line);
+        if (rfb && drop.has(Number(rfb[1]))) continue;
+        const trr = /^a=rtcp-fb-trr-int:(\d+)\s/i.exec(line);
+        if (trr && drop.has(Number(trr[1]))) continue;
+      }
+    }
+    out.push(line);
+  }
+  return joinSdpLines(out, sep);
 }
 
-/**
- * Post-processes an SDP offer: selected codec payload types outside [96,127] are remapped
- * into the dynamic range. M-sections are processed in document order; new PTs avoid
- * collision with payload types already used on earlier m-lines.
- *
- * When no such change applies, returns the input string unchanged (avoids sdp-transform
- * normalizing session fields such as an implicit `s=` line).
- */
 function transformOfferSdpCodecDynamicPts(sdp: string): string {
   const session = parse(sdp);
   if (!session.media.some(mediaSectionNeedsSanitizedPtRelocate)) {
     return sdp;
   }
 
+  const remaps: Map<number, number>[] = [];
   const forbidden = new Set<number>();
   for (const media of session.media) {
-    remapSanitizedCodecPayloadTypesMedia(media, forbidden);
+    const R = computeCodecRemapForMedia(media, forbidden);
+    remaps.push(R);
     for (const p of mediaMLinePayloadTypes(media)) {
-      forbidden.add(p);
+      forbidden.add(R.get(p) ?? p);
     }
   }
 
-  return write(session);
+  const sep = sdpLineSeparator(sdp);
+  const lines = splitSdpLines(sdp);
+  let secIdx = -1;
+  const out: string[] = [];
+  for (let line of lines) {
+    if (line.startsWith("m=")) {
+      secIdx++;
+      const R = remaps[secIdx]!;
+      if (R.size > 0 && /\bRTP\/SAVPF\b/.test(line)) {
+        line = rewriteRtpSavpfMPayloads(line, (p) => R.get(p) ?? p);
+      }
+      out.push(line);
+      continue;
+    }
+    const R = secIdx >= 0 ? remaps[secIdx]! : null;
+    if (!R || R.size === 0) {
+      out.push(line);
+      continue;
+    }
+    out.push(applyRemapToMediaAttributeLine(line, R));
+  }
+  return joinSdpLines(out, sep);
 }
 
 export function sanitize(sdp: string): string {
-  return transformOfferSdpCodecDynamicPts(stripTelephoneEvents(sdp));
+  const stripped = stripTelephoneEventsPreserveOrder(sdp);
+  const remapped = transformOfferSdpCodecDynamicPts(stripped);
+  return reorderCodecAttributes(remapped);
 }

--- a/packages/js-sdk/src/utils/webrtc.ts
+++ b/packages/js-sdk/src/utils/webrtc.ts
@@ -28,54 +28,6 @@ const FORCE_RELAY_MODE = false;
  */
 const DEFAULT_MAX_MESSAGE_BYTES = 256 * 1024; // 256 KiB
 
-function isHevcMimeType(mimeType: string): boolean {
-  const t = mimeType.toLowerCase();
-  return (
-    t.includes("h265") ||
-    t.includes("hevc") ||
-    t.includes("hev1") ||
-    t.includes("hvc1")
-  );
-}
-
-/** Fields from RTCRtpCodecCapability used for setCodecPreferences. */
-type VideoCodecPreference = {
-  mimeType: string;
-  clockRate: number;
-  sdpFmtpLine?: string;
-  channels?: number;
-};
-
-function collectVideoCodecCapabilities(): VideoCodecPreference[] {
-  const seen = new Set<string>();
-  const out: VideoCodecPreference[] = [];
-  const add = (codecs: ReadonlyArray<VideoCodecPreference> | undefined) => {
-    if (!codecs) return;
-    for (const c of codecs) {
-      const key = `${c.mimeType}|${c.sdpFmtpLine ?? ""}|${c.clockRate}|${
-        c.channels ?? 0
-      }`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(c);
-    }
-  };
-  if (typeof RTCRtpSender !== "undefined" && RTCRtpSender.getCapabilities) {
-    add(RTCRtpSender.getCapabilities?.("video")?.codecs);
-  }
-  if (typeof RTCRtpReceiver !== "undefined" && RTCRtpReceiver.getCapabilities) {
-    add(RTCRtpReceiver.getCapabilities?.("video")?.codecs);
-  }
-  return out;
-}
-
-function transceiverIsVideo(t: RTCRtpTransceiver): boolean {
-  const extended = t as RTCRtpTransceiver & { kind?: string };
-  if (extended.kind === "video") return true;
-  if (extended.kind === "audio") return false;
-  return t.sender.track?.kind === "video" || t.receiver.track?.kind === "video";
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Peer Connection Creation
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### WHY

We were using `write()` method from `sdpTransform` module, but it results in a SDP grouped by rtpmap, fmtp and rtcp-fb lines. This somehow makes browser ignores ALL rtx options.

This PR replaces `write()` method with pure vanilla js.

Added some tests to cover this