### PR TITLE
[codegen] react hook + provider derive surface from js-sdk d.ts

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -370,17 +370,33 @@ helios.on("statusChanged", handler); // preferred — directly on the instance
 
 The accessor returns `this` so subclass-only methods (`helios.setPrompt(...)`, etc.) remain reachable through it. It will be removed in a future major version of the generated packages.
 
-#### Maintaining the inheritance contract
+#### Maintaining the inheritance / hook / provider contract
 
-The verifier needs to know which method names are reserved so a schema can't declare an event whose camelCase form silently shadows an inherited Reactor method (e.g. an event literally called `send_command`). Rather than maintain a hand-edited list, the verifier **parses `@reactor-team/js-sdk`'s `dist/index.d.ts` at module-load time** and extracts every non-`private`/`protected` method declared on the `Reactor` class — see `loadReactorPublicMethodsFromDts` in [`src/verifier.ts`](src/verifier.ts).
+Three pieces of the codegen output mirror the SDK's surface:
+
+1. **Generated class `<Prefix>Model extends Reactor`** — every public method on the SDK's `Reactor` class is reachable on the instance.
+2. **Generated hook `use<Prefix>()`** — exposes every public field on the SDK's `ReactorStore` (`ReactorState & ReactorActions`) as a Zustand selector, alongside one typed method per model event.
+3. **Generated provider `<Prefix>Provider`** — accepts every prop `ReactorProvider` does (minus `modelName` / `modelTracks`, which it bakes in) and forwards them via `...rest` spread.
+
+Rather than maintain hand-edited lists of "what's on the SDK", all three derive from the **installed `@reactor-team/js-sdk`'s `dist/index.d.ts` at codegen runtime** (see [`src/sdk-surface.ts`](src/sdk-surface.ts)):
+
+| Codegen output                                                                                          | Source of truth                                                                                                                                                                                                                 | Loader                            |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `RESERVED_CLASS_METHODS` in verifier (rejects schemas that would shadow a class method)                 | `declare class Reactor { ... }` block in d.ts                                                                                                                                                                                   | `loadReactorPublicMethodsFromDts` |
+| `RESERVED_HOOK_FIELDS` in verifier (rejects schemas that would shadow a store field on the hook return) | `interface ReactorState { ... }` + `interface ReactorActions { ... }` blocks in d.ts                                                                                                                                            | `loadReactorStoreFieldsFromDts`   |
+| `use<Prefix>()` selectors in emitter                                                                    | Same two interfaces as above (same loader)                                                                                                                                                                                      | `loadReactorStoreFieldsFromDts`   |
+| `<Prefix>Options` / `<Prefix>ProviderProps` in emitter                                                  | `Reactor` / `ReactorProvider` function signatures, projected via `ConstructorParameters<typeof Reactor>[0]` / `Parameters<typeof ReactorProvider>[0]` in the emitted TS source — resolved by the consumer's TypeScript compiler | (type-level; no runtime loader)   |
 
 Consequences:
 
-- **Adding a public method to `Reactor`** in the SDK requires zero codegen changes. The next codegen run that resolves to a newer `js-sdk` install picks up the new surface automatically.
-- **The only knob is `defaultSdkVersion`** in this package's `package.json` — it controls which `js-sdk` release generated packages pin to in their `dependencies["@reactor-team/js-sdk"]`. The codegen package itself depends on `@reactor-team/js-sdk` (`workspace:*` in this repo, rewritten to the concrete version on publish) so the d.ts is always reachable at runtime.
-- **TS-private methods are skipped** — the d.ts emission preserves the `private` keyword, and the loader's regex explicitly excludes those, so internal helpers (`setStatus`, `setupTransportHandlers`, …) don't appear as reserved names. They're runtime-reachable on `Reactor.prototype` but not part of the inheritable type surface.
+- **Adding a public method to `Reactor`** in the SDK requires zero codegen changes. The class-side inheritance flow picks it up on the next install, and the verifier's reserved set widens automatically.
+- **Adding a field to `ReactorState` or `ReactorActions`** in the SDK requires zero codegen changes. The hook emits a new selector for it, the return object includes it, and the verifier's hook reserved set widens automatically — all on the next install.
+- **Adding a prop to `ReactorProvider`** requires zero codegen changes. The derived `<Prefix>ProviderProps` widens via the TS `Parameters<typeof ReactorProvider>[0]` projection, and the `...rest` spread inside the provider body forwards it through.
+- **The only knob is `defaultSdkVersion`** in this package's `package.json` — it controls which `js-sdk` release generated packages pin to. The codegen package itself depends on `@reactor-team/js-sdk` (`workspace:*` in this repo, rewritten to the concrete version on publish) so the d.ts is always reachable at runtime.
+- **TS-private methods are skipped** — the d.ts emission preserves the `private` keyword, and the class loader's regex explicitly excludes those, so internal helpers (`setStatus`, `setupTransportHandlers`, …) don't appear as reserved names. They're runtime-reachable on `Reactor.prototype` but not part of the inheritable type surface.
+- **The `internal` field on `ReactorStore` is skipped** — it exposes the underlying `Reactor` handle for the SDK's own React layer, not for consumer code reading through `useReactor`.
 
-The d.ts shape is uniformly formatted by tsup (4-space class-body indent, visibility keywords preserved); the loader's regex is anchored to that. If a future tsup/api-extractor change alters that shape, the loader's internal floor check ("must find at least `connect`, `disconnect`, `sendCommand`") trips at codegen startup with a pointed error rather than silently shipping an under-protected verifier.
+The d.ts shape is uniformly formatted by tsup (4-space class-body / interface-body indent, visibility keywords preserved on class members, identifier-clean interface names). Each loader has an internal floor check ("must find at least `connect`, `disconnect`, `sendCommand`") that trips at codegen startup with a pointed error if a future tsup / api-extractor change alters that shape — preferable to silently shipping an under-protected verifier or an empty hook.
 
 ### Parallel SDP preparation
 

