### PR TITLE
[codegen] generated model class extends Reactor

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -342,19 +342,45 @@ const unsub = helios.onChunkComplete((msg) => {
   console.log(`Chunk ${msg.chunk_index}: ${msg.frames_emitted} frames`);
 });
 
-// File uploads
+// File uploads — inherited from Reactor
 const ref = await helios.uploadFile(imageBlob);
 await helios.setImage({ image: ref });
+
+// Connection events — inherited from Reactor (`on`/`off`/`emit`/`getStats`/…
+// are all directly callable on the model instance)
+helios.on("statusChanged", (status) => {
+  /* ... */
+});
 
 // Options (optional)
 const heliosLocal = new HeliosModel({ local: true });
 const heliosCustom = new HeliosModel({ apiUrl: "https://custom.api.com" });
-
-// Access the underlying Reactor instance for advanced use
-helios.reactor.on("statusChanged", (status) => {
-  /* ... */
-});
 ```
+
+### Inheritance from `Reactor`
+
+The generated `<Prefix>Model` class **extends `Reactor` directly** rather than wrapping it. Every public method on the SDK's `Reactor` class — `connect`, `disconnect`, `reconnect`, `sendCommand`, `uploadFile`, `publishTrack`, `unpublishTrack`, `on`/`off`/`emit`, the `get*` accessors — is reachable on the model instance with no codegen wrapper involved. Future additions to the SDK (such as the recording client's `requestClip` / `requestRecording` / `downloadClipAsFile`) flow into every generated `<Prefix>Model` the moment downstream packages re-pin to a `js-sdk` version that ships them; no codegen PR or regeneration is required for the _surface_ to expand (only for the typed sugar on top to grow, when new events/messages are added to the model's schema).
+
+For backwards compatibility with code written against the previous composition shape, a deprecated `get reactor(): this` accessor is emitted:
+
+```typescript
+helios.reactor.on("statusChanged", handler); // still works, marked @deprecated
+helios.on("statusChanged", handler); // preferred — directly on the instance
+```
+
+The accessor returns `this` so subclass-only methods (`helios.setPrompt(...)`, etc.) remain reachable through it. It will be removed in a future major version of the generated packages.
+
+#### Maintaining the inheritance contract
+
+The verifier needs to know which method names are reserved so a schema can't declare an event whose camelCase form silently shadows an inherited Reactor method (e.g. an event literally called `send_command`). Rather than maintain a hand-edited list, the verifier **parses `@reactor-team/js-sdk`'s `dist/index.d.ts` at module-load time** and extracts every non-`private`/`protected` method declared on the `Reactor` class — see `loadReactorPublicMethodsFromDts` in [`src/verifier.ts`](src/verifier.ts).
+
+Consequences:
+
+- **Adding a public method to `Reactor`** in the SDK requires zero codegen changes. The next codegen run that resolves to a newer `js-sdk` install picks up the new surface automatically.
+- **The only knob is `defaultSdkVersion`** in this package's `package.json` — it controls which `js-sdk` release generated packages pin to in their `dependencies["@reactor-team/js-sdk"]`. The codegen package itself depends on `@reactor-team/js-sdk` (`workspace:*` in this repo, rewritten to the concrete version on publish) so the d.ts is always reachable at runtime.
+- **TS-private methods are skipped** — the d.ts emission preserves the `private` keyword, and the loader's regex explicitly excludes those, so internal helpers (`setStatus`, `setupTransportHandlers`, …) don't appear as reserved names. They're runtime-reachable on `Reactor.prototype` but not part of the inheritable type surface.
+
+The d.ts shape is uniformly formatted by tsup (4-space class-body indent, visibility keywords preserved); the loader's regex is anchored to that. If a future tsup/api-extractor change alters that shape, the loader's internal floor check ("must find at least `connect`, `disconnect`, `sendCommand`") trips at codegen startup with a pointed error rather than silently shipping an under-protected verifier.
 
 ### Parallel SDP preparation
 

--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -604,10 +604,14 @@ describe("generateModelSdk", () => {
     expect(withSrc.content).toContain(
       'import { Reactor, FileRef } from "@reactor-team/js-sdk";',
     );
-    expect(withSrc.content).toContain("async uploadFile(");
     // Re-export FileRef so consumers can type `const ref: FileRef = ...`
     // without pulling in a second import from `@reactor-team/js-sdk`.
     expect(withSrc.content).toContain("export { FileRef };");
+    // `uploadFile` is now inherited from `Reactor` (the generated
+    // class is `extends Reactor`), so the subclass body must NOT
+    // emit a typed wrapper — that would be a duplicate-method TS
+    // compile error.
+    expect(withSrc.content).not.toContain("async uploadFile(");
     expect(withoutSrc.content).toContain(
       'import { Reactor } from "@reactor-team/js-sdk";',
     );
@@ -639,11 +643,9 @@ describe("generateModelSdk", () => {
     expect(src).toContain(
       "async schedulePrompt(params: HeliosSchedulePromptParams)",
     );
-    expect(src).toContain(
-      'await this.reactor.sendCommand("schedule_prompt", params);',
-    );
+    expect(src).toContain('await this.sendCommand("schedule_prompt", params);');
     expect(src).toContain("async start():");
-    expect(src).toContain('await this.reactor.sendCommand("start", {});');
+    expect(src).toContain('await this.sendCommand("start", {});');
   });
 
   it("wires per-message listener helpers onto the discriminated union", () => {
@@ -797,11 +799,20 @@ describe("generateModelSdk", () => {
     });
 
     const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
-    expect(src).not.toContain("modelTracks");
-    expect(src).not.toContain("HeliosTracks");
-    expect(src).toContain(
-      "this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });",
-    );
+    // Look for the property-emit form (`modelTracks: [...HeliosTracks]`)
+    // and the tracks constant array, both of which are guarded on
+    // `hasTracks`. We intentionally do NOT match the bare word
+    // `modelTracks` — the class-level JSDoc references it as part of
+    // documenting the constructor shape, and that doc text is present
+    // on every generated class regardless of whether the schema
+    // declares any tracks.
+    expect(src).not.toContain("modelTracks: [");
+    expect(src).not.toContain("export const HeliosTracks = [");
+    // No-tracks path keeps the constructor on a single line; the
+    // `extends Reactor` + `super(...)` shape is otherwise identical
+    // to the tracks-declared path (just without `modelTracks`).
+    expect(src).toContain("export class HeliosModel extends Reactor {");
+    expect(src).toContain("super({ ...options, modelName: MODEL_NAME });");
   });
 
   it("is deterministic for a given input (same output twice)", () => {
@@ -818,6 +829,111 @@ describe("generateModelSdk", () => {
     const a = generateModelSdk(opts);
     const b = generateModelSdk(opts);
     expect(a).toEqual(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inheritance shape: the generated `<Prefix>Model` extends `Reactor`
+// directly (rather than composing one) so every public method on
+// `Reactor` is reachable on the subclass without a hand-rolled
+// passthrough in this emitter. Pins:
+//   - `extends Reactor` in the class header
+//   - `super(...)` (not `this.reactor = new Reactor(...)`) in the
+//     constructor body — tracks-on path and no-tracks path both
+//   - the deprecated `get reactor(): this` backwards-compat accessor
+//     so existing call sites of `helios.reactor.X(...)` keep working
+//   - the absence of hand-rolled `connect` / `disconnect` /
+//     `uploadFile` passthrough methods (which would shadow the
+//     inherited versions and produce TS compile errors on overrides)
+// ---------------------------------------------------------------------------
+
+describe("emitter — inheritance shape", () => {
+  function indexOf(opts: {
+    events?: EventSchema[];
+    messages?: MessageSchema[];
+    tracks?: TrackSchema[];
+  }) {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.3",
+      schema: schema({
+        events: opts.events ?? [],
+        messages: opts.messages ?? [],
+        tracks: opts.tracks ?? [],
+      }),
+      outputDir: "/tmp/ignored",
+    });
+    return pkg.files.find((f) => f.path === "src/index.ts")!.content;
+  }
+
+  it("emits `extends Reactor` on the class header", () => {
+    const src = indexOf({});
+    expect(src).toContain("export class HeliosModel extends Reactor {");
+  });
+
+  it("calls `super(...)` (no `new Reactor(...)`) in the constructor body", () => {
+    const noTracks = indexOf({});
+    expect(noTracks).toContain("super({ ...options, modelName: MODEL_NAME });");
+    // The old composition form must be fully gone — no `new Reactor(...)`
+    // anywhere in the generated source.
+    expect(noTracks).not.toContain("new Reactor(");
+    expect(noTracks).not.toContain("readonly reactor:");
+    expect(noTracks).not.toContain("this.reactor =");
+
+    const withTracks = indexOf({
+      tracks: [{ name: "main_video", kind: "video", direction: "out" }],
+    });
+    expect(withTracks).toContain("super({");
+    expect(withTracks).toContain("modelName: MODEL_NAME,");
+    expect(withTracks).toContain("modelTracks: [...HeliosTracks],");
+    expect(withTracks).not.toContain("new Reactor(");
+  });
+
+  it("emits a deprecated `get reactor(): this` backwards-compat accessor", () => {
+    const src = indexOf({});
+    expect(src).toContain("get reactor(): this {");
+    expect(src).toContain("return this;");
+    // The accessor must carry an `@deprecated` JSDoc tag so IDE
+    // tooling strikes through call sites and lint rules can flag uses.
+    const reactorIdx = src.indexOf("get reactor(): this");
+    expect(reactorIdx).toBeGreaterThan(-1);
+    const docWindow = src.slice(Math.max(0, reactorIdx - 400), reactorIdx);
+    expect(docWindow).toContain("@deprecated");
+  });
+
+  it("does not emit hand-rolled `connect` / `disconnect` passthroughs (inherited from Reactor)", () => {
+    const src = indexOf({});
+    expect(src).not.toContain("async connect(jwtToken");
+    expect(src).not.toContain("async disconnect():");
+  });
+
+  it("inherits `sendCommand` — typed event methods call `this.sendCommand(...)`", () => {
+    const src = indexOf({
+      events: [
+        {
+          name: "set_prompt",
+          description: "",
+          fields: { prompt: { type: "string" } },
+        },
+      ],
+    });
+    expect(src).toContain('await this.sendCommand("set_prompt", params);');
+    // The old `this.reactor.sendCommand` form must be gone.
+    expect(src).not.toContain("this.reactor.sendCommand");
+  });
+
+  it("inherits `on` / `off` — onMessage and recvonly-track helpers call `this.on(...)` / `this.off(...)`", () => {
+    const src = indexOf({
+      messages: [{ name: "prompt_accepted", description: "", fields: {} }],
+      tracks: [{ name: "main_video", kind: "video", direction: "out" }],
+    });
+    expect(src).toContain('this.on("message", wrappedHandler);');
+    expect(src).toContain('this.off("message", wrappedHandler);');
+    expect(src).toContain('this.on("trackReceived", wrapped);');
+    expect(src).toContain('this.off("trackReceived", wrapped);');
+    expect(src).not.toContain("this.reactor.on(");
+    expect(src).not.toContain("this.reactor.off(");
   });
 });
 
@@ -1381,11 +1497,9 @@ describe("emitter — typed track helpers (REA-1791)", () => {
       { name: "webcam", kind: "video", direction: "in" },
     ]);
     expect(index).toContain("async publishWebcam(track: MediaStreamTrack)");
-    expect(index).toContain(
-      'await this.reactor.publishTrack("webcam", track);',
-    );
+    expect(index).toContain('await this.publishTrack("webcam", track);');
     expect(index).toContain("async unpublishWebcam(): Promise<void>");
-    expect(index).toContain('await this.reactor.unpublishTrack("webcam");');
+    expect(index).toContain('await this.unpublishTrack("webcam");');
   });
 
   it("emits an `on<Name>` subscription per recvonly track, filtering by name internally", () => {
@@ -1397,17 +1511,20 @@ describe("emitter — typed track helpers (REA-1791)", () => {
       "const wrapped = (name: string, t: MediaStreamTrack, s: MediaStream) => {",
     );
     expect(index).toContain('if (name === "main_video") handler(t, s);');
-    expect(index).toContain('this.reactor.on("trackReceived", wrapped);');
-    expect(index).toContain(
-      'return () => this.reactor.off("trackReceived", wrapped);',
-    );
+    expect(index).toContain('this.on("trackReceived", wrapped);');
+    expect(index).toContain('return () => this.off("trackReceived", wrapped);');
   });
 
   it("does not emit any track methods when the schema has no tracks", () => {
     const { index } = sourceOf([]);
-    expect(index).not.toContain("publishTrack");
-    expect(index).not.toContain("unpublishTrack");
-    expect(index).not.toContain('this.reactor.on("trackReceived"');
+    // `publishTrack` / `unpublishTrack` are inherited from Reactor on
+    // every generated class — we're checking that the schema-derived
+    // sugar (`publish<Name>` / `unpublish<Name>` typed wrappers) is
+    // absent, not the inherited base methods. Match the call-site
+    // strings that only show up inside the schema-derived sugar.
+    expect(index).not.toContain('await this.publishTrack("');
+    expect(index).not.toContain('await this.unpublishTrack("');
+    expect(index).not.toContain('this.on("trackReceived"');
   });
 
   // ---- React hook ------------------------------------------------------

--- a/packages/codegen/__tests__/verifier.test.ts
+++ b/packages/codegen/__tests__/verifier.test.ts
@@ -322,8 +322,30 @@ describe("verifySchema — reserved identifier classes", () => {
     expect(__testing__.DANGEROUS_PROPERTY_KEYS.has("toJSON")).toBe(true);
   });
 
-  it.each(["connect", "disconnect", "on_message", "upload_file"])(
-    "rejects event %s — shadows a built-in client class method",
+  // The rejection cases are *derived* from `RESERVED_CLASS_METHODS`
+  // (which is itself d.ts-derived in the verifier) by reversing the
+  // codegen's `toCamelCase` transform. This means a future js-sdk
+  // release that adds e.g. `requestClip` to the inheritable surface
+  // automatically lights up a `request_clip` rejection test on the
+  // next `defaultSdkVersion` bump — no hand-edited mirror list.
+  //
+  // The camel-to-snake reversal is the inverse of `toCamelCase` (lower
+  // the first char, then `_<lower>` for every uppercase letter). It's
+  // unambiguous for the snake_case → camelCase shapes the verifier
+  // accepts (no consecutive uppercase letters in any Reactor method
+  // name), so the round-trip is faithful.
+  const camelToSnake = (s: string): string =>
+    s.replace(/([A-Z])/g, (_, c) => `_${(c as string).toLowerCase()}`);
+  const reservedAsSnakeCase = [...__testing__.RESERVED_CLASS_METHODS]
+    .map(camelToSnake)
+    // The verifier's `STRICT_SNAKE_CASE_RE` requires segments of `+`,
+    // not `*`, after a leading `_`. Defensive filter (no current name
+    // produces an invalid shape; this just future-proofs).
+    .filter((s) => /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(s))
+    .sort();
+
+  it.each(reservedAsSnakeCase)(
+    "rejects event %s — shadows a built-in or inherited client method",
     (badName) => {
       const schema = baseSchema({ events: [event(badName)] });
 
@@ -338,7 +360,8 @@ describe("verifySchema — reserved identifier classes", () => {
           (p) =>
             p.includes("shadowing the built-in") ||
             p.includes("class method") ||
-            p.includes("emitted twice"),
+            p.includes("emitted twice") ||
+            p.includes("inherited"),
         ),
       ).toBe(true);
     },
@@ -787,5 +810,67 @@ describe("generateModelSdk integration", () => {
     expect(src).toContain('export const MODEL_NAME = "my-cool-model"');
     // npm package name keeps the hyphenated form (npm convention).
     expect(pkgJson.name).toBe("@reactor-models/my-cool-model");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inheritance contract: the verifier auto-derives the Reactor public
+// surface from `@reactor-team/js-sdk`'s installed `index.d.ts` at
+// module load time (see `loadReactorPublicMethodsFromDts` in
+// `verifier.ts`). This means future `js-sdk` releases that add new
+// public methods (e.g. the recording stack adds `requestClip`,
+// `requestRecording`, `downloadClipAsFile`) flow into the verifier
+// automatically on the next `defaultSdkVersion` bump — no hand-edited
+// reserved list and no parity test to keep updated.
+//
+// The tests below sanity-check that the loader actually found a
+// reasonable surface (so a future tsup d.ts format change can't
+// silently produce an empty set), not that the set contains every
+// method — that's what the loader's own internal floor check is for.
+// ---------------------------------------------------------------------------
+
+describe("RESERVED_CLASS_METHODS — d.ts-derived surface", () => {
+  it("includes the canonical Reactor lifecycle + IO methods", () => {
+    const reserved = __testing__.RESERVED_CLASS_METHODS;
+    // Spot-check across the major method groups:
+    //   - lifecycle: connect / disconnect / reconnect
+    //   - commands: sendCommand / uploadFile / publishTrack
+    //   - events: on / off / emit
+    //   - getters: at least getStats
+    //   - scaffold: onMessage (NOT on Reactor; added by codegen)
+    for (const name of [
+      "connect",
+      "disconnect",
+      "reconnect",
+      "sendCommand",
+      "uploadFile",
+      "publishTrack",
+      "unpublishTrack",
+      "on",
+      "off",
+      "emit",
+      "getStats",
+      "onMessage",
+    ]) {
+      expect(reserved.has(name)).toBe(true);
+    }
+  });
+
+  it("does not include TS-private methods (e.g. setStatus, setupTransportHandlers)", () => {
+    // The d.ts loader filters by the `private` keyword that tsup
+    // preserves in the emitted declarations. TS-private methods would
+    // be runtime-reachable on Reactor.prototype but are not part of
+    // the inheritable type surface, so claiming them in the verifier
+    // would reject schemas the type system would otherwise accept.
+    const reserved = __testing__.RESERVED_CLASS_METHODS;
+    for (const name of [
+      "setStatus",
+      "setSessionId",
+      "setupTransportHandlers",
+      "createError",
+      "finalizeConnectionTimings",
+    ]) {
+      expect(reserved.has(name)).toBe(false);
+    }
   });
 });

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -35,6 +35,9 @@
   "defaultSdkVersion": "2.9.3",
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
+  "dependencies": {
+    "@reactor-team/js-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsup": "^8.5.0",

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -490,7 +490,6 @@ function generateClientClass(
 ): string {
   const className = `${modelPrefix}Model`;
   const optionsType = `${modelPrefix}Options`;
-  const needsFileRef = events.some(hasUploadRefParam);
   const hasTracks = tracks.length > 0;
 
   const lines: string[] = [];
@@ -498,33 +497,49 @@ function generateClientClass(
   const classDoc = [
     `Strongly-typed client for the ${modelPrefix} model.`,
     "",
-    "Creates a Reactor connection with the model name pre-configured.",
-    "Provides typed methods for every event and typed message listeners.",
+    `Extends {@link Reactor} with the model name (and modelTracks) baked into the`,
+    `constructor, so every public method on Reactor — \`connect\`, \`disconnect\`,`,
+    "`sendCommand`, `on`/`off`, `getStats`, `publishTrack`/`unpublishTrack`,",
+    "etc. — is reachable directly on the instance. The schema-derived sugar",
+    "below adds typed wrappers for every declared event, message, and track.",
   ];
   lines.push(generateJsDoc(classDoc, 0));
