### PR TITLE
[REA-2086] create-app: add --model flag with name->folder mapping

### DIFF
--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -5,70 +5,67 @@
 ## Quick Start
 
 ```bash
-npx create-reactor-app my-app
+npx create-reactor-app my-app --model=helios
 ```
 
 Or with pnpm:
 
 ```bash
-pnpm dlx create-reactor-app my-app
+pnpm dlx create-reactor-app my-app --model=helios
 ```
 
 ## Usage
 
-### Interactive Mode
-
-Simply run the command without arguments to be prompted for project details:
-
 ```bash
-npx create-reactor-app
+npx create-reactor-app [project-name] --model=<name> [options]
 ```
 
-You'll be asked to:
+The model argument is required. If you omit the project name, you will be prompted for it interactively.
 
-1. Enter your project name
-2. Select a template from available options
+**Arguments:**
 
-### Command Line Arguments
-
-You can also provide arguments directly:
-
-```bash
-npx create-reactor-app [project-name] [template] [options]
-```
+| Argument        | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `project-name`  | Name of the project to create (prompted if omitted)         |
 
 **Options:**
 
-| Option          | Description                                |
-| --------------- | ------------------------------------------ |
-| `--token`, `-t` | GitHub token for private repository access |
-| `--help`, `-h`  | Show help message                          |
+| Option          | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `--model`, `-m` | Model to scaffold a project for (required)               |
+| `--token`, `-t` | GitHub token for private repository access (optional)    |
+| `--help`, `-h`  | Show help message                                        |
 
 **Examples:**
 
 ```bash
-# Create a project with longlive template
-npx create-reactor-app my-game longlive
+# Project name first, model flag after
+npx create-reactor-app my-app --model=helios
 
-# Create a project with matrix template
-npx create-reactor-app my-matrix-app matrix-2
+# Flag first, project name after
+npx create-reactor-app --model=helios my-app
 
-# Create a project with a GitHub token (for private repos)
-npx create-reactor-app my-app longlive --token ghp_xxxxxxxxxxxx
+# Project name omitted — you will be prompted for it
+npx create-reactor-app --model=helios
+
+# With a GitHub token (only needed if the template repo is private)
+npx create-reactor-app my-app --model=helios --token ghp_xxxxxxxxxxxx
 ```