--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -1076,7 +1076,12 @@ describe("React emission — on via react: true", () => {
   it("Provider omits modelTracks for schemas without tracks", () => {
     const react = reactSource({ tracks: [] });
     expect(react).toContain("export function HeliosProvider(");
-    expect(react).not.toContain("modelTracks");
+    // The class-level JSDoc on the Provider references `modelTracks`
+    // generically — we're asserting the *prop emit* is absent, not
+    // the doc text. Look for the actual `modelTracks: [...XTracks]`
+    // line that only appears when `hasTracks` is true.
+    expect(react).not.toContain("modelTracks: [...");
+    expect(react).not.toContain("HeliosTracks");
   });
 
   it("emits a useHelios() hook with a typed method per event", () => {
@@ -1092,6 +1097,9 @@ describe("React emission — on via react: true", () => {
     });
 
     expect(react).toContain("export function useHelios()");
+    // Store-field selector for sendCommand is derived from the SDK's
+    // `ReactorActions` interface in the d.ts; every typed event method
+    // below it calls the captured `sendCommand` directly.
     expect(react).toContain(
       "const sendCommand = useReactor((s) => s.sendCommand);",
     );
@@ -1102,6 +1110,66 @@ describe("React emission — on via react: true", () => {
     expect(react).toContain("start: (): Promise<void>");
     expect(react).toContain('sendCommand("start", {})');
     expect(react).toContain("status,");
+  });
+
+  it("derives the full store surface — every public field on ReactorState/ReactorActions appears as a selector", () => {
+    // This pins the d.ts-derivation contract. The list below is a
+    // *snapshot* of what `ReactorState & ReactorActions` exposes on
+    // the currently-pinned `defaultSdkVersion`. New fields the SDK
+    // adds will fail this test — at which point the fix is to extend
+    // the expected list to match the new shape (and rely on the
+    // verifier's floor check to confirm the canonical fields are
+    // still present).
+    //
+    // The point isn't to gold-master the entire surface forever; it's
+    // to make a deliberate decision the day the SDK widens the
+    // contract.
+    const react = reactSource({
+      events: [{ name: "start", description: "", fields: {} }],
+    });
+    for (const field of [
+      // ReactorState
+      "status",
+      "sessionId",
+      "sessionExpiration",
+      "lastError",
+      "tracks",
+      "jwtToken",
+      // ReactorActions
+      "connect",
+      "disconnect",
+      "reconnect",
+      "sendCommand",
+      "uploadFile",
+      "publish",
+      "unpublish",
+    ]) {
+      expect(react).toContain(
+        `const ${field} = useReactor((s) => s.${field});`,
+      );
+    }
+    // None of the schema-derived methods should accidentally shadow
+    // a store selector — that's the verifier's job, but pinning the
+    // observable effect here documents the invariant.
+    expect(react).not.toContain("connect: (");
+    expect(react).not.toContain("disconnect: (");
+  });
+
+  it("emits `<Prefix>Options` and `<Prefix>ProviderProps` as type aliases derived from Reactor / ReactorProvider", () => {
+    // The old shape was a hand-rolled `interface` per type. Type
+    // aliases let us project from the SDK's own types via
+    // `Omit<Parameters<typeof X>[0], ...>`, so new SDK constructor
+    // options / provider props flow through without a codegen edit.
+    const react = reactSource({
+      tracks: [{ name: "main", kind: "video", direction: "out" }],
+    });
+    expect(react).toContain("export type HeliosProviderProps = Omit<");
+    expect(react).toContain("Parameters<typeof ReactorProvider>[0]");
+    expect(react).toContain(`"modelName" | "modelTracks"`);
+    // Provider body uses `{ children, ...rest }` spread, not named
+    // forwarding — the rest spread is what guarantees future
+    // ReactorProvider props pass through without a codegen edit.
+    expect(react).toContain("...rest");
   });
 
   it("exposes connect + disconnect on useHelios() so consumers don't need @reactor-team/js-sdk directly", () => {
@@ -1124,7 +1192,14 @@ describe("React emission — on via react: true", () => {
     expect(react).toMatch(/return\s*\{[\s\S]*\bdisconnect,[\s\S]*\}/);
   });
 
-  it("exposes uploadFile only when events use upload references", () => {
+  it("exposes uploadFile on useHelios() unconditionally — it's a store field", () => {
+    // Old behaviour: the codegen emitted a typed `uploadFile` wrapper
+    // ONLY when an event took an upload-reference param. That gated
+    // the SDK's actual `uploadFile` action behind a schema feature
+    // it has no logical dependency on. The new shape derives store
+    // selectors from the SDK's d.ts (`ReactorActions`), so
+    // `uploadFile` — like every other store action — is always
+    // reachable on `useHelios()` regardless of schema content.
     const withUpload = reactSource({
       events: [
         {
@@ -1140,12 +1215,19 @@ describe("React emission — on via react: true", () => {
       events: [{ name: "start", description: "", fields: {} }],
     });
 
-    expect(withUpload).toContain(
-      "const uploadFile = useReactor((s) => s.uploadFile);",
-    );
-    expect(withUpload).toContain("uploadFile: (");
-    expect(withUpload).toContain("type FileRef");
-    expect(withoutUpload).not.toContain("s.uploadFile");
+    for (const src of [withUpload, withoutUpload]) {
+      expect(src).toContain(
+        "const uploadFile = useReactor((s) => s.uploadFile);",
+      );
+      // Both source files include `uploadFile` shorthand in the return
+      // object, but match it with a comma boundary so the assertion
+      // doesn't accidentally also match a typed wrapper line.
+      expect(src).toMatch(/uploadFile,/);
+    }
+    // The React file no longer names `FileRef` — events that take a
+    // FileRef get their `<Prefix><Event>Params` interface emitted in
+    // `index.ts` and the hook just passes it through `sendCommand(...)`.
+    expect(withUpload).not.toContain("type FileRef");
     expect(withoutUpload).not.toContain("type FileRef");
   });
 

--- a/packages/codegen/__tests__/verifier.test.ts
+++ b/packages/codegen/__tests__/verifier.test.ts
@@ -803,7 +803,9 @@ describe("generateModelSdk integration", () => {
 
     // Generated TS prefix: split on both separators, capitalise.
     expect(src).toContain("export class MyCoolModelModel");
-    expect(src).toContain("export interface MyCoolModelOptions");
+    // `<Prefix>Options` is now a derived type alias, not a hand-rolled
+    // interface — the prefix derivation is what's load-bearing here.
+    expect(src).toContain("export type MyCoolModelOptions");
     expect(src).toContain("export interface MyCoolModelPromptAcceptedMessage");
     // MODEL_NAME constant preserves the original (raw) name verbatim —
     // it's a string literal, not an identifier.
@@ -872,5 +874,54 @@ describe("RESERVED_CLASS_METHODS — d.ts-derived surface", () => {
     ]) {
       expect(reserved.has(name)).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// React hook contract: `RESERVED_HOOK_FIELDS` mirrors what the codegen
+// emitter writes into `use<Prefix>()`'s return literal. Both are
+// d.ts-derived from `ReactorState & ReactorActions` via the shared
+// `loadReactorStoreFieldsFromDts` loader, so a future SDK release that
+// adds an action (e.g. recording's `requestClip`) lights up both the
+// rejection rule AND the emitted selector with no codegen edit.
+// ---------------------------------------------------------------------------
+
+describe("RESERVED_HOOK_FIELDS — d.ts-derived store surface", () => {
+  it("includes the canonical store state + action fields", () => {
+    const reserved = __testing__.RESERVED_HOOK_FIELDS;
+    // ReactorState fields:
+    for (const name of [
+      "status",
+      "sessionId",
+      "sessionExpiration",
+      "lastError",
+      "tracks",
+      "jwtToken",
+    ]) {
+      expect(reserved.has(name)).toBe(true);
+    }
+    // ReactorActions fields:
+    for (const name of [
+      "connect",
+      "disconnect",
+      "reconnect",
+      "sendCommand",
+      "uploadFile",
+      "publish",
+      "unpublish",
+    ]) {
+      expect(reserved.has(name)).toBe(true);
+    }
+  });
+
+  it("excludes the `internal` back-channel field", () => {
+    // `ReactorInternalState` exposes the underlying `Reactor` handle
+    // for the SDK's own React layer. Consumer code reading
+    // `useReactor((s) => s.internal.reactor)` is escaping the
+    // hook abstraction — we deliberately don't surface `internal`
+    // through `use<Prefix>()` and don't reserve the name for
+    // schema-collision purposes either (the field shape is
+    // intentionally hidden from the public hook contract).
+    expect(__testing__.RESERVED_HOOK_FIELDS.has("internal")).toBe(false);
   });
 });

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -9,6 +9,7 @@ import type {
   TrackSchema,
 } from "./types.js";
 import { generateReadme } from "./readme-emitter.js";
+import { loadReactorStoreFieldsFromDts } from "./sdk-surface.js";
 
 // ---------------------------------------------------------------------------
 // String helpers
@@ -466,20 +467,30 @@ function generateTrackTypes(
 // ---------------------------------------------------------------------------
 
 function generateOptionsType(modelPrefix: string): string {
-  const lines: string[] = [];
-  lines.push(
+  // Derived from Reactor's own constructor parameter type rather than
+  // a hand-rolled `{ apiUrl?, local? }` literal, so any future option
+  // the SDK adds to `Reactor`'s constructor flows through to
+  // `<Prefix>Model`'s constructor signature with no codegen edit.
+  // `modelName` and `modelTracks` are always supplied by this class
+  // (we bake them in via `super(...)`), so they're stripped from the
+  // user-facing options surface.
+  return (
     generateJsDoc(
       [
         `Options for creating a ${modelPrefix}Model (model name is set automatically).`,
+        "",
+        "Derived from `Reactor`'s own constructor options with `modelName`",
+        "and `modelTracks` removed — those are supplied by this class.",
+        "Any new option the SDK adds appears here automatically on the",
+        "next `defaultSdkVersion` bump.",
       ],
       0,
-    ),
+    ) +
+    `export type ${modelPrefix}Options = Omit<\n` +
+    `  ConstructorParameters<typeof Reactor>[0],\n` +
+    `  "modelName" | "modelTracks"\n` +
+    `>;`
   );
-  lines.push(`export interface ${modelPrefix}Options {`);
-  lines.push(`  apiUrl?: string;`);
-  lines.push(`  local?: boolean;`);
-  lines.push("}");
-  return lines.join("\n");
 }
 
 function generateClientClass(
@@ -781,11 +792,32 @@ function generateReactHooksForMessages(
 function generateUseModelHook(
   modelPrefix: string,
   events: EventSchema[],
+  storeFields: ReadonlySet<string>,
 ): string {
   const hookName = `use${modelPrefix}`;
-  const needsFileRef = events.some(hasUploadRefParam);
 
-  const methods: string[] = [];
+  // One `useReactor((s) => s.X)` selector per non-internal field on
+  // the SDK's `ReactorStore` (d.ts-derived in `verifier.ts` and
+  // threaded through here). Fine-grained selectors preserve Zustand's
+  // shallow re-render scoping — consumers only re-render when the
+  // specific store field they read changes — vs. a single
+  // `(s) => s` selector which would re-render on every store update.
+  //
+  // The schema-derived typed event methods (and `sendCommand`-bound
+  // wrappers) are layered ON TOP of the store fields in the returned
+  // object literal, so an event named `connect` (rejected by the
+  // verifier) would shadow the inherited store selector and produce
+  // a duplicate-key compile error — the verifier rejects pre-emit so
+  // the failure surfaces as a schema problem.
+  const sortedStoreFields = [...storeFields].sort();
+  const selectorLines = sortedStoreFields.map(
+    (name) => `  const ${name} = useReactor((s) => s.${name});`,
+  );
+
+  // Schema-derived typed event methods. Each one re-emits the
+  // sendCommand call against the matching event name, bound to the
+  // store's `sendCommand` field captured above.
+  const typedMethodLines: string[] = [];
   for (const event of events) {
     const methodName = toCamelCase(event.name);
     const fields = Object.entries(event.fields);
@@ -794,66 +826,55 @@ function generateUseModelHook(
       : undefined;
 
     if (paramType) {
-      methods.push(
+      typedMethodLines.push(
         `    ${methodName}: (params: ${paramType}): Promise<void> =>
       sendCommand(${JSON.stringify(event.name)}, params),`,
       );
     } else {
-      methods.push(
+      typedMethodLines.push(
         `    ${methodName}: (): Promise<void> =>
       sendCommand(${JSON.stringify(event.name)}, {}),`,
       );
     }
   }
 
-  if (needsFileRef) {
-    methods.push(
-      `    uploadFile: (
-      file: File | Blob,
-      options?: { name?: string },
-    ): Promise<FileRef> => uploadFile(file, options),`,
-    );
-  }
+  // Return-object construction. The store fields are spread first via
+  // shorthand identifiers; the typed event methods then layer on top.
+  // Sorting the field list keeps the emitted source deterministic
+  // across regenerations even if the d.ts loader's underlying Set
+  // iteration order shifts.
+  const returnBody = [
+    ...sortedStoreFields.map((name) => `    ${name},`),
+    ...typedMethodLines,
+  ].join("\n");
 
   const doc = generateJsDoc(
     [
       `Access the ${modelPrefix} model as typed commands bound to the nearest`,
-      `{@link ${modelPrefix}Provider}. Re-renders when \`status\` changes.`,
+      `{@link ${modelPrefix}Provider}.`,
       "",
-      "Returns the full action surface — connection `status`, `connect` /",
-      "`disconnect` for manual lifecycle control, one method per model event" +
-        (needsFileRef ? ", and `uploadFile` for upload-reference params" : "") +
-        ".",
+      "Returns the full action surface — every public field on the SDK's",
+      "`ReactorStore` (`status`, `sessionId`, `connect`, `disconnect`,",
+      "`sendCommand`, `uploadFile`, `publish`, `unpublish`, `reconnect`,",
+      "…) is exposed automatically, alongside one typed method per",
+      "model event.",
       "",
-      "`connect` / `disconnect` are pulled off the store so consumers using",
-      `\`<${modelPrefix}Provider>\` with \`autoConnect: false\` (or manual reconnect`,
-      "flows) don't have to reach for the raw `useReactor` hook themselves,",
-      "which in turn would force `@reactor-team/js-sdk` to be a direct",
-      "dependency instead of a transitive one through this package.",
+      "Fields are pulled off the store one at a time so Zustand's",
+      "shallow-equality selector keeps each subscription scoped — a",
+      "component reading only `status` doesn't re-render when",
+      "`sessionExpiration` changes. Future SDK releases that add new",
+      "store fields flow into this hook on the next codegen run with no",
+      "hand-edit (the field list is derived from `js-sdk`'s d.ts via",
+      "`loadReactorStoreFieldsFromDts` in `sdk-surface.ts`).",
     ],
     0,
   );
 
-  // `connect` / `disconnect` are pulled off the store so consumers using
-  // `<Prefix>Provider` with `autoConnect: false` (or any manual reconnect
-  // flow) don't have to reach for `useReactor` themselves. Function
-  // identities are stable across renders because they're Zustand actions.
   return `${doc}export function ${hookName}() {
-  const sendCommand = useReactor((s) => s.sendCommand);${
-    needsFileRef
-      ? `
-  const uploadFile = useReactor((s) => s.uploadFile);`
-      : ""
-  }
-  const connect = useReactor((s) => s.connect);
-  const disconnect = useReactor((s) => s.disconnect);
-  const status = useReactor((s) => s.status);
+${selectorLines.join("\n")}
 
   return {
-    status,
-    connect,
-    disconnect,
-${methods.join("\n")}
+${returnBody}
   };
 }`;
 }
@@ -863,7 +884,6 @@ function generateProviderComponent(
   hasTracks: boolean,
 ): string {
   const providerName = `${modelPrefix}Provider`;
-  const optionsType = `${modelPrefix}Options`;
 
   const doc = generateJsDoc(
     [
@@ -878,13 +898,24 @@ function generateProviderComponent(
     0,
   );
 
-  const providerProps = `{
-  apiUrl,
-  local,
-  jwtToken,
-  connectOptions,
-  children,
-}: ${providerName}Props`;
+  // Props type derived from `ReactorProvider` itself — every prop the
+  // SDK supports flows through automatically, minus the two we own
+  // (`modelName`, `modelTracks`). When `ReactorProvider` gains a new
+  // prop on a future SDK release, consumers of `<Prefix>Provider`
+  // get access to it on the next `defaultSdkVersion` bump without
+  // any codegen edit. `Parameters<typeof ReactorProvider>[0]` works
+  // even when the SDK's `ReactorProviderProps` interface itself isn't
+  // exported (TS extracts the resolved structural type from the
+  // function signature).
+  const propsDoc = generateJsDoc(
+    [
+      `Props for the {@link ${providerName}} component.`,
+      "",
+      "Derived from `ReactorProvider`'s own props, with `modelName` and",
+      "`modelTracks` stripped — those are supplied by this provider.",
+    ],
+    0,
+  );
 
   // `children` is passed as `createElement`'s third positional
   // argument rather than as a key inside the props object. Both forms
@@ -896,38 +927,34 @@ function generateProviderComponent(
   //
   // The third-arg form only compiles against @types/react's
   // overloads when the component's prop type doesn't declare
-  // `children` as a required field — the overload's second arg is
-  // typed `Attributes & P | null`, so a required `children: ReactNode`
-  // forces every callsite to put `children` in the props object. The
-  // SDK's `ReactorProviderProps` declares `children?: ReactNode` for
-  // exactly this reason; if that's ever tightened back to required,
-  // this emitter has to fall back to the in-props form with a
-  // targeted `eslint-disable-next-line react/no-children-prop`
-  // comment. Pinned by a regression test in `emitter.test.ts`.
-  const reactorProviderProps = [
-    `      apiUrl: apiUrl,`,
-    `      local: local,`,
-    `      modelName: MODEL_NAME,`,
-  ];
-  if (hasTracks) {
-    reactorProviderProps.push(`      modelTracks: [...${modelPrefix}Tracks],`);
-  }
-  reactorProviderProps.push(
-    `      jwtToken: jwtToken,`,
-    `      connectOptions: connectOptions,`,
-  );
+  // `children` as a required field. The SDK's `ReactorProviderProps`
+  // declares `children?: ReactNode` (since js-sdk 2.9.3); if that's
+  // ever tightened back to required, this emitter has to fall back to
+  // the in-props form with a targeted `eslint-disable-next-line
+  // react/no-children-prop` comment. Pinned by a regression test in
+  // `emitter.test.ts`.
+  //
+  // Everything other than `children` is forwarded via `...rest`
+  // spread, so a future `ReactorProvider` prop addition reaches
+  // through without renaming each field by hand.
+  const tracksProp = hasTracks
+    ? `\n      modelTracks: [...${modelPrefix}Tracks],`
+    : "";
 
-  return `export interface ${providerName}Props extends ${optionsType} {
-  jwtToken?: string;
-  connectOptions?: ReactorConnectOptions;
-  children: ReactNode;
-}
+  return `${propsDoc}export type ${providerName}Props = Omit<
+  Parameters<typeof ReactorProvider>[0],
+  "modelName" | "modelTracks"
+>;
 
-${doc}export function ${providerName}(${providerProps}): ReactElement {
+${doc}export function ${providerName}({
+  children,
+  ...rest
+}: ${providerName}Props): ReactElement {
   return createElement(
     ReactorProvider,
     {
-${reactorProviderProps.join("\n")}
+      ...rest,
+      modelName: MODEL_NAME,${tracksProp}
     },
     children,
   );
@@ -973,7 +1000,6 @@ function generateReactFile(options: CodegenOptions): string {
   const emitsTrackHook = recv.length > 0;
   const emitsViewComponents = recvVideo.length > 0;
   const emitsPublisherComponents = sendVideo.length > 0;
-  const needsFileRef = events.some(hasUploadRefParam);
 
   const sections: string[] = [];
 
@@ -990,19 +1016,23 @@ function generateReactFile(options: CodegenOptions): string {
   sections.push("");
 
   // React imports. `createElement` lets us stay in `.ts` (no JSX).
-  sections.push(
-    `import { createElement, type ReactElement, type ReactNode } from "react";`,
-  );
+  // `ReactNode` is no longer named in the emitted source — the
+  // `<Prefix>ProviderProps` type derives from `ReactorProvider`'s
+  // own props, so `children` lives inside that resolved type and we
+  // don't need a separate alias here.
+  sections.push(`import { createElement, type ReactElement } from "react";`);
 
   // SDK imports. We only import what the emitted surface actually uses so
-  // tree-shaking in the consumer project stays tight.
+  // tree-shaking in the consumer project stays tight. `Parameters<typeof
+  // ReactorProvider>[0]` (used by the derived props type) needs the
+  // value-level `ReactorProvider` in scope, which we already import.
+  // `ReactorConnectOptions` / `FileRef` are no longer named directly
+  // here — they flow through the derived prop / store-field types.
   const sdkImports = [
     "ReactorProvider",
     "useReactor",
     ...(messages.length > 0 ? ["useReactorMessage"] : []),
-    "type ReactorConnectOptions",
   ];
-  if (needsFileRef) sdkImports.push("type FileRef");
   if (emitsViewComponents)
     sdkImports.push("ReactorView", "type ReactorViewProps");
   if (emitsPublisherComponents)
@@ -1055,8 +1085,14 @@ function generateReactFile(options: CodegenOptions): string {
   sections.push(generateProviderComponent(modelPrefix, hasTracks));
   sections.push("");
 
-  // use<Prefix>() hook.
-  sections.push(generateUseModelHook(modelPrefix, events));
+  // use<Prefix>() hook. Store-field selectors are derived from the
+  // installed js-sdk's d.ts (same source of truth as the verifier's
+  // RESERVED_HOOK_FIELDS), so a future SDK release that adds a field
+  // to `ReactorState` / `ReactorActions` shows up here on the next
+  // codegen run with no hand-edit.
+  sections.push(
+    generateUseModelHook(modelPrefix, events, loadReactorStoreFieldsFromDts()),
+  );
 
   // Per-message hooks.
   if (messages.length > 0) {

--- a/packages/codegen/src/sdk-surface.ts
+++ b/packages/codegen/src/sdk-surface.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// ---------------------------------------------------------------------------
+// SDK-surface introspection.
+//
+// The codegen needs to know *which symbols* the installed
+// `@reactor-team/js-sdk` exposes so the verifier can reject schema
+// shapes that would shadow them, and so the emitter can wire React
+// hooks / provider props without naming SDK fields by hand.
+//
+// Both concerns share the same source of truth: the d.ts file that
+// ships in the installed `@reactor-team/js-sdk` package
+// (`dist/index.d.ts`). The file is uniformly formatted by `tsup`
+// (4-space class-body and interface-body indent, visibility keywords
+// preserved on class members), so a small handful of regexes give us
+// exactly the public surface — without parsing a TypeScript AST and
+// without adding a typescript runtime dependency.
+//
+// This module is the only place that touches the filesystem / parses
+// the d.ts. Verifier and emitter both import the surface getters
+// below, so the d.ts is read once per codegen process (the loader
+// caches the file contents in a module-level closure).
+//
+// Why parse the d.ts and not introspect at runtime (e.g.
+// `Object.getOwnPropertyNames(Reactor.prototype)`):
+//
+//   - The prototype walk includes TS-`private` methods, which survive
+//     compilation because TS visibility is compile-time only. Those
+//     methods are NOT inheritable in the type system, so a schema
+//     event of the same name cannot collide with them.
+//   - The d.ts emission, on the other hand, preserves the `private`
+//     keyword (e.g. `private setStatus;`), so the loader sees exactly
+//     the type-visible public surface — which is what `extends
+//     Reactor` actually exposes to a subclass author.
+//   - Interfaces (`ReactorState`, `ReactorActions`) only exist at
+//     compile time; the d.ts is the only place they're observable.
+//
+// If the d.ts shape ever changes (a future tsup major, an
+// api-extractor migration, …), each loader's internal floor check
+// trips at codegen startup with a pointed error rather than silently
+// shipping under-protected verifier output.
+// ---------------------------------------------------------------------------
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Read the installed `@reactor-team/js-sdk` package's bundled
+ * `index.d.ts`. Cached at module scope — every loader below shares
+ * one disk read per codegen process.
+ */
+let cachedDts: string | null = null;
+function loadSdkDts(): string {
+  if (cachedDts !== null) return cachedDts;
+  // `require.resolve` locates the package's main entry; the d.ts ships
+  // alongside it under `dist/index.d.ts` (tsup config in js-sdk). Walk
+  // up one level to reach the d.ts. Works in both pnpm-workspace mode
+  // (symlinked source build) and published-npm mode (real tarball).
+  const sdkEntry = require.resolve("@reactor-team/js-sdk");
+  const dtsPath = path.join(path.dirname(sdkEntry), "index.d.ts");
+  cachedDts = fs.readFileSync(dtsPath, "utf-8");
+  return cachedDts;
+}
+
+// ---------------------------------------------------------------------------
+// `Reactor` class — public methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Names of every non-private/protected method declared on the
+ * {@link Reactor} class in the installed SDK's d.ts.
+ *
+ * Consumed by:
+ *
+ *   - `RESERVED_CLASS_METHODS` in `verifier.ts` — rejects schemas that
+ *     would emit a method whose camelCase form shadows an inherited
+ *     Reactor method on the generated `<Prefix>Model extends Reactor`.
+ *   - (indirectly) `checkClassMethodCollisions` in `verifier.ts` —
+ *     seeds the per-name error-message catalog from the same set.
+ *
+ * Throws if the d.ts cannot be read, the `declare class Reactor`
+ * block cannot be located, or the floor check (must find `connect` /
+ * `disconnect` / `sendCommand`) fails. Hard-failing at codegen
+ * startup is preferred to silently emitting an under-protected
+ * verifier.
+ */
+export function loadReactorPublicMethodsFromDts(): Set<string> {
+  const dts = loadSdkDts();
+
+  // Find the `declare class Reactor` block. The trailing `^}` anchors
+  // on a top-level `}` (no indentation) so a nested object literal in
+  // a method signature doesn't terminate the match early.
+  //
+  // The negative lookahead `(?![A-Za-z0-9_$])` enforces a clean name
+  // boundary so a future `Reactor$1` (tsup's roll-up naming when two
+  // exports collide) doesn't accidentally hijack the match. See
+  // `extractInterfaceFieldNames` for the same anchor used on
+  // interfaces.
+  const classMatch = dts.match(
+    /declare class Reactor(?![A-Za-z0-9_$])[^{]*\{([\s\S]*?)^\}/m,
+  );
+  if (!classMatch) {
+    throw new Error(
+      "Codegen sdk-surface: could not locate `declare class Reactor` block " +
+        "in @reactor-team/js-sdk d.ts. The d.ts format may have changed; " +
+        "update the regex in `loadReactorPublicMethodsFromDts`.",
+    );
+  }
+  const body = classMatch[1];
+
+  // Method declarations at the class's 4-space indent. Negative
+  // lookahead skips `private ` / `protected ` members (those don't
+  // form part of the inheritable surface). We require `(` or `<`
+  // immediately after the name so the regex doesn't accidentally
+  // match property declarations like `readonly recording:
+  // RecordingClient;` — properties are surfaced separately if a
+  // future caller ever needs them.
+  const methodRe = /^ {4}(?!private |protected )([a-zA-Z_$][\w$]*)\s*[(<]/gm;
+  const out = new Set<string>();
+  for (const match of body.matchAll(methodRe)) {
+    const name = match[1];
+    if (name !== "constructor") out.add(name);
+  }
+
+  // Sanity floor: the loader must find AT LEAST the canonical
+  // lifecycle surface. A zero-result parse almost certainly means the
+  // d.ts shape has changed in a way the regex doesn't tolerate;
+  // surfacing that here is more useful than silently shipping an
+  // under-protected verifier set.
+  for (const required of ["connect", "disconnect", "sendCommand"]) {
+    if (!out.has(required)) {
+      throw new Error(
+        "Codegen sdk-surface: d.ts parse did not find the " +
+          `\`${required}\` method on the Reactor class. The d.ts shape may ` +
+          "have changed; update `loadReactorPublicMethodsFromDts`.",
+      );
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// `ReactorStore` (Zustand store) — public fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Names of every public field on the `ReactorStore` type
+ * (`ReactorState & ReactorActions`) the SDK exposes through
+ * `useReactor((s) => s.X)`.
+ *
+ * Excludes the `internal` field on `ReactorInternalState` — it's a
+ * back-channel for the SDK's own React layer and not part of the
+ * surface generated `<Prefix>Provider` consumers should reach for.
+ *
+ * Consumed by:
+ *
+ *   - `RESERVED_HOOK_FIELDS` in `verifier.ts` — rejects schemas that
+ *     would emit a field name on `use<Prefix>()`'s return literal
+ *     that shadows a store field.
+ *   - `generateUseModelHook` in `emitter.ts` — emits one
+ *     `const X = useReactor((s) => s.X);` selector per field, then
+ *     spreads them into the hook's return object.
+ *
+ * The dual use means a future SDK release that adds e.g. `requestClip`
+ * to `ReactorActions` lights up BOTH the rejection rule (so a schema
+ * can't declare a `request_clip` event) AND the hook surface (so
+ * `const { requestClip } = useHelios()` works at the consumer's React
+ * tree) with no codegen edit.
+ */
+export function loadReactorStoreFieldsFromDts(): Set<string> {
+  const dts = loadSdkDts();
+
+  // The store type is `type ReactorStore = ReactorState & ReactorActions &
+  // { internal: ReactorInternalState };` — we union the two named
+  // interfaces and drop `internal`. Look up each by name; both blocks
+  // are at top-level indent and have the same shape.
+  const stateFields = extractInterfaceFieldNames(dts, "ReactorState");
+  const actionFields = extractInterfaceFieldNames(dts, "ReactorActions");
+
+  const out = new Set<string>([...stateFields, ...actionFields]);
+  out.delete("internal");
+
+  // Floor check: every store consumer relies on `status` + `connect` +
+  // `disconnect` + `sendCommand`. If any is missing the d.ts parse
+  // has regressed.
+  for (const required of ["status", "connect", "disconnect", "sendCommand"]) {
+    if (!out.has(required)) {
+      throw new Error(
+        "Codegen sdk-surface: d.ts parse did not find " +
+          `\`${required}\` on ReactorState/ReactorActions. The d.ts shape ` +
+          "may have changed; update `loadReactorStoreFieldsFromDts`.",
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull the field names out of a top-level `interface Foo { ... }`
+ * block in the SDK's d.ts. Returns an empty set if the interface is
+ * absent — caller decides whether that's a hard error (the
+ * floor-check in {@link loadReactorStoreFieldsFromDts} does for the
+ * two interfaces it cares about).
+ *
+ * Field shapes covered (4-space indent, optional `?` for optional
+ * properties, both property and method signatures):
+ *
+ *   `    status: ReactorStatus;`
+ *   `    lastError?: ReactorError;`
+ *   `    sendCommand(command: string, …): Promise<void>;`
+ */
+function extractInterfaceFieldNames(dts: string, name: string): Set<string> {
+  // Match `interface <name>` at the start of a line. We deliberately
+  // do NOT require the `interface` to be exported (the SDK's
+  // `ReactorState` / `ReactorActions` interfaces are emitted without
+  // an `export` keyword when used as type aliases internally — they
+  // surface only via `ReactorStore`).
+  //
+  // The negative lookahead `(?![A-Za-z0-9_$])` ensures we don't match
+  // a *prefix*-collision interface. tsup's d.ts roll-up renames
+  // duplicate-export interfaces by appending `$N` (e.g. the
+  // re-exported `ReactorState` from `types.ts` and the in-source
+  // `ReactorState` from `store.ts` both land in the same flat file,
+  // and tsup disambiguates them as `ReactorState` / `ReactorState$1`).
+  // `\b` alone would happily anchor inside the `$1` suffix because
+  // `$` is not in `\w`; the explicit identifier-char negative
+  // lookahead forces the name to terminate cleanly.
+  const re = new RegExp(
+    String.raw`^(?:export )?interface ${name}(?![A-Za-z0-9_$])[^{]*\{([\s\S]*?)^\}`,
+    "m",
+  );
+  const match = dts.match(re);
+  if (!match) return new Set();
+  const body = match[1];
+
+  const fieldRe = /^ {4}([a-zA-Z_$][\w$]*)\??\s*[:(]/gm;
+  const out = new Set<string>();
+  for (const m of body.matchAll(fieldRe)) {
+    out.add(m[1]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for unit testing.
+// ---------------------------------------------------------------------------
+
+export const __testing__ = {
+  extractInterfaceFieldNames,
+  loadSdkDts,
+};

--- a/packages/codegen/src/verifier.ts
+++ b/packages/codegen/src/verifier.ts
@@ -1,7 +1,5 @@
 // Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import type {
   EventSchema,
   FieldSchema,
@@ -10,6 +8,10 @@ import type {
   TrackSchema,
 } from "./types.js";
 import { toCamelCase, toPascalCase } from "./emitter.js";
+import {
+  loadReactorPublicMethodsFromDts,
+  loadReactorStoreFieldsFromDts,
+} from "./sdk-surface.js";
 
 // ---------------------------------------------------------------------------
 // Verifier — second-line defence between the parser/IR ingest and the emitter.
@@ -432,84 +434,9 @@ const RESERVED_CLASS_METHODS: Set<string> = (() => {
   return set;
 })();
 
-/**
- * Read the installed `@reactor-team/js-sdk` package's bundled
- * `index.d.ts` and extract the names of every non-private method
- * declared on the `Reactor` class. This is the source of truth for
- * what the verifier needs to reject as a schema-side collision.
- *
- * Why parse the d.ts (and not, say, `Object.getOwnPropertyNames(
- * Reactor.prototype)`):
- *
- *   - The prototype walk includes TS-`private` methods, which survive
- *     compilation because TS visibility is compile-time only. Those
- *     methods are NOT inheritable in the type system, so a schema
- *     event of the same name cannot collide with them.
- *   - The d.ts emission, on the other hand, preserves the `private`
- *     keyword (e.g. `private setStatus;`), so a single regex sweep
- *     gives us exactly the type-visible public surface — which is
- *     what `extends Reactor` actually exposes to a subclass author.
- *
- * The loader runs once at module load (the IIFE that populates
- * {@link RESERVED_CLASS_METHODS} above). If `js-sdk` is missing or
- * the d.ts cannot be parsed, the loader throws — that's a hard
- * dependency failure and we'd rather fail loud at codegen startup
- * than emit an under-protected verifier that silently accepts
- * shadowing schemas.
- */
-function loadReactorPublicMethodsFromDts(): Set<string> {
-  // `require.resolve` locates the package's main entry; the d.ts ships
-  // alongside it under `dist/index.d.ts` (tsup config in js-sdk). Walk
-  // up one level to reach the d.ts. Works in both pnpm-workspace mode
-  // (symlinked source build) and published-npm mode (real tarball).
-  const sdkEntry = require.resolve("@reactor-team/js-sdk");
-  const dtsPath = path.join(path.dirname(sdkEntry), "index.d.ts");
-  const dts = fs.readFileSync(dtsPath, "utf-8");
-
-  // Find the `declare class Reactor` block. The trailing `^}` anchors
-  // on a top-level `}` (no indentation) so a nested object literal in
-  // a method signature doesn't terminate the match early.
-  const classMatch = dts.match(/declare class Reactor\b[^{]*\{([\s\S]*?)^\}/m);
-  if (!classMatch) {
-    throw new Error(
-      "Codegen verifier: could not locate `declare class Reactor` block in " +
-        `${dtsPath}. The d.ts format may have changed; update the regex in ` +
-        "`loadReactorPublicMethodsFromDts` and the matching docstring.",
-    );
-  }
-  const body = classMatch[1];
-
-  // Method declarations at the class's 4-space indent. Negative
-  // lookahead skips `private ` / `protected ` members (those don't
-  // form part of the inheritable surface). We require `(` or `<`
-  // immediately after the name so the regex doesn't accidentally
-  // match property declarations like `readonly recording:
-  // RecordingClient;` — properties land in
-  // {@link RESERVED_CLASS_PROPERTIES} via a separate code path if
-  // ever needed.
-  const methodRe = /^ {4}(?!private |protected )([a-zA-Z_$][\w$]*)\s*[(<]/gm;
-  const out = new Set<string>();
-  for (const match of body.matchAll(methodRe)) {
-    const name = match[1];
-    if (name !== "constructor") out.add(name);
-  }
-
-  // Sanity floor: the loader must find AT LEAST the canonical lifecycle
-  // surface. A zero-result parse almost certainly means the d.ts shape
-  // has changed in a way the regex doesn't tolerate; surfacing that
-  // here is more useful than silently shipping an under-protected
-  // verifier set.
-  for (const required of ["connect", "disconnect", "sendCommand"]) {
-    if (!out.has(required)) {
-      throw new Error(
-        `Codegen verifier: d.ts parse of ${dtsPath} did not find the ` +
-          `\`${required}\` method on the Reactor class. The d.ts shape may ` +
-          "have changed; update `loadReactorPublicMethodsFromDts`.",
-      );
-    }
-  }
-  return out;
-}
+// The d.ts loader implementations live in `./sdk-surface.ts` so the
+// same parse can feed the emitter's React hook generation. Verifier
+// and emitter share one source of truth and one disk read.
 
 /**
  * Properties on the `<Prefix>Model` instance. `reactor` is the
@@ -524,14 +451,16 @@ const RESERVED_CLASS_PROPERTIES = new Set<string>(["reactor"]);
  * camelCase transform matches one of these would land twice in the
  * returned object literal and either compile-error or silently
  * override the built-in.
+ *
+ * Auto-derived from the installed `@reactor-team/js-sdk`'s d.ts via
+ * the shared `loadReactorStoreFieldsFromDts` loader, so any new field
+ * on `ReactorState` / `ReactorActions` (e.g. a future
+ * `requestClip: (s: number) => Promise<Clip>` on actions) flows in
+ * without a hand-edit here AND simultaneously gets emitted as a
+ * selector by `generateUseModelHook` in `emitter.ts` — single source
+ * of truth.
  */
-const RESERVED_HOOK_FIELDS = new Set<string>([
-  "connect",
-  "disconnect",
-  "sendCommand",
-  "status",
-  "uploadFile",
-]);
+const RESERVED_HOOK_FIELDS: Set<string> = loadReactorStoreFieldsFromDts();
 
 /**
  * Field names reserved inside a *message* schema only. `type` is the


### PR DESCRIPTION
Why
---
The class-side inheritance refactor (previous commit) made every public
method on Reactor flow into the generated `<Prefix>Model` automatically,
but it left two parallel maintenance surfaces on the React side:

  1. `generateUseModelHook` hardcoded five `useReactor((s) => s.X)`
     selectors (`sendCommand`, `uploadFile`, `connect`, `disconnect`,
     `status`) and `RESERVED_HOOK_FIELDS` mirrored them by hand. New
     fields on `ReactorState` / `ReactorActions` would not be exposed
     by the hook even though the class side reaches them via
     inheritance (e.g. the recording PR will add `requestClip` to
     `ReactorActions` — it would land on `helios.requestClip(5)` but
     stay invisible from `useHelios()` until a codegen PR).

  2. `<Prefix>Options` and `<Prefix>ProviderProps` were hand-rolled
     interfaces — new options on `Reactor`'s constructor or new props
     on `ReactorProvider` would not flow through.

Both were also a *correctness* trap: the hand-rolled `<Prefix>Options`
declared `apiUrl?: string; local?: boolean` which would silently drift
out of date with the SDK's actual constructor signature.

What changed
------------
- New module `packages/codegen/src/sdk-surface.ts`:

  * `loadReactorPublicMethodsFromDts()` (moved from `verifier.ts`,
    same regex, same floor check).
  * `loadReactorStoreFieldsFromDts()` (new) — parses the
    `interface ReactorState { ... }` + `interface ReactorActions { ... }`
    blocks in the installed `@reactor-team/js-sdk`'s `dist/index.d.ts`,
    drops the back-channel `internal` field, returns the union.

  Both loaders use a tightened name anchor — `(?![A-Za-z0-9_$])` —
  that survives tsup's roll-up rename of duplicate-export symbols
  (the previous `\b` anchor would happily match `ReactorState$1`
  because `$` is a non-word character; that bug surfaced as the
  d.ts-derived store set being empty until the negative-lookahead
  fix).

- `packages/codegen/src/verifier.ts`:

  * `RESERVED_CLASS_METHODS` now imports its loader from
    `sdk-surface.ts` (the body of `loadReactorPublicMethodsFromDts`
    moved out; the export stays).
  * `RESERVED_HOOK_FIELDS` becomes
    `loadReactorStoreFieldsFromDts()` — same derivation pattern as
    the class-method set.

- `packages/codegen/src/emitter.ts`:

  * `generateOptionsType` emits a `type` alias
    `Omit<ConstructorParameters<typeof Reactor>[0], "modelName" |
    "modelTracks">` (not a hand-rolled `interface`). New Reactor
    constructor options flow through on the next `defaultSdkVersion`
    bump.

  * `generateProviderComponent` emits a `type` alias
    `Omit<Parameters<typeof ReactorProvider>[0], "modelName" |
    "modelTracks">` and the provider body uses
    `{ children, ...rest }` spread instead of naming each forwarded
    prop. New `ReactorProvider` props flow through with no codegen
    edit; the `children` third-positional shape is preserved so
    `react/no-children-prop` stays clean.

  * `generateUseModelHook` no longer accepts the implicit "five
    known selectors" — it takes a `storeFields: ReadonlySet<string>`
    parameter, emits one `useReactor((s) => s.X)` per field,
    spreads them into the returned object alongside schema-derived
    typed event methods. Fine-grained selectors preserve Zustand's
    shallow re-render scoping.

  * `generateReactFile` drops the `ReactorConnectOptions` / `FileRef`
    / `ReactNode` imports — none are named in the emitted source
    anymore (their type info flows in through the derived prop /
    store-field types).

- Tests (`packages/codegen/__tests__/`):

  * Two new `verifier.test.ts` describes: pin the d.ts-derived store
    surface (canonical state + action fields present; `internal`
    excluded).

  * New `emitter.test.ts` cases pin the derivation:
    - "derives the full store surface" — every ReactorState +
      ReactorActions field appears as a hook selector.
    - "<Prefix>Options and <Prefix>ProviderProps are type aliases"
      — pins the `Omit<Parameters<typeof X>[0], ...>` shape and the
      `...rest` spread in the provider body.

  * Updated existing tests: `exposes uploadFile only when events
    use upload references` flipped to assert `uploadFile` is now
    *unconditional* on the hook (it's a store field, not a
    schema-conditional wrapper). `MyCoolModelOptions` assertion
    flipped from `export interface` to `export type` to match the
    new alias shape. Provider-no-tracks assertion tightened to
    match the property emit, not the doc text.

- README updated: the "Maintaining the inheritance contract" section
  now covers all three derivations (class methods, store fields,
  provider props) with a single table of "what's derived from what".

Forward compatibility
---------------------
When the recording PR stack adds e.g. `requestClip: (...) => Promise<Clip>`
to `ReactorActions`, every generated `useHelios()` exposes it
automatically on the next `defaultSdkVersion` bump:

  const { requestClip } = useHelios();
  const clip = await requestClip({ durationSeconds: 5 });

Same for new options on `Reactor` (flow through `<Prefix>Options`) and
new props on `ReactorProvider` (flow through `<Prefix>ProviderProps`).
Zero codegen edits required.

Tests: `pnpm --filter @reactor-team/codegen test` (345 pass, +4 new)
and `pnpm --filter @reactor-team/js-sdk test:unit` (284 pass).
E2E: regenerate + build the example fixture with both the default
and the `--react` paths against the published 2.9.3 js-sdk; both
succeed.

Co-authored-by: Cursor <cursoragent@cursor.com>