-  lines.push(`export class ${className} {`);
-  lines.push(`  readonly reactor: Reactor;`);
-  lines.push("");
+  // `extends Reactor` makes every public Reactor method part of the
+  // subclass's surface for free — including new methods on future
+  // `@reactor-team/js-sdk` releases (e.g. the recording stack). The
+  // verifier's `RESERVED_CLASS_METHODS` set is kept in lockstep with
+  // Reactor's prototype keys (parity test in `verifier.test.ts`) so a
+  // schema event whose camelCase shadows an inherited method is
+  // rejected before it can produce a duplicate-member compile error.
+  lines.push(`export class ${className} extends Reactor {`);
   lines.push(`  constructor(options?: ${optionsType}) {`);
   if (hasTracks) {
-    lines.push(`    this.reactor = new Reactor({`);
+    lines.push(`    super({`);
     lines.push(`      ...options,`);
     lines.push(`      modelName: MODEL_NAME,`);
     lines.push(`      modelTracks: [...${modelPrefix}Tracks],`);
     lines.push(`    });`);
   } else {
-    lines.push(
-      `    this.reactor = new Reactor({ ...options, modelName: MODEL_NAME });`,
-    );
+    lines.push(`    super({ ...options, modelName: MODEL_NAME });`);
   }
   lines.push(`  }`);
   lines.push("");
