### PR TITLE
js-sdk: bump to 2.9.3 + matching codegen defaultSdkVersion

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -28,7 +28,7 @@ The codegen reads a model's OpenAPI schema (events, messages, tracks) and produc
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output ./out/helios
 ```
 
@@ -94,7 +94,7 @@ Use `--standalone` when you want the typed client as a single `.ts` file inside 
 # Drop a typed Helios client into an existing project's src/ folder.
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output ./src/helios.ts \
   --standalone
 ```
@@ -108,7 +108,7 @@ Pass `--react` to additionally emit a React entry point. The provider, hooks, an
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output ./out/helios \
   --react
 ```
@@ -257,20 +257,20 @@ The generated `package.json` strips a leading `v` from the schema's `info.versio
 # Run codegen against the test schema (Helios)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output .generated/helios
 
 # Dry-run to preview output without writing files
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output .generated/helios \
   --dry-run
 
 # With React hooks (adds src/react.ts; root re-export — no `/react` subpath)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.2 \
+  --sdk-version 2.9.3 \
   --output .generated/helios \
   --react
 
@@ -314,7 +314,7 @@ const schema = parseSchema(rawSchema);
 const pkg = generateModelSdk({
   modelName: schema.modelName,
   modelVersion: schema.modelVersion,
-  sdkVersion: "2.9.2",
+  sdkVersion: "2.9.3",
   schema,
   outputDir: "./out/helios",
 });

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -71,7 +71,7 @@ describe("reactor-codegen CLI — argument validation", () => {
           "utf-8",
         ),
       );
-      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.2");
+      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.3");
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -25,14 +25,14 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.2 --output .generated/example"
+    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.3 --output .generated/example"
   },
   "keywords": [
     "reactor",
     "codegen",
     "sdk"
   ],
-  "defaultSdkVersion": "2.9.2",
+  "defaultSdkVersion": "2.9.3",
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "devDependencies": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Why
---
The published `@reactor-team/js-sdk@2.9.2` declares
`ReactorProviderProps.children` as required:

    interface ReactorProviderProps extends ReactorInitializationProps {
      ...
      children: ReactNode;
    }

The codegen's React emitter (`generateProviderComponent`) passes
`children` as the third positional argument to `createElement(...)`,
which only type-checks when `children` is optional on the target
props type. The DTS build of every generated React package
therefore fails:

    src/react.ts(85,5): error TS2769: No overload matches this call.
      Property 'children' is missing in type '...'
      but required in type 'ReactorProviderProps'.

`origin/main` already carries the source fix (f560b42, #136), which
relaxed `children` to optional, but it hasn't been republished — so
every `@reactor-models/*` Buildkite publish run is currently broken.

What changed
------------
- `packages/js-sdk/package.json`: 2.9.2 -> 2.9.3 (PATCH; bundles
  the optional-children relaxation plus the bitrate-stats and
  SDP-sanitize fixes already merged since 2.9.2).
- `packages/codegen/package.json`: `defaultSdkVersion` 2.9.2 -> 2.9.3
  and the `codegen:test` script's `--sdk-version` to match, so every
  newly-generated `@reactor-models/*` pins to a `js-sdk` that has the
  fix and the regression test pinning the third-arg `createElement`
  form (emitter.test.ts:1798) keeps passing.
- `packages/codegen/__tests__/cli.test.ts`: assertion that the
  generated `package.json` dep is `^2.9.3` (the test exists precisely
  to verify the default flows through; matched to the new value).
- `packages/codegen/README.md`: example `--sdk-version` flags and the
  programmatic API snippet bumped for consistency.

Once this lands and a `v2.9.3` GitHub Release is cut, the next
scheduled Buildkite `MODELS_SYNC=true` run republishes lingbot et al.
against the fixed js-sdk with no further code changes.

Tests: `pnpm --filter @reactor-team/codegen test` (319 pass) and
`pnpm --filter @reactor-team/js-sdk test:unit` (284 pass) locally.

Co-authored-by: Cursor <cursoragent@cursor.com>