+
+### Available Models
+
+Templates live in the public [`reactor-team/reactor-experiments`](https://github.com/reactor-team/reactor-experiments) repository. The CLI ships with a small alias map so common model names resolve to their template folder:
+
+| `--model` value     | Template folder         |
+| ------------------- | ----------------------- |
+| `helios`            | `helios-interactive`    |
+| `film-director`     | `film-director`         |
+
+If you pass a model name that is not in the map, the CLI will look for a folder of that exact name in the templates repo. If neither resolves, it prints the available mappings and folders and exits.
 
 ### Private Repository Access
 
-If the repository is private, you'll be prompted to enter a GitHub token when:
-
-- Fetching available templates fails
-- Cloning the repository fails
-
-You can also pass the token directly via the `--token` (or `-t`) argument to skip the prompt.
-
-### Available Templates
-
-The CLI automatically fetches the latest templates from the repository.
+If the templates repository is private, you will be prompted for a GitHub token when fetching the template list or cloning fails. You can also pass `--token` (or `-t`) directly to skip the prompt.
 
 ## Getting Started After Creation
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -24,17 +24,17 @@ The model argument is required. If you omit the project name, you will be prompt
 
 **Arguments:**
 
-| Argument        | Description                                                 |
-| --------------- | ----------------------------------------------------------- |
-| `project-name`  | Name of the project to create (prompted if omitted)         |
+| Argument       | Description                                         |
+| -------------- | --------------------------------------------------- |
+| `project-name` | Name of the project to create (prompted if omitted) |
 
 **Options:**
 
-| Option          | Description                                              |
-| --------------- | -------------------------------------------------------- |
-| `--model`, `-m` | Model to scaffold a project for (required)               |
-| `--token`, `-t` | GitHub token for private repository access (optional)    |
-| `--help`, `-h`  | Show help message                                        |
+| Option          | Description                                           |
+| --------------- | ----------------------------------------------------- |
+| `--model`, `-m` | Model to scaffold a project for (required)            |
+| `--token`, `-t` | GitHub token for private repository access (optional) |
+| `--help`, `-h`  | Show help message                                     |
 
 **Examples:**
 
@@ -56,10 +56,10 @@ npx create-reactor-app my-app --model=helios --token ghp_xxxxxxxxxxxx
 
 Templates live in the public [`reactor-team/reactor-experiments`](https://github.com/reactor-team/reactor-experiments) repository. The CLI ships with a small alias map so common model names resolve to their template folder:
 
-| `--model` value     | Template folder         |
-| ------------------- | ----------------------- |
-| `helios`            | `helios-interactive`    |
-| `film-director`     | `film-director`         |
+| `--model` value | Template folder      |
+| --------------- | -------------------- |
+| `helios`        | `helios-interactive` |
+| `film-director` | `film-director`      |
 
 If you pass a model name that is not in the map, the CLI will look for a folder of that exact name in the templates repo. If neither resolves, it prints the available mappings and folders and exits.
 

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -43,7 +43,7 @@ The model argument is required. If you omit the project name, you will be prompt
 npx create-reactor-app my-app --model=helios
 
 # Flag first, project name after
-npx create-reactor-app --model=helios my-app
+npx create-reactor-app --model=lingbot my-app
 
 # Project name omitted — you will be prompted for it
 npx create-reactor-app --model=helios
@@ -54,14 +54,11 @@ npx create-reactor-app my-app --model=helios --token ghp_xxxxxxxxxxxx
 
 ### Available Models
 
-Templates live in the public [`reactor-team/reactor-experiments`](https://github.com/reactor-team/reactor-experiments) repository. The CLI ships with a small alias map so common model names resolve to their template folder:
+Templates live in the [`reactor-team/reactor-experiments`](https://github.com/reactor-team/reactor-experiments) repository. By default the model name maps 1:1 to a top-level folder of the same name (e.g. `--model=helios` clones the `helios/` folder).
 
-| `--model` value | Template folder      |
-| --------------- | -------------------- |
-| `helios`        | `helios-interactive` |
-| `film-director` | `film-director`      |
+The CLI also supports an optional alias map (`MODEL_MAP` in `bin/create-reactor-app.ts`) for cases where the public model name needs to differ from the folder name. It is empty by default — add an entry only when you want a name → folder rename.
 
-If you pass a model name that is not in the map, the CLI will look for a folder of that exact name in the templates repo. If neither resolves, it prints the available mappings and folders and exits.
+Run the CLI without `--model` to see the list of available models in the templates repo. The output lists explicit aliases first (with the resolved folder shown after `→`) and then any remaining unmapped folders.
 
 ### Private Repository Access
 

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -10,7 +10,26 @@ const REPO_OWNER = "reactor-team";
 const REPO_NAME = "reactor-experiments";
 const REPO_URL = `github.com/${REPO_OWNER}/${REPO_NAME}.git`;
 const EXAMPLES_PATH = "";
-const DEFAULT_TEMPLATE = "helios-interactive";
+
+// Maps a Reactor model name to its folder in the templates repo.
+// If a name is not present here, it is used as the folder name directly.
+const MODEL_MAP: Record<string, string> = {
+  helios: "helios-interactive",
+  "film-director": "film-director",
+};
+
+function resolveTemplateFolder(name: string): string {
+  return MODEL_MAP[name] ?? name;
+}
+
+function formatAvailableModels(repoTemplates: string[]): string {
+  const known = Object.keys(MODEL_MAP).sort();
+  const folders = [...repoTemplates].sort();
+  return [
+    `  Known models:    ${known.length > 0 ? known.join(", ") : "(none)"}`,
+    `  Repo folders:    ${folders.length > 0 ? folders.join(", ") : "(none)"}`,
+  ].join("\n");
+}
 
 function getAuthenticatedRepoUrl(token: string): string {
   return `https://${token}@${REPO_URL}`;
@@ -71,13 +90,13 @@ async function promptForToken(): Promise<string | undefined> {
 
 function parseArgs(args: string[]): {
   projectName?: string;
-  template?: string;
+  model?: string;
   token?: string;
   help: boolean;
 } {
   const result: {
     projectName?: string;
-    template?: string;
+    model?: string;
     token?: string;
     help: boolean;
   } = { help: false };
@@ -91,40 +110,45 @@ function parseArgs(args: string[]): {
       result.token = args[++i];
     } else if (arg.startsWith("--token=")) {
       result.token = arg.split("=")[1];
+    } else if (arg === "--model" || arg === "-m") {
+      result.model = args[++i];
+    } else if (arg.startsWith("--model=")) {
+      result.model = arg.slice("--model=".length);
     } else if (!arg.startsWith("-")) {
       positionalArgs.push(arg);
     }
   }
 
   result.projectName = positionalArgs[0];
-  result.template = positionalArgs[1];
 
   return result;
 }
 
 function showUsage(): void {
+  const known = Object.keys(MODEL_MAP).sort().join(", ") || "(none)";
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
   console.log(
-    chalk.white("  create-reactor-app [project-name] [template] [options]\n")
+    chalk.white("  create-reactor-app [project-name] --model=<name> [options]\n")
   );
   console.log(chalk.white("Arguments:"));
-  console.log(chalk.white("  project-name  Name of the project to create"));
   console.log(
-    chalk.white(
-      "  template      Template to use (longlive, matrix-2, mk64, etc.)\n"
-    )
+    chalk.white("  project-name  Name of the project to create (prompted if omitted)\n")
   );
   console.log(chalk.white("Options:"));
+  console.log(
+    chalk.white("  --model, -m   Model to scaffold a project for (required)")
+  );
   console.log(
     chalk.white("  --token, -t   GitHub token for private repository access")
   );
   console.log(chalk.white("  --help, -h    Show this help message\n"));
-  console.log(
-    chalk.white(
-      "If arguments are not provided, you will be prompted interactively.\n"
-    )
-  );
+  console.log(chalk.white("Known models:"));
+  console.log(chalk.white(`  ${known}\n`));
+  console.log(chalk.white("Examples:"));
+  console.log(chalk.white("  create-reactor-app my-app --model=helios"));
+  console.log(chalk.white("  create-reactor-app --model=helios my-app"));
+  console.log(chalk.white("  create-reactor-app --model=helios\n"));
 }
 
 async function main(): Promise<void> {
@@ -133,7 +157,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     projectName: argProjectName,
-    template: argTemplate,
+    model: argModel,
     token: argToken,
     help,
   } = parseArgs(args);
@@ -175,10 +199,30 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Validate template argument if provided
-  if (argTemplate && !templates.includes(argTemplate)) {
-    console.error(chalk.red(`Template "${argTemplate}" is not available.`));
-    console.log(chalk.white("Available templates:"), templates.join(", "));
+  // Require --model; if missing, print known + repo folders and exit
+  if (!argModel) {
+    console.error(
+      chalk.red("\n❌ No model specified. Use --model=<name>.\n")
+    );
+    console.log(chalk.white("Available models:"));
+    console.log(chalk.white(formatAvailableModels(templates)));
+    console.log();
+    process.exit(1);
+  }
+
+  // Resolve folder via mapping (fallback: model name itself)
+  const template = resolveTemplateFolder(argModel);
+
+  // Validate the resolved folder exists in the repo
+  if (!templates.includes(template)) {
+    console.error(
+      chalk.red(
+        `\n❌ Model "${argModel}" not found (resolved to folder "${template}").\n`
+      )
+    );
+    console.log(chalk.white("Available models:"));
+    console.log(chalk.white(formatAvailableModels(templates)));
+    console.log();
     process.exit(1);
   }
 
@@ -215,14 +259,8 @@ async function main(): Promise<void> {
     }
   }
 
-  if (!argTemplate) {
-    answers.template = DEFAULT_TEMPLATE;
-    console.log(chalk.green(`Using default template "${DEFAULT_TEMPLATE}"`));
-  }
-
   // Use provided arguments or prompted answers
   const projectName = argProjectName || answers.projectName;
-  const template = argTemplate || answers.template;
   const dest = path.resolve(process.cwd(), projectName);
 
   if (fs.existsSync(dest)) {
@@ -230,7 +268,9 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log(chalk.green(`\nCloning template "${template}"...\n`));
+  console.log(
+    chalk.green(`\nCloning model "${argModel}" (folder: ${template})...\n`)
+  );
 
   const git = simpleGit();
 
@@ -303,7 +343,7 @@ async function main(): Promise<void> {
 
   console.log(
     chalk.green(
-      `\n✅ Project "${projectName}" created successfully using "${template}" template!\n`
+      `\n✅ Project "${projectName}" created successfully using model "${argModel}"!\n`
     )
   );
   console.log(chalk.cyan("Next steps:"));

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -129,11 +129,15 @@ function showUsage(): void {
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
   console.log(
-    chalk.white("  create-reactor-app [project-name] --model=<name> [options]\n")
+    chalk.white(
+      "  create-reactor-app [project-name] --model=<name> [options]\n"
+    )
   );
   console.log(chalk.white("Arguments:"));
   console.log(
-    chalk.white("  project-name  Name of the project to create (prompted if omitted)\n")
+    chalk.white(
+      "  project-name  Name of the project to create (prompted if omitted)\n"
+    )
   );
   console.log(chalk.white("Options:"));
   console.log(
@@ -201,9 +205,7 @@ async function main(): Promise<void> {
 
   // Require --model; if missing, print known + repo folders and exit
   if (!argModel) {
-    console.error(
-      chalk.red("\n❌ No model specified. Use --model=<name>.\n")
-    );
+    console.error(chalk.red("\n❌ No model specified. Use --model=<name>.\n"));
     console.log(chalk.white("Available models:"));
     console.log(chalk.white(formatAvailableModels(templates)));
     console.log();

--- a/packages/create-app/bin/create-reactor-app.ts
+++ b/packages/create-app/bin/create-reactor-app.ts
@@ -11,24 +11,42 @@ const REPO_NAME = "reactor-experiments";
 const REPO_URL = `github.com/${REPO_OWNER}/${REPO_NAME}.git`;
 const EXAMPLES_PATH = "";
 
-// Maps a Reactor model name to its folder in the templates repo.
-// If a name is not present here, it is used as the folder name directly.
-const MODEL_MAP: Record<string, string> = {
-  helios: "helios-interactive",
-  "film-director": "film-director",
-};
+// Aliases for cases where a model's public name differs from its template
+// folder in the repo. Leave empty when names map 1:1 to folders.
+const MODEL_MAP: Record<string, string> = {};
 
 function resolveTemplateFolder(name: string): string {
   return MODEL_MAP[name] ?? name;
 }
 
 function formatAvailableModels(repoTemplates: string[]): string {
-  const known = Object.keys(MODEL_MAP).sort();
-  const folders = [...repoTemplates].sort();
-  return [
-    `  Known models:    ${known.length > 0 ? known.join(", ") : "(none)"}`,
-    `  Repo folders:    ${folders.length > 0 ? folders.join(", ") : "(none)"}`,
-  ].join("\n");
+  const lines: string[] = [];
+
+  // Section 1: explicit name → folder aliases, with the resolved folder
+  // shown in a lighter, italic style.
+  const mappings = Object.entries(MODEL_MAP).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [name, folder] of mappings) {
+    if (repoTemplates.includes(folder)) {
+      lines.push(`  ${name}${chalk.dim.italic(` → ${folder}`)}`);
+    }
+  }
+
+  // Section 2: remaining folders that aren't already covered by an alias.
+  const mappedTargets = new Set(Object.values(MODEL_MAP));
+  const remaining = repoTemplates
+    .filter((folder) => !mappedTargets.has(folder))
+    .sort();
+  for (const folder of remaining) {
+    lines.push(`  ${folder}`);
+  }
+
+  if (lines.length === 0) {
+    lines.push("  (none)");
+  }
+
+  return lines.join("\n");
 }
 
 function getAuthenticatedRepoUrl(token: string): string {
@@ -125,7 +143,6 @@ function parseArgs(args: string[]): {
 }
 
 function showUsage(): void {
-  const known = Object.keys(MODEL_MAP).sort().join(", ") || "(none)";
   console.log(chalk.cyan("\n⚛️ Create Reactor App\n"));
   console.log(chalk.white("Usage:"));
   console.log(
@@ -147,11 +164,12 @@ function showUsage(): void {
     chalk.white("  --token, -t   GitHub token for private repository access")
   );
   console.log(chalk.white("  --help, -h    Show this help message\n"));
-  console.log(chalk.white("Known models:"));
-  console.log(chalk.white(`  ${known}\n`));
+  console.log(
+    chalk.white("Run without --model to see the list of available models.\n")
+  );
   console.log(chalk.white("Examples:"));
   console.log(chalk.white("  create-reactor-app my-app --model=helios"));
-  console.log(chalk.white("  create-reactor-app --model=helios my-app"));
+  console.log(chalk.white("  create-reactor-app --model=lingbot my-app"));
   console.log(chalk.white("  create-reactor-app --model=helios\n"));
 }
 
@@ -203,11 +221,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Require --model; if missing, print known + repo folders and exit
+  // Require --model; if missing, print available models and exit
   if (!argModel) {
     console.error(chalk.red("\n❌ No model specified. Use --model=<name>.\n"));
     console.log(chalk.white("Available models:"));
-    console.log(chalk.white(formatAvailableModels(templates)));
+    console.log(formatAvailableModels(templates));
     console.log();
     process.exit(1);
   }
@@ -217,13 +235,13 @@ async function main(): Promise<void> {
 
   // Validate the resolved folder exists in the repo
   if (!templates.includes(template)) {
+    const resolvedHint =
+      template !== argModel ? ` (resolved to folder "${template}")` : "";
     console.error(
-      chalk.red(
-        `\n❌ Model "${argModel}" not found (resolved to folder "${template}").\n`
-      )
+      chalk.red(`\n❌ Model "${argModel}" not found${resolvedHint}.\n`)
     );
     console.log(chalk.white("Available models:"));
-    console.log(chalk.white(formatAvailableModels(templates)));
+    console.log(formatAvailableModels(templates));
     console.log();
     process.exit(1);
   }
@@ -270,9 +288,8 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log(
-    chalk.green(`\nCloning model "${argModel}" (folder: ${template})...\n`)
-  );
+  const cloneSuffix = template !== argModel ? ` (folder: ${template})` : "";
+  console.log(chalk.green(`\nCloning model "${argModel}"${cloneSuffix}...\n`));
 
   const git = simpleGit();
 

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-reactor-app",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "bin": {
     "create-reactor-app": "dist/bin/create-reactor-app.js"
   },


### PR DESCRIPTION
## Summary

Replaces the second positional template argument and silent `helios-interactive` default in `create-reactor-app` with a required `--model=<name>` flag, backed by a tiny in-code mapping that resolves a model name to a folder in the public [`reactor-team/reactor-experiments`](https://github.com/reactor-team/reactor-experiments) repo.

Linear: [REA-2086](https://linear.app/reactor-team/issue/REA-2086/allow-multiple-models-in-create-app-cli)

Closes REA-2086.

## What changed

- New `MODEL_MAP` constant in `packages/create-app/bin/create-reactor-app.ts`:
  - `helios -> helios-interactive`
  - `film-director -> film-director`
- Unmapped model names fall back to being used as the folder name directly, so any folder in the templates repo is reachable without code changes to the CLI.
- New `--model` / `-m` flag, accepted as `--model=<value>` or `--model <value>`. It may appear before or after the project-name positional.
- Behavior when `--model` is missing or resolves to a non-existent folder: print the known mapping keys and the current repo folder list, exit non-zero. No interactive model picker.
- Project name is still prompted when omitted, so `create-reactor-app --model=helios` works without any positional.
- Removed the previous silent default to `helios-interactive` (from commit `c18f5f4`); model selection is now always explicit.
- README updated with the new flag, the alias table, and the three supported invocation styles.
- Version bumped `2.0.4` -> `2.1.0` (removal of the second `[template]` positional is a breaking change for anyone relying on it).

## CLI shape

```bash
create-reactor-app my-app --model=helios
create-reactor-app my-app --model helios
create-reactor-app --model=helios my-app
create-reactor-app --model=helios          # project name prompted
create-reactor-app                          # prints known + repo folders, exits 1
```

## Test plan

Smoke-tested the built CLI from `dist/`:

- [x] `--help` shows the new usage and lists `Known models: film-director, helios`.
- [x] `create-reactor-app my-app` (no `--model`) prints "No model specified" with the known + repo folder list and exits 1.
- [x] `create-reactor-app my-app --model=nonexistent` prints `Model "nonexistent" not found` with the same list and exits 1.
- [ ] End-to-end clone with `--model=helios` against the public repo (not run here; relies on a clean cwd and `pnpm install` inside the scaffolded project).

## Notes / follow-ups

- Multi-model composition (comma-separated `--model=a,b`) is intentionally out of scope.
- Namespacing (`vendor/name`) is forward-compatible: if introduced, namespaced keys can be added to `MODEL_MAP` without changing the resolver.