-  lines.push(`  async connect(jwtToken?: string): Promise<void> {`);
-  lines.push(`    await this.reactor.connect(jwtToken);`);
-  lines.push(`  }`);
-  lines.push("");
-  lines.push(`  async disconnect(): Promise<void> {`);
-  lines.push(`    await this.reactor.disconnect();`);
+  // Backwards-compat alias for the previous composition-based shape
+  // (`model.reactor.X(...)`). Returns `this` so call sites that read
+  // `helios.reactor.on(...)`, `helios.reactor.getStats()`, etc. keep
+  // working without forcing every downstream consumer to migrate in
+  // lockstep with this codegen change. Typed as `this` (not `Reactor`)
+  // so subclass methods stay reachable through the alias.
+  lines.push(
+    indent(
+      generateJsDoc([
+        `@deprecated The model client now extends \`Reactor\` directly — call methods on \`this\` instead. This accessor returns \`this\` for backwards compatibility and will be removed in a future major release.`,
+      ]),
+      1,
+    ),
+  );
+  lines.push(`  get reactor(): this {`);
+  lines.push(`    return this;`);
   lines.push(`  }`);
 
   for (const event of events) {
@@ -556,12 +571,12 @@ function generateClientClass(
         `  async ${methodName}(params: ${paramType}): Promise<void> {`,
       );
       lines.push(
-        `    await this.reactor.sendCommand(${JSON.stringify(event.name)}, params);`,
+        `    await this.sendCommand(${JSON.stringify(event.name)}, params);`,
       );
     } else {
       lines.push(`  async ${methodName}(): Promise<void> {`);
       lines.push(
-        `    await this.reactor.sendCommand(${JSON.stringify(event.name)}, {});`,
+        `    await this.sendCommand(${JSON.stringify(event.name)}, {});`,
       );
     }
     lines.push(`  }`);
@@ -581,8 +596,8 @@ function generateClientClass(
     lines.push(`    const wrappedHandler = (raw: unknown) => {`);
     lines.push(`      handler(_unwrapMessage<${modelPrefix}Message>(raw));`);
     lines.push(`    };`);
-    lines.push(`    this.reactor.on("message", wrappedHandler);`);
-    lines.push(`    return () => this.reactor.off("message", wrappedHandler);`);
+    lines.push(`    this.on("message", wrappedHandler);`);
+    lines.push(`    return () => this.off("message", wrappedHandler);`);
     lines.push(`  }`);
 
     for (const message of messages) {
@@ -610,20 +625,15 @@ function generateClientClass(
     }
   }
 
-  if (needsFileRef) {
-    lines.push("");
-    const uploadDoc = [
-      "Upload a file and get a FileRef for use in events.",
-      "@param file - File or Blob to upload",
-      "@param options - Optional name override",
-    ];
-    lines.push(indent(generateJsDoc(uploadDoc), 1));
-    lines.push(
-      `  async uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef> {`,
-    );
-    lines.push(`    return this.reactor.uploadFile(file, options);`);
-    lines.push(`  }`);
-  }
+  // Note: `uploadFile` is inherited from `Reactor` directly — every
+  // generated class gets it via `extends Reactor` without a typed
+  // wrapper here. Earlier revisions of this emitter emitted a thin
+  // passthrough so the method only appeared when the schema declared
+  // an upload-reference event; with inheritance that conditional is
+  // moot (the method always exists on the base class). The
+  // `<Prefix>Options` type and `FileRef` re-export are still gated on
+  // `needsFileRef` because they're authored at the generated-package
+  // level, not inherited.
 
   // Typed track helpers — one publish/unpublish pair per sendonly track
   // and one `on<Name>` subscription per recvonly track. Keeps the
@@ -631,10 +641,10 @@ function generateClientClass(
   // messages ({model}.onFoo(...)) so consumers never hand-write a
   // track name as a string literal.
   //
-  // The generic `reactor.publishTrack(name, ...)` /
-  // `reactor.on("trackReceived", ...)` APIs remain reachable through
-  // `{model}.reactor` for callers that need to pass a dynamic name —
-  // this generator only emits per-schema sugar.
+  // The generic `publishTrack(name, ...)` / `on("trackReceived", ...)`
+  // APIs remain reachable directly on `this` (inherited from Reactor)
+  // for callers that need to pass a dynamic name — this generator only
+  // emits per-schema sugar.
   for (const track of sendonlyTracks(tracks)) {
     const pascal = toPascalCase(track.name);
     const kindNote = track.kind === "audio" ? " audio" : " video";
@@ -655,7 +665,7 @@ function generateClientClass(
       `  async publish${pascal}(track: MediaStreamTrack): Promise<void> {`,
     );
     lines.push(
-      `    await this.reactor.publishTrack(${JSON.stringify(track.name)}, track);`,
+      `    await this.publishTrack(${JSON.stringify(track.name)}, track);`,
     );
     lines.push(`  }`);
 
@@ -671,9 +681,7 @@ function generateClientClass(
       ),
     );
     lines.push(`  async unpublish${pascal}(): Promise<void> {`);
-    lines.push(
-      `    await this.reactor.unpublishTrack(${JSON.stringify(track.name)});`,
-    );
+    lines.push(`    await this.unpublishTrack(${JSON.stringify(track.name)});`);
     lines.push(`  }`);
   }
 
@@ -702,8 +710,8 @@ function generateClientClass(
       `      if (name === ${JSON.stringify(track.name)}) handler(t, s);`,
     );
     lines.push(`    };`);
-    lines.push(`    this.reactor.on("trackReceived", wrapped);`);
-    lines.push(`    return () => this.reactor.off("trackReceived", wrapped);`);
+    lines.push(`    this.on("trackReceived", wrapped);`);
+    lines.push(`    return () => this.off("trackReceived", wrapped);`);
     lines.push(`  }`);
   }
 

--- a/packages/codegen/src/verifier.ts
+++ b/packages/codegen/src/verifier.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type {
   EventSchema,
   FieldSchema,
@@ -47,11 +49,15 @@ import { toCamelCase, toPascalCase } from "./emitter.js";
 //   2. RESERVED identifiers — names that, after case transformation,
 //      would collide with the JS prototype chain (`__proto__`,
 //      `constructor`, `toString`, `toJSON`, …), with JS reserved words
-//      (`default`, `let`, `null`, `void`, …), with the class scaffold's
-//      own built-in methods (`connect`, `disconnect`, `onMessage`,
-//      `uploadFile`) or properties (`reactor`), with the React hook's
-//      reserved fields (`status`, `connect`, `disconnect`, `uploadFile`,
-//      `sendCommand`), or with the message discriminator field (`type`).
+//      (`default`, `let`, `null`, `void`, …), with methods inherited
+//      from `Reactor` (the generated class extends it — the list is
+//      **auto-derived** from the installed `@reactor-team/js-sdk`'s
+//      `dist/index.d.ts` at module load time, so any new public method
+//      on a future js-sdk release flows through with no hand-edit
+//      here), the scaffold's catch-all `onMessage`, the deprecated
+//      `reactor` getter, the React hook's reserved fields (`status`,
+//      `connect`, `disconnect`, `uploadFile`, `sendCommand`), or the
+//      message discriminator field (`type`).
 //
 //   3. SURFACE COLLISION detection — every public symbol the emitter
 //      would write is computed up front and de-duplicated across
@@ -395,17 +401,115 @@ const DANGEROUS_PROPERTY_KEYS = new Set<string>([
 ]);
 
 /**
- * Methods the emitter unconditionally writes onto `<Prefix>Model`. An
- * event whose camelCase transform matches one of these would emit a
- * duplicate method on the generated class — TS compile error if both
- * are typed identically, silent override if not.
+ * Methods reachable on `<Prefix>Model` — either inherited from
+ * {@link Reactor} (every public method on its prototype, since the
+ * generated class is `extends Reactor`) or unconditionally written by
+ * the emitter scaffold (`onMessage` when the schema declares messages).
+ *
+ * An event/message/track whose camelCase / `on<Pascal>` transform
+ * matches one of these names would either shadow an inherited method
+ * (silent override at runtime) or compile-error on duplicate-method
+ * declaration. The verifier rejects both up front.
+ *
+ * The Reactor portion is **derived automatically** from the installed
+ * `@reactor-team/js-sdk` package's `index.d.ts` at module-load time
+ * (see {@link loadReactorPublicMethodsFromDts}). No hand-maintained
+ * mirror — any public method `js-sdk` declares is picked up on the
+ * next `defaultSdkVersion` bump, including future additions (e.g. the
+ * recording stack's `requestClip` / `requestRecording` /
+ * `downloadClipAsFile`).
+ *
+ * Only the scaffold-only `onMessage` name has to be added explicitly,
+ * because it's not declared on Reactor itself but is unconditionally
+ * emitted by the codegen onto every subclass that has messages.
  */
-const RESERVED_CLASS_METHODS = new Set<string>([
-  "connect",
-  "disconnect",
-  "onMessage",
-  "uploadFile",
-]);
+const RESERVED_CLASS_METHODS: Set<string> = (() => {
+  const set = loadReactorPublicMethodsFromDts();
+  // Scaffold-only: the emitter writes a typed `onMessage` wrapper onto
+  // the subclass when the schema declares at least one message. It's
+  // NOT on Reactor.prototype, so the d.ts loader doesn't see it.
+  set.add("onMessage");
+  return set;
+})();
+
+/**
+ * Read the installed `@reactor-team/js-sdk` package's bundled
+ * `index.d.ts` and extract the names of every non-private method
+ * declared on the `Reactor` class. This is the source of truth for
+ * what the verifier needs to reject as a schema-side collision.
+ *
+ * Why parse the d.ts (and not, say, `Object.getOwnPropertyNames(
+ * Reactor.prototype)`):
+ *
+ *   - The prototype walk includes TS-`private` methods, which survive
+ *     compilation because TS visibility is compile-time only. Those
+ *     methods are NOT inheritable in the type system, so a schema
+ *     event of the same name cannot collide with them.
+ *   - The d.ts emission, on the other hand, preserves the `private`
+ *     keyword (e.g. `private setStatus;`), so a single regex sweep
+ *     gives us exactly the type-visible public surface — which is
+ *     what `extends Reactor` actually exposes to a subclass author.
+ *
+ * The loader runs once at module load (the IIFE that populates
+ * {@link RESERVED_CLASS_METHODS} above). If `js-sdk` is missing or
+ * the d.ts cannot be parsed, the loader throws — that's a hard
+ * dependency failure and we'd rather fail loud at codegen startup
+ * than emit an under-protected verifier that silently accepts
+ * shadowing schemas.
+ */
+function loadReactorPublicMethodsFromDts(): Set<string> {
+  // `require.resolve` locates the package's main entry; the d.ts ships
+  // alongside it under `dist/index.d.ts` (tsup config in js-sdk). Walk
+  // up one level to reach the d.ts. Works in both pnpm-workspace mode
+  // (symlinked source build) and published-npm mode (real tarball).
+  const sdkEntry = require.resolve("@reactor-team/js-sdk");
+  const dtsPath = path.join(path.dirname(sdkEntry), "index.d.ts");
+  const dts = fs.readFileSync(dtsPath, "utf-8");
+
+  // Find the `declare class Reactor` block. The trailing `^}` anchors
+  // on a top-level `}` (no indentation) so a nested object literal in
+  // a method signature doesn't terminate the match early.
+  const classMatch = dts.match(/declare class Reactor\b[^{]*\{([\s\S]*?)^\}/m);
+  if (!classMatch) {
+    throw new Error(
+      "Codegen verifier: could not locate `declare class Reactor` block in " +
+        `${dtsPath}. The d.ts format may have changed; update the regex in ` +
+        "`loadReactorPublicMethodsFromDts` and the matching docstring.",
+    );
+  }
+  const body = classMatch[1];
+
+  // Method declarations at the class's 4-space indent. Negative
+  // lookahead skips `private ` / `protected ` members (those don't
+  // form part of the inheritable surface). We require `(` or `<`
+  // immediately after the name so the regex doesn't accidentally
+  // match property declarations like `readonly recording:
+  // RecordingClient;` — properties land in
+  // {@link RESERVED_CLASS_PROPERTIES} via a separate code path if
+  // ever needed.
+  const methodRe = /^ {4}(?!private |protected )([a-zA-Z_$][\w$]*)\s*[(<]/gm;
+  const out = new Set<string>();
+  for (const match of body.matchAll(methodRe)) {
+    const name = match[1];
+    if (name !== "constructor") out.add(name);
+  }
+
+  // Sanity floor: the loader must find AT LEAST the canonical lifecycle
+  // surface. A zero-result parse almost certainly means the d.ts shape
+  // has changed in a way the regex doesn't tolerate; surfacing that
+  // here is more useful than silently shipping an under-protected
+  // verifier set.
+  for (const required of ["connect", "disconnect", "sendCommand"]) {
+    if (!out.has(required)) {
+      throw new Error(
+        `Codegen verifier: d.ts parse of ${dtsPath} did not find the ` +
+          `\`${required}\` method on the Reactor class. The d.ts shape may ` +
+          "have changed; update `loadReactorPublicMethodsFromDts`.",
+      );
+    }
+  }
+  return out;
+}
 
 /**
  * Properties on the `<Prefix>Model` instance. `reactor` is the
@@ -567,7 +671,7 @@ class VerifyContext {
         this.fail(
           `event ${JSON.stringify(event.name)} would emit method ` +
             `\`${camel}()\`, shadowing the built-in \`${camel}()\` on the ` +
-            `generated client class`,
+            `generated client class (inherited from Reactor or built into the scaffold)`,
         );
       }
       if (RESERVED_CLASS_PROPERTIES.has(camel)) {
@@ -703,18 +807,28 @@ class VerifyContext {
   }
 
   private checkClassMethodCollisions(schema: ModelSchema): void {
-    // The class scaffold already declares these unconditionally — they
-    // count as the "first source" so an event/message/track that would
+    // The class scaffold inherits every Reactor public method (via
+    // `extends Reactor` in the emitter output) and unconditionally
+    // writes `onMessage` when the schema has messages. They count as
+    // the "first source" so an event / message / track that would
     // emit a duplicate is reported with both sides of the conflict.
-    const claims = new Map<string, string>([
-      ["connect", "built-in `connect()` on the client class"],
-      ["disconnect", "built-in `disconnect()` on the client class"],
-      ["onMessage", "built-in catch-all `onMessage()` listener"],
-      [
-        "uploadFile",
-        "built-in `uploadFile()` (when any event takes an upload reference)",
-      ],
-    ]);
+    //
+    // The Reactor-side claims are seeded from the SAME d.ts-derived
+    // set the rule-level check uses — so when js-sdk grows a method
+    // (e.g. recording adds `requestClip`), both the rejection and the
+    // error message flow through automatically without a second list
+    // to maintain.
+    const claims = new Map<string, string>();
+    for (const name of RESERVED_CLASS_METHODS) {
+      if (name === "onMessage") {
+        claims.set(name, "built-in catch-all `onMessage()` listener");
+      } else {
+        claims.set(
+          name,
+          `inherited \`${name}()\` from \`Reactor\` (base class)`,
+        );
+      }
+    }
 
     const claim = (name: string, source: string): void => {
       const prior = claims.get(name);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,10 @@ importers:
         version: 3.8.1
 
   packages/codegen:
+    dependencies:
+      '@reactor-team/js-sdk':
+        specifier: workspace:*
+        version: link:../js-sdk
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
Why
---
The previous generated `<Prefix>Model` composed a `Reactor` instance
behind a `readonly reactor: Reactor` field and hand-rolled passthrough
methods for `connect` / `disconnect` / `uploadFile` etc. Every time the
SDK grew a new public method, the codegen needed a parallel PR to
emit a wrapper, and consumers had to use `helios.reactor.X(...)` for
anything not yet wrapped.

After this change the generated class extends Reactor directly, so
every public method on the SDK is reachable on the model instance with
zero codegen wrapper involved. Future js-sdk additions (e.g. the
recording stack adds `requestClip` / `requestRecording` /
`downloadClipAsFile`) flow into every generated `@reactor-models/*`
the moment downstream packages re-pin to a js-sdk that ships them —
no codegen PR or regeneration is required for the surface to expand.

What changed
------------
- `packages/codegen/src/emitter.ts` (`generateClientClass`):
  generated class is now `class <Prefix>Model extends Reactor`, the
  constructor calls `super({ ...options, modelName, modelTracks? })`,
  and every internal `this.reactor.X(...)` call site is replaced with
  `this.X(...)`. Hand-rolled `connect` / `disconnect` / `uploadFile`
  passthrough methods are removed (now inherited). A deprecated
  `get reactor(): this` accessor stays for backwards compatibility
  with code that already calls `helios.reactor.X(...)`.

- `packages/codegen/src/verifier.ts` (`RESERVED_CLASS_METHODS`):
  replaced the hand-edited 17-name list with a d.ts-derived loader.
  `loadReactorPublicMethodsFromDts()` reads
  `@reactor-team/js-sdk`'s installed `dist/index.d.ts` at module load
  time and extracts every non-private/protected method on the
  `declare class Reactor` block. The `onMessage` scaffold name is
  added explicitly (it's not on Reactor itself). The
  `checkClassMethodCollisions` claims map is seeded from the same
  derived set, so the rule check and the error-message catalog stay
  in lockstep without a second list to maintain.

- `packages/codegen/package.json`: `@reactor-team/js-sdk` moves from
  devDep to runtime dep (`workspace:*`, rewritten to the concrete
  version on publish) so the d.ts is reachable at codegen run time
  in both workspace and published-npm modes.

- `packages/codegen/__tests__/`: snapshot/contain assertions updated
  from `this.reactor.X(...)` to `this.X(...)` (8 sites). A new
  `emitter — inheritance shape` describe block pins `extends Reactor`,
  the `super(...)` shape, the deprecated `get reactor(): this`
  accessor, the absence of hand-rolled passthroughs, and that
  `sendCommand` / `on` / `off` flow through `this` rather than
  `this.reactor`. The verifier-side parity test is replaced by two
  smoke tests on the d.ts-derived set, and the rejection it.each
  list is itself derived from the reserved set via a camel→snake
  reversal, so adding a new Reactor method automatically lights up
  new rejection coverage on the next defaultSdkVersion bump.

- `packages/codegen/README.md`: `Generated package usage` snippet
  calls methods directly on the model; new `Inheritance from Reactor`
  subsection explains the deprecated `.reactor` accessor; new
  `Maintaining the inheritance contract` subsection documents the
  d.ts-derivation contract and the floor check.

Forward compatibility
---------------------
When the recording stack lands on js-sdk and bumps the SDK version,
the codegen flow is:

  1. Bump `defaultSdkVersion` in `packages/codegen/package.json` to
     the recording-aware release.
  2. The d.ts loader re-runs on next install and automatically picks
     up `requestClip` / `requestRecording` / `downloadClipAsFile` as
     reserved names — no verifier edit, no test edit, no emitter
     edit.

Tests: `pnpm --filter @reactor-team/codegen test` (341 pass) and
`pnpm --filter @reactor-team/js-sdk test:unit` (284 pass). E2E:
`pnpm codegen:test` regenerates + builds the example fixture end to
end against the freshly-published 2.9.3 js-sdk.

Co-authored-by: Cursor <cursoragent@cursor.com>