### PR TITLE
[codegen] split generated package into index/core/react with subpath exports

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -8,11 +8,23 @@ Code generator that turns a model's OpenAPI schema into a strongly-typed npm pac
 
 ```
 schema.json ──▶ codegen ──▶ @reactor-models/helios (npm package)
-                              ├── src/index.ts      (typed client)
-                              ├── package.json
+                              ├── src/index.ts      (re-export hub)
+                              ├── src/core.ts       (typed client + types)
+                              ├── src/react.tsx     (Provider + hooks, with --react)
+                              ├── package.json      (subpath exports for /core, /react)
                               ├── tsconfig.json
                               └── dist/             (built output)
 ```
+
+The package is structured as a three-file split (with `--react`) so consumers can pick their import scope:
+
+```typescript
+import { HeliosModel, HeliosProvider } from "@reactor-models/helios"; // everything
+import { HeliosModel } from "@reactor-models/helios/core"; // React-free
+import { HeliosProvider, useHelios } from "@reactor-models/helios/react"; // React-only
+```
+
+The `"use client"` directive is scoped to `react.tsx` only — RSC consumers importing from `/core` aren't dragged into a client boundary.
 
 The codegen reads a model's OpenAPI schema (events, messages, tracks) and produces a TypeScript package with:
 
@@ -99,11 +111,11 @@ reactor-codegen \
   --standalone
 ```
 
-The emitted `.ts` file is byte-identical to the `src/index.ts` produced by the full-package mode — it still imports `Reactor` (and `FileRef` when needed) from `@reactor-team/js-sdk`, so make sure `@reactor-team/js-sdk` is already a dependency of the host project.
+The emitted `.ts` file is the same content as the full-package mode's `src/core.ts` (the imperative + types surface) — it imports `Reactor` (and `FileRef` when needed) from `@reactor-team/js-sdk`, so make sure `@reactor-team/js-sdk` is already a dependency of the host project. Standalone mode collapses the package-mode `index.ts` re-export hub into the single output file (the consumer controls the import path themselves, so the hop is unnecessary).
 
 ### React output (`--react`)
 
-Pass `--react` to additionally emit a React entry point. The provider, hooks, and track components are emitted in `src/react.ts` and re-exported from `src/index.ts`, so consumers import everything from the package root — there is no `/react` subpath:
+Pass `--react` to additionally emit a React entry point. In package mode the React layer lands in its own `src/react.tsx` (real JSX, not `createElement` calls) and gets its own subpath export at `<pkg>/react`. The `src/index.ts` re-export hub re-exports both `./core.js` and `./react.js`, so consumers using the package root keep working unchanged:
 
 ```bash
 reactor-codegen \
@@ -115,12 +127,14 @@ reactor-codegen \
 
 Generated shape:
 
-| Mode                     | Files                                                                                                                                                                                                                           | Import path                                                                |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| full package + `--react` | `src/index.ts` (re-exports `./react.js`) + `src/react.ts` + package scaffold (`react` peer dep, `react`/`@types/react` dev deps, `"use client"` directive at root). Single root entry in `package.json` `exports` — no subpath. | `@reactor-models/<name>` (single import path for both plain JS and React)  |
-| `--standalone --react`   | `<base>.ts` + `<base>.react.ts` (no package scaffold). Cross-imports between the two files are rewired to the chosen basename.                                                                                                  | relative imports; the React file imports from `./<base>.js` and vice versa |
+| Mode                     | Files                                                                                                                                                                                                                                           | Import paths                                                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| full package + `--react` | `src/index.ts` (re-exports both), `src/core.ts` (class + types), `src/react.tsx` (Provider + hooks + JSX components), plus the usual package scaffold (`react` peer dep, `jsx: "react-jsx"` tsconfig, three subpath exports in `package.json`). | `@reactor-models/<name>` (everything) / `@reactor-models/<name>/core` (React-free) / `@reactor-models/<name>/react` (React-only) |
+| `--standalone --react`   | `<base>.ts` (core content; no re-export hub) + `<base>.react.tsx` (React layer). The React file's cross-import is rewired to point at the chosen main basename without a `.js` extension.                                                       | relative imports; the React file imports from `./<base>` and vice versa                                                          |
 
-The React file declares `"use client"` (Next.js RSC compat), uses `React.createElement` (no JSX in the emitted file, so it stays `.ts`), and exposes:
+The `"use client"` directive lives only on `react.tsx`. Neither `index.ts` nor `core.ts` carries it, so RSC consumers importing from `@reactor-models/<name>/core` aren't dragged into a client boundary.
+
+The React file uses real JSX (file is `.tsx`, generated tsconfig sets `jsx: "react-jsx"` for the new transform) and exposes:
 
 - **`<Prefix>Provider`** — wraps `ReactorProvider` with `modelName: MODEL_NAME` and (when the schema declares tracks) `modelTracks: [...<Prefix>Tracks]` pre-configured. Accepts `apiUrl`, `local`, `jwtToken`, and `connectOptions` props.
 - **`use<Prefix>()`** — typed commands bound to the nearest provider: one method per model event (camelCase) plus `status`, `connect`, `disconnect`, and (when any event takes an upload reference) `uploadFile`.

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -155,6 +155,7 @@ describe("reactor-codegen CLI — --no-build write", () => {
 
     const expected = [
       "src/index.ts",
+      "src/core.ts",
       "package.json",
       "tsup.config.ts",
       "tsconfig.json",
@@ -164,12 +165,17 @@ describe("reactor-codegen CLI — --no-build write", () => {
       expect(fs.existsSync(path.join(outputDir, rel))).toBe(true);
     }
 
-    // The generated client must wire `modelTracks` (the committed dummy
-    // fixture declares one track) — this is the user-visible contract for PR 4.
-    const src = fs.readFileSync(path.join(outputDir, "src/index.ts"), "utf-8");
-    expect(src).toContain("modelTracks: [...ExampleTracks]");
-    expect(src).toContain("ExampleTracks = [");
-    expect(src).toContain('direction: "recvonly"');
+    // index.ts is the re-export hub.
+    const idx = fs.readFileSync(path.join(outputDir, "src/index.ts"), "utf-8");
+    expect(idx).toContain('export * from "./core.js";');
+
+    // The generated class lives in src/core.ts — that's where the
+    // `modelTracks` wiring lands. The fixture declares one track,
+    // exercising the hasTracks branch.
+    const core = fs.readFileSync(path.join(outputDir, "src/core.ts"), "utf-8");
+    expect(core).toContain("modelTracks: [...ExampleTracks]");
+    expect(core).toContain("ExampleTracks = [");
+    expect(core).toContain('direction: "recvonly"');
   });
 });
 
@@ -270,7 +276,7 @@ describe("reactor-codegen CLI — --react (full package)", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("emits src/react.ts, re-exports it from src/index.ts, and keeps one root export", () => {
+  it("emits src/react.tsx + src/core.ts + src/index.ts with /core and /react subpath exports", () => {
     const outputDir = path.join(tmpDir, "example");
     const result = runCli([
       "--schema",
@@ -287,7 +293,8 @@ describe("reactor-codegen CLI — --react (full package)", () => {
 
     for (const rel of [
       "src/index.ts",
-      "src/react.ts",
+      "src/core.ts",
+      "src/react.tsx",
       "package.json",
       "tsup.config.ts",
       "tsconfig.json",
@@ -296,37 +303,55 @@ describe("reactor-codegen CLI — --react (full package)", () => {
       expect(fs.existsSync(path.join(outputDir, rel))).toBe(true);
     }
 
-    // Provider + hooks live in src/react.ts (not duplicated in
-    // src/index.ts), and src/index.ts re-exports them so the public
-    // surface is a single root import.
     const index = fs.readFileSync(
       path.join(outputDir, "src/index.ts"),
       "utf-8",
     );
+    const core = fs.readFileSync(path.join(outputDir, "src/core.ts"), "utf-8");
     const react = fs.readFileSync(
-      path.join(outputDir, "src/react.ts"),
+      path.join(outputDir, "src/react.tsx"),
       "utf-8",
     );
-    expect(index).toContain('"use client";');
+    // index.ts is the re-export hub: NO use-client (that's scoped to
+    // the react file only) and NO declarations of its own.
+    expect(index).not.toContain('"use client";');
+    expect(index).toContain('export * from "./core.js";');
     expect(index).toContain('export * from "./react.js";');
     expect(index).not.toContain("export function ExampleProvider(");
+    expect(index).not.toContain("export class ExampleModel");
+    // Class lives in core.ts; no React imports here.
+    expect(core).toContain("export class ExampleModel");
+    expect(core).not.toContain('"use client";');
+    expect(core).not.toContain('from "react"');
+    // React file: use-client + JSX + back-import from ./core.js.
+    expect(react).toContain('"use client";');
     expect(react).toContain("export function ExampleProvider(");
     expect(react).toContain("export function useExample()");
     expect(react).toContain("export function useExampleMessage(");
+    expect(react).toContain('from "./core.js"');
 
     const pkgJson = JSON.parse(
       fs.readFileSync(path.join(outputDir, "package.json"), "utf-8"),
     );
-    // Exactly one export path — no `./react` subpath, ever.
-    expect(Object.keys(pkgJson.exports)).toEqual(["."]);
+    expect(Object.keys(pkgJson.exports).sort()).toEqual([
+      ".",
+      "./core",
+      "./react",
+    ]);
     expect(pkgJson.peerDependencies).toEqual({ react: ">=18" });
 
     const tsup = fs.readFileSync(
       path.join(outputDir, "tsup.config.ts"),
       "utf-8",
     );
-    expect(tsup).toContain('entry: ["src/index.ts"]');
-    expect(tsup).not.toContain("src/react.ts");
+    expect(tsup).toContain(
+      'entry: ["src/index.ts", "src/core.ts", "src/react.tsx"]',
+    );
+
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "tsconfig.json"), "utf-8"),
+    );
+    expect(tsconfig.compilerOptions.jsx).toBe("react-jsx");
   });
 
   it("--dry-run exits 0 and writes nothing", () => {
@@ -362,9 +387,9 @@ describe("reactor-codegen CLI — --standalone --react", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("writes <base>.ts + <base>.react.ts and wires up the cross-imports", () => {
+  it("writes <base>.ts (core) + <base>.react.tsx with cross-imports rewired", () => {
     const outputFile = path.join(tmpDir, "src", "example.ts");
-    const reactFile = path.join(tmpDir, "src", "example.react.ts");
+    const reactFile = path.join(tmpDir, "src", "example.react.tsx");
     const result = runCli([
       "--schema",
       SCHEMA_PATH,
@@ -381,35 +406,35 @@ describe("reactor-codegen CLI — --standalone --react", () => {
     expect(fs.existsSync(outputFile)).toBe(true);
     expect(fs.existsSync(reactFile)).toBe(true);
     expect(fs.readdirSync(path.dirname(outputFile)).sort()).toEqual([
-      "example.react.ts",
+      "example.react.tsx",
       "example.ts",
     ]);
 
     const main = fs.readFileSync(outputFile, "utf-8");
     const react = fs.readFileSync(reactFile, "utf-8");
 
-    // Main file: re-export points at the chosen sibling basename, not
-    // the full-package default `./react.js`. Standalone mode strips
-    // the `.js` extension so the consumer's bundler resolves the
-    // sibling `.ts` source regardless of moduleResolution setting.
-    expect(main).toContain('"use client";');
-    expect(main).toContain('export * from "./example.react";');
-    expect(main).not.toContain('export * from "./react.js";');
-    expect(main).not.toContain('export * from "./example.react.js";');
-    // Main file still has the plain-JS surface.
+    // Main file is the core content verbatim — no use-client (that's
+    // scoped to the React file), no Provider, just the class + types.
+    expect(main).not.toContain('"use client";');
     expect(main).toContain("export class ExampleModel");
     expect(main).not.toContain("export function ExampleProvider(");
+    // No re-export hub in standalone mode — there's no separate
+    // core/index split, so nothing to re-export from.
+    expect(main).not.toContain('export * from "./');
 
-    // React file: imports back from the chosen main basename, also
-    // without the `.js` extension.
+    // React file: imports back from the chosen main basename, without
+    // the `.js` extension so the consumer's bundler resolves the
+    // sibling `.ts` regardless of moduleResolution setting.
+    expect(react).toContain('"use client";');
     expect(react).toContain('from "./example"');
     expect(react).not.toContain('from "./example.js"');
+    expect(react).not.toContain('from "./core.js"');
     expect(react).not.toContain('from "./index.js"');
     expect(react).toContain("export function ExampleProvider(");
     expect(react).toContain("export function useExample()");
   });
 
-  it("with --output as a directory, writes index.ts + index.react.ts", () => {
+  it("with --output as a directory, writes index.ts + index.react.tsx", () => {
     const outputDir = path.join(tmpDir, "src");
     const result = runCli([
       "--schema",
@@ -424,23 +449,24 @@ describe("reactor-codegen CLI — --standalone --react", () => {
 
     expect(result.status).toBe(0);
     expect(fs.readdirSync(outputDir).sort()).toEqual([
-      "index.react.ts",
+      "index.react.tsx",
       "index.ts",
     ]);
     const main = fs.readFileSync(path.join(outputDir, "index.ts"), "utf-8");
     const react = fs.readFileSync(
-      path.join(outputDir, "index.react.ts"),
+      path.join(outputDir, "index.react.tsx"),
       "utf-8",
     );
-    // Both sides of the cross-import get rewritten in standalone
-    // mode: the main file's re-export points at the sibling basename
-    // (`./index.react`), and the React file's back-import points at
-    // the main basename (`./index`). Both have the `.js` extension
-    // stripped so the consumer's bundler resolves the `.ts` source.
-    expect(main).toContain('export * from "./index.react";');
-    expect(main).not.toContain('export * from "./index.react.js";');
+    // Main file is the core content (no re-export hub in standalone
+    // mode). React file's back-import points at the main basename
+    // (`./index`), with the `.js` extension stripped so the
+    // consumer's bundler resolves the `.ts` source regardless of
+    // moduleResolution setting.
+    expect(main).not.toContain('export * from "./');
+    expect(main).toContain("export class ExampleModel");
     expect(react).toContain('from "./index"');
     expect(react).not.toContain('from "./index.js"');
+    expect(react).not.toContain('from "./core.js"');
   });
 
   it("in --dry-run writes nothing and exits 0", () => {

--- a/packages/codegen/__tests__/emitter.test.ts
+++ b/packages/codegen/__tests__/emitter.test.ts
@@ -548,6 +548,7 @@ describe("generateModelSdk", () => {
     expect(pkg.files.map((f) => f.path).sort()).toEqual([
       "README.md",
       "package.json",
+      "src/core.ts",
       "src/index.ts",
       "tsconfig.json",
       "tsup.config.ts",
@@ -596,9 +597,9 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const withSrc = withUpload.files.find((f) => f.path === "src/index.ts")!;
+    const withSrc = withUpload.files.find((f) => f.path === "src/core.ts")!;
     const withoutSrc = withoutUpload.files.find(
-      (f) => f.path === "src/index.ts",
+      (f) => f.path === "src/core.ts",
     )!;
 
     expect(withSrc.content).toContain(
@@ -639,7 +640,7 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain(
       "async schedulePrompt(params: HeliosSchedulePromptParams)",
     );
@@ -662,7 +663,7 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain(
       "onMessage(handler: (message: HeliosMessage) => void)",
     );
@@ -684,7 +685,7 @@ describe("generateModelSdk", () => {
       schema: schema({ modelName: "waypoint", modelVersion: "v0.0.0" }),
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("// Model: waypoint v0.0.0");
     expect(src).not.toContain("vv0.0.0");
     expect(src).toContain('export const MODEL_VERSION = "v0.0.0" as const;');
@@ -698,7 +699,7 @@ describe("generateModelSdk", () => {
       schema: schema({ modelVersion: "1.2.3" }),
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("// Model: helios v1.2.3");
     expect(src).toContain('export const MODEL_VERSION = "1.2.3" as const;');
   });
@@ -720,7 +721,7 @@ describe("generateModelSdk", () => {
     );
     expect(pkgJson.version).toBe("0.0.0");
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain('export const MODEL_VERSION = "v0.0.0" as const;');
   });
 
@@ -757,7 +758,7 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("// Model: helios v0.8.3");
     expect(src).not.toContain("g404f6950");
     expect(src).toContain('export const MODEL_VERSION = "v0.8.3" as const;');
@@ -783,7 +784,7 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("modelTracks: [...HeliosTracks]");
     expect(src).toContain("export const HeliosTracks = [");
     expect(src).toContain('direction: "recvonly"');
@@ -798,7 +799,7 @@ describe("generateModelSdk", () => {
       outputDir: "/tmp/ignored",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     // Look for the property-emit form (`modelTracks: [...HeliosTracks]`)
     // and the tracks constant array, both of which are guarded on
     // `hasTracks`. We intentionally do NOT match the bare word
@@ -864,7 +865,7 @@ describe("emitter — inheritance shape", () => {
       }),
       outputDir: "/tmp/ignored",
     });
-    return pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    return pkg.files.find((f) => f.path === "src/core.ts")!.content;
   }
 
   it("emits `extends Reactor` on the class header", () => {
@@ -951,15 +952,15 @@ describe("React emission — off by default", () => {
       outputDir: "/tmp/ignored",
     });
     // No sibling React file, and no re-export hook in the main file.
-    expect(pkg.files.find((f) => f.path === "src/react.ts")).toBeUndefined();
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    expect(pkg.files.find((f) => f.path === "src/react.tsx")).toBeUndefined();
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).not.toContain('"use client";');
     expect(src).not.toContain('from "react"');
     expect(src).not.toContain("ReactorProvider");
     expect(src).not.toContain('export * from "./react.js"');
   });
 
-  it("package.json exports only the package root", () => {
+  it("package.json exposes the root entry plus a /core subpath (no /react without --react)", () => {
     const pkg = generateModelSdk({
       modelName: "helios",
       modelVersion: "0.1.0",
@@ -976,11 +977,17 @@ describe("React emission — off by default", () => {
         import: "./dist/index.mjs",
         require: "./dist/index.js",
       },
+      "./core": {
+        types: "./dist/core.d.ts",
+        import: "./dist/core.mjs",
+        require: "./dist/core.js",
+      },
     });
+    expect(pkgJson.exports["./react"]).toBeUndefined();
     expect(pkgJson.peerDependencies).toBeUndefined();
   });
 
-  it("tsup entry list has a single entry", () => {
+  it("tsup entry list has two entries (index + core) without --react", () => {
     const pkg = generateModelSdk({
       modelName: "helios",
       modelVersion: "0.1.0",
@@ -989,17 +996,34 @@ describe("React emission — off by default", () => {
       outputDir: "/tmp/ignored",
     });
     const tsup = pkg.files.find((f) => f.path === "tsup.config.ts")!.content;
-    expect(tsup).toContain('entry: ["src/index.ts"]');
-    expect(tsup).not.toContain("src/react.ts");
+    expect(tsup).toContain('entry: ["src/index.ts", "src/core.ts"]');
+    expect(tsup).not.toContain("src/react.tsx");
+  });
+
+  it("tsconfig.json does not set `jsx` when --react is off", () => {
+    const pkg = generateModelSdk({
+      modelName: "helios",
+      modelVersion: "0.1.0",
+      sdkVersion: "2.9.1",
+      schema: schema(),
+      outputDir: "/tmp/ignored",
+    });
+    const tsconfig = JSON.parse(
+      pkg.files.find((f) => f.path === "tsconfig.json")!.content,
+    );
+    expect(tsconfig.compilerOptions.jsx).toBeUndefined();
   });
 });
 
 // ---------------------------------------------------------------------------
 // React emission — on via `react: true`
 //
-// `src/react.ts` ships as a sibling of `src/index.ts`; the main file
-// re-exports everything from it so the public surface stays a single
-// root import. Package.json only exposes `.` — no `/react` subpath.
+// Layout: `src/index.ts` (re-export hub), `src/core.ts` (imperative),
+// `src/react.tsx` (JSX Provider + hooks + track components). The
+// `"use client"` directive lives only on `react.tsx` — neither
+// `index.ts` nor `core.ts` carries it, so RSC consumers importing
+// from `@reactor-models/<name>/core` aren't dragged into a client
+// boundary.
 // ---------------------------------------------------------------------------
 
 describe("React emission — on via react: true", () => {
@@ -1015,7 +1039,12 @@ describe("React emission — on via react: true", () => {
   }
 
   function reactSource(overrides?: Partial<ModelSchema>): string {
-    return reactPkg(overrides).files.find((f) => f.path === "src/react.ts")!
+    return reactPkg(overrides).files.find((f) => f.path === "src/react.tsx")!
+      .content;
+  }
+
+  function coreSource(overrides?: Partial<ModelSchema>): string {
+    return reactPkg(overrides).files.find((f) => f.path === "src/core.ts")!
       .content;
   }
 
@@ -1024,9 +1053,9 @@ describe("React emission — on via react: true", () => {
       .content;
   }
 
-  it("emits src/react.ts with the usual header + use-client directive", () => {
+  it("emits src/react.tsx with the usual header + use-client directive", () => {
     const pkg = reactPkg();
-    const react = pkg.files.find((f) => f.path === "src/react.ts");
+    const react = pkg.files.find((f) => f.path === "src/react.tsx");
     expect(react).toBeDefined();
     expect(react!.content).toContain('"use client";');
     expect(react!.content).toContain(
@@ -1034,34 +1063,36 @@ describe("React emission — on via react: true", () => {
     );
   });
 
-  it("re-exports everything from ./react.js at the bottom of src/index.ts", () => {
-    const src = indexSource();
-    expect(src).toContain('export * from "./react.js";');
-    // The re-export must appear *after* every value declaration — the
-    // circular `react.ts → index.ts` imports (MODEL_NAME, tracks, …)
-    // depend on those bindings being initialised first.
-    const reExportIdx = src.indexOf('export * from "./react.js";');
-    const classIdx = src.indexOf("export class HeliosModel");
-    expect(classIdx).toBeGreaterThan(-1);
-    expect(reExportIdx).toBeGreaterThan(classIdx);
+  it("index.ts re-exports both core and react in that order", () => {
+    const idx = indexSource();
+    expect(idx).toContain('export * from "./core.js";');
+    expect(idx).toContain('export * from "./react.js";');
+    // Core comes first so the React file's back-imports (types from
+    // `./core.js`) resolve to fully-initialised bindings.
+    const coreIdx = idx.indexOf('export * from "./core.js";');
+    const reactIdx = idx.indexOf('export * from "./react.js";');
+    expect(coreIdx).toBeGreaterThan(-1);
+    expect(reactIdx).toBeGreaterThan(coreIdx);
   });
 
-  it("puts a single use-client directive at the top of src/index.ts", () => {
-    const src = indexSource();
-    // Directive must sit in the module prologue, before any imports,
-    // or React/Next.js will ignore it.
-    const directiveIdx = src.indexOf('"use client";');
-    const firstImportIdx = src.indexOf("import ");
-    expect(directiveIdx).toBeGreaterThan(-1);
-    expect(firstImportIdx).toBeGreaterThan(directiveIdx);
-    expect(src.split('"use client";').length - 1).toBe(1);
+  it("puts `use client` only on react.tsx — never on index.ts or core.ts", () => {
+    // The directive must scope the client boundary to the React
+    // module only. Putting it on `index.ts` or `core.ts` would force
+    // every RSC importing from `@reactor-models/<name>` or
+    // `@reactor-models/<name>/core` into a client component.
+    expect(reactSource()).toContain('"use client";');
+    expect(coreSource()).not.toContain('"use client";');
+    expect(indexSource()).not.toContain('"use client";');
   });
 
-  it("src/react.ts uses createElement (never JSX, so file can stay .ts)", () => {
+  it("src/react.tsx emits real JSX (file is .tsx, no createElement)", () => {
     const react = reactSource();
-    expect(react).toContain("createElement(");
-    // No JSX angle brackets in the emitted component bodies.
-    expect(react).not.toMatch(/return\s+</);
+    // No `createElement(` calls — the emitter writes `<Tag ... />`.
+    expect(react).not.toContain("createElement(");
+    // Inside the emitted Provider / track components, the body
+    // returns a JSX expression — the closing `>` of an opening tag
+    // appears.
+    expect(react).toMatch(/return\s+\(?\s*<\w/);
   });
 
   it("emits a <Prefix>Provider that bakes in modelName and modelTracks", () => {
@@ -1069,8 +1100,11 @@ describe("React emission — on via react: true", () => {
       tracks: [{ name: "main", kind: "video", direction: "out" }],
     });
     expect(react).toContain("export function HeliosProvider(");
-    expect(react).toContain("modelName: MODEL_NAME");
-    expect(react).toContain("modelTracks: [...HeliosTracks]");
+    // JSX form: `modelName={MODEL_NAME}` and `modelTracks={[...HeliosTracks]}`
+    // — `{...}` is JSX's expression-container syntax for non-string
+    // prop values.
+    expect(react).toContain("modelName={MODEL_NAME}");
+    expect(react).toContain("modelTracks={[...HeliosTracks]}");
   });
 
   it("Provider omits modelTracks for schemas without tracks", () => {
@@ -1078,9 +1112,9 @@ describe("React emission — on via react: true", () => {
     expect(react).toContain("export function HeliosProvider(");
     // The class-level JSDoc on the Provider references `modelTracks`
     // generically — we're asserting the *prop emit* is absent, not
-    // the doc text. Look for the actual `modelTracks: [...XTracks]`
-    // line that only appears when `hasTracks` is true.
-    expect(react).not.toContain("modelTracks: [...");
+    // the doc text. Look for the actual JSX `modelTracks={[...XTracks]}`
+    // attribute that only appears when `hasTracks` is true.
+    expect(react).not.toContain("modelTracks={[...");
     expect(react).not.toContain("HeliosTracks");
   });
 
@@ -1262,33 +1296,40 @@ describe("React emission — on via react: true", () => {
     expect(react).not.toContain("useHeliosMessage(");
   });
 
-  it("src/react.ts pulls generated constants and types from ./index.js", () => {
+  it("src/react.tsx pulls generated constants and types from ./core.js", () => {
     const react = reactSource({
       events: [{ name: "set_prompt", description: "", fields: {} }],
       messages: [{ name: "prompt_accepted", description: "", fields: {} }],
       tracks: [{ name: "main", kind: "video", direction: "out" }],
     });
-    expect(react).toContain('} from "./index.js";');
+    expect(react).toContain('} from "./core.js";');
     expect(react).toContain("MODEL_NAME");
     expect(react).toContain("HeliosTracks");
     expect(react).toContain("type HeliosOptions");
     expect(react).toContain("type HeliosMessage");
   });
 
-  it("package.json exposes a single root entry + declares react peer dep + hook keywords", () => {
+  it("package.json exposes root + /core + /react subpath exports, declares react peer dep + hook keywords", () => {
     const pkg = reactPkg();
     const pkgJson = JSON.parse(
       pkg.files.find((f) => f.path === "package.json")!.content,
     );
 
-    // Only the root export — the `./react` subpath is intentionally
-    // absent; consumers reach the hooks through the re-export in
-    // `src/index.ts`.
     expect(pkgJson.exports).toEqual({
       ".": {
         types: "./dist/index.d.ts",
         import: "./dist/index.mjs",
         require: "./dist/index.js",
+      },
+      "./core": {
+        types: "./dist/core.d.ts",
+        import: "./dist/core.mjs",
+        require: "./dist/core.js",
+      },
+      "./react": {
+        types: "./dist/react.d.ts",
+        import: "./dist/react.mjs",
+        require: "./dist/react.js",
       },
     });
     expect(pkgJson.peerDependencies).toEqual({ react: ">=18" });
@@ -1298,14 +1339,20 @@ describe("React emission — on via react: true", () => {
     expect(pkgJson.keywords).toContain("hooks");
   });
 
-  it("tsup.config.ts keeps a single entry — bundler follows the re-export", () => {
+  it("tsup.config.ts has three entries when --react: index, core, react", () => {
     const tsup = reactPkg().files.find(
       (f) => f.path === "tsup.config.ts",
     )!.content;
-    // Only `src/index.ts` is compiled; tsup follows `export * from
-    // "./react.js"` to bundle the React file into the same output.
-    expect(tsup).toContain('entry: ["src/index.ts"]');
-    expect(tsup).not.toContain("src/react.ts");
+    expect(tsup).toContain(
+      'entry: ["src/index.ts", "src/core.ts", "src/react.tsx"]',
+    );
+  });
+
+  it("tsconfig.json sets `jsx: react-jsx` when --react is on", () => {
+    const tsconfig = JSON.parse(
+      reactPkg().files.find((f) => f.path === "tsconfig.json")!.content,
+    );
+    expect(tsconfig.compilerOptions.jsx).toBe("react-jsx");
   });
 
   it("the React file stays deterministic for a given input", () => {
@@ -1367,27 +1414,23 @@ describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
     });
   }
 
-  it("emits the `_unwrapMessage` helper in src/index.ts when the schema has messages", () => {
-    const src = buildPkg().files.find(
-      (f) => f.path === "src/index.ts",
-    )!.content;
+  it("emits the `_unwrapMessage` helper in src/core.ts when the schema has messages", () => {
+    const src = buildPkg().files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("function _unwrapMessage<T>(raw: unknown): T {");
     // The helper re-applies `type` after the spread so a payload that
     // happens to carry a `type` field cannot shadow the discriminator.
     expect(src).toContain("...env.data, type: env.type");
   });
 
-  it("omits the `_unwrapMessage` helper in src/index.ts when the schema has no messages (no dead code)", () => {
+  it("omits the `_unwrapMessage` helper in src/core.ts when the schema has no messages (no dead code)", () => {
     const src = buildPkg({ messages: [] }).files.find(
-      (f) => f.path === "src/index.ts",
+      (f) => f.path === "src/core.ts",
     )!.content;
     expect(src).not.toContain("_unwrapMessage");
   });
 
   it("uses `_unwrapMessage` inside the class's onMessage wrapper instead of a naked cast", () => {
-    const src = buildPkg().files.find(
-      (f) => f.path === "src/index.ts",
-    )!.content;
+    const src = buildPkg().files.find((f) => f.path === "src/core.ts")!.content;
     expect(src).toContain("handler(_unwrapMessage<HeliosMessage>(raw));");
     // Guard against the old buggy pattern creeping back.
     expect(src).not.toContain("handler(raw as HeliosMessage);");
@@ -1396,7 +1439,7 @@ describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
   it("on<Name> helpers inherit the unwrap via this.onMessage", () => {
     const src = buildPkg({
       messages: [{ name: "state", description: "", fields: {} }],
-    }).files.find((f) => f.path === "src/index.ts")!.content;
+    }).files.find((f) => f.path === "src/core.ts")!.content;
     // `onState` calls `this.onMessage(...)` which already unwraps, so
     // `msg.type` here is the post-unwrap discriminator, not a raw
     // envelope field.
@@ -1404,23 +1447,23 @@ describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
     expect(src).toContain('if (msg.type === "state") handler(msg as');
   });
 
-  it("emits the `_unwrapMessage` helper in src/react.ts when the schema has messages", () => {
+  it("emits the `_unwrapMessage` helper in src/react.tsx when the schema has messages", () => {
     const react = buildPkg({}, true).files.find(
-      (f) => f.path === "src/react.ts",
+      (f) => f.path === "src/react.tsx",
     )!.content;
     expect(react).toContain("function _unwrapMessage<T>(raw: unknown): T {");
   });
 
-  it("omits the `_unwrapMessage` helper in src/react.ts when there are no messages", () => {
+  it("omits the `_unwrapMessage` helper in src/react.tsx when there are no messages", () => {
     const react = buildPkg({ messages: [] }, true).files.find(
-      (f) => f.path === "src/react.ts",
+      (f) => f.path === "src/react.tsx",
     )!.content;
     expect(react).not.toContain("_unwrapMessage");
   });
 
   it("React catch-all useHeliosMessage unwraps before handing to the handler", () => {
     const react = buildPkg({}, true).files.find(
-      (f) => f.path === "src/react.ts",
+      (f) => f.path === "src/react.tsx",
     )!.content;
     expect(react).toContain(
       "handler(_unwrapMessage<HeliosMessage>(msg)),\n  );",
@@ -1435,7 +1478,7 @@ describe("emitter — message envelope unwrap (REA-1581 follow-up)", () => {
         messages: [{ name: "state", description: "", fields: {} }],
       },
       true,
-    ).files.find((f) => f.path === "src/react.ts")!.content;
+    ).files.find((f) => f.path === "src/react.tsx")!.content;
     expect(react).toContain("const m = _unwrapMessage<HeliosMessage>(msg);");
     expect(react).toContain('if (m.type === "state") {');
     // The prior buggy form compared against the raw envelope.
@@ -1535,9 +1578,9 @@ describe("emitter — typed track helpers (REA-1791)", () => {
     react = false,
   ): { index: string; react?: string } {
     const pkg = pkgWith(tracks, react);
-    const index = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const index = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     const reactFile = react
-      ? pkg.files.find((f) => f.path === "src/react.ts")!.content
+      ? pkg.files.find((f) => f.path === "src/react.tsx")!.content
       : undefined;
     return { index, react: reactFile };
   }
@@ -1641,7 +1684,9 @@ describe("emitter — typed track helpers (REA-1791)", () => {
       true,
     );
     expect(react).toContain("export function HeliosMainVideoView(");
-    expect(react).toContain('track: "main_video"');
+    // JSX prop: `track="main_video"` (string literals use double quotes,
+    // no braces around the expression).
+    expect(react).toContain('track="main_video"');
     // Props are emitted as `type` aliases rather than empty
     // `interface … extends …` declarations — see the lint-friendly
     // emission test below for why.
@@ -1649,7 +1694,7 @@ describe("emitter — typed track helpers (REA-1791)", () => {
       'export type HeliosMainVideoViewProps = Omit<ReactorViewProps, "track">;',
     );
     expect(react).toContain("export function HeliosWebcamView(");
-    expect(react).toContain('track: "webcam"');
+    expect(react).toContain('track="webcam"');
     expect(react).toContain(
       'export type HeliosWebcamViewProps = Omit<WebcamStreamProps, "track">;',
     );
@@ -1788,7 +1833,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       schema,
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     expect(src).toContain('sendCommand("set_prompt\\"; evil(); \\"", {});');
     expect(src).not.toMatch(/sendCommand\("set_prompt"; evil\(\); ""/);
@@ -1822,7 +1867,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       schema,
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     // Both sinks — `type: "…";` in the interface and `msg.type === "…"`
     // in the per-message listener — must emit an escaped literal.
@@ -1843,7 +1888,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       }),
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     expect(src).toContain(
       'export const MODEL_VERSION = "1.0.0\\"; globalThis.pwned = true; \\"" as const;',
@@ -1877,7 +1922,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       }),
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     expect(src).toContain("*\\/ await fetch('attacker');");
     expect(src).not.toContain("*/ await fetch('attacker');");
@@ -1899,7 +1944,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       }),
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     // The smuggled `import` must stay inside the JSDoc body where
     // sanitizeJsDocLine collapsed it next to `first line`; it must not
@@ -1941,7 +1986,7 @@ describe("emitter — injection defence (defense in depth)", () => {
       schema,
       outputDir: "/tmp/ignored",
     });
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
 
     expect(src).toContain('name: "main_video\\"; evil()"');
     expect(src).not.toMatch(/name: "main_video"; evil\(\)"/);
@@ -1962,8 +2007,8 @@ describe("emitter — injection defence (defense in depth)", () => {
 // rules in those configs flag patterns the emitter used to produce:
 //
 //   - `react/no-children-prop` — fires when `children` is passed as a
-//     prop key inside `createElement(Comp, { children: … })` instead of
-//     as the third positional argument.
+//     prop key inside the JSX opening tag (`<Comp children={...}>`)
+//     instead of as JSX body content.
 //   - `@typescript-eslint/no-empty-object-type` (and the older
 //     `no-empty-interface`) — fires on empty
 //     `interface Foo extends Bar {}` declarations because they're
@@ -1991,43 +2036,36 @@ describe("emitter — lint-friendly React emission", () => {
       },
       outputDir: "/tmp/ignored",
       react: true,
-    }).files.find((f) => f.path === "src/react.ts")!.content;
+    }).files.find((f) => f.path === "src/react.tsx")!.content;
   }
 
-  it("Provider passes children as the third createElement argument, not as a prop key (react/no-children-prop)", () => {
-    // The buggy form embeds `children: children,` (or a bare
-    // `children,` shorthand) in the props object passed to
-    // `createElement(ReactorProvider, …)`; that's what
+  it("Provider passes children inside the JSX body, not as a prop key (react/no-children-prop)", () => {
+    // The buggy form embeds `children={children}` (or a bare
+    // `children` shorthand) inside the JSX opening tag; that's what
     // `eslint-plugin-react`'s `react/no-children-prop` rule flags.
     //
-    // The canonical form passes `children` as the third positional
-    // argument to `createElement`. This compiles against @types/react
-    // because the SDK's `ReactorProviderProps` declares `children` as
-    // optional — see the comment in `ReactorProvider.tsx` — so the
-    // overload's second arg can omit it. If the SDK ever tightens
-    // `children` back to required, the emitter has to fall back to
-    // the in-props form with a targeted
-    // `eslint-disable-next-line react/no-children-prop` comment, and
-    // this test will catch the regression.
+    // The canonical form puts children BETWEEN the opening and
+    // closing tags so React's implicit children-prop folding fills
+    // them in — same runtime behaviour, lint-clean. The negative
+    // assertions below pin the absence of both buggy spellings; the
+    // positive assertion confirms the canonical shape.
     const react = reactSourceWith({
       tracks: [{ name: "main_video", kind: "video", direction: "out" }],
     });
 
-    // Buggy form (explicit `children: children` key inside the
-    // createElement props object) must be absent. We don't also
-    // pattern-match a bare `children,` shorthand because the
-    // function's destructuring parameter list legitimately contains
-    // exactly that line — the positive assertion below catches any
-    // accidental shorthand in the props object.
-    expect(react).not.toContain("children: children");
+    expect(react).not.toContain("children={children}");
     // No eslint-disable workaround anywhere in the file: the
     // canonical form lints clean and shouldn't need one.
     expect(react).not.toContain("eslint-disable-next-line");
-    // Canonical form: `createElement(ReactorProvider, { … }, children, );`.
-    // The trailing `}, children,` shape is the load-bearing part —
-    // intermediate spacing varies with the prop list length.
+    // The file should also have ZERO createElement calls now — JSX
+    // is used throughout.
+    expect(react).not.toContain("createElement(");
+    // Canonical JSX form: the `<ReactorProvider …>` open tag closes
+    // with `>`, `{children}` appears in the body, and `</ReactorProvider>`
+    // closes it. The multi-line match tolerates the prop list
+    // wrapping over multiple lines.
     expect(react).toMatch(
-      /createElement\(\s*ReactorProvider,\s*\{[\s\S]*?\},\s*children,\s*\);/,
+      /<ReactorProvider[\s\S]*?>\s*\{children\}\s*<\/ReactorProvider>/,
     );
   });
 

--- a/packages/codegen/__tests__/verifier.test.ts
+++ b/packages/codegen/__tests__/verifier.test.ts
@@ -769,7 +769,7 @@ describe("generateModelSdk integration", () => {
       outputDir: "./out",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     // The zero-width char is stripped before reaching the emitter.
     expect(src).not.toContain("\u200B");
   });
@@ -796,7 +796,7 @@ describe("generateModelSdk integration", () => {
       outputDir: "./out",
     });
 
-    const src = pkg.files.find((f) => f.path === "src/index.ts")!.content;
+    const src = pkg.files.find((f) => f.path === "src/core.ts")!.content;
     const pkgJson = JSON.parse(
       pkg.files.find((f) => f.path === "package.json")!.content,
     );

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -327,7 +327,9 @@ function resolveStandaloneOutputPath(output: string): string {
  *     `.ts` regardless of `moduleResolution` setting.
  */
 function resolveStandaloneReactPath(standaloneOutput: string): string {
-  return standaloneOutput.replace(/\.ts$/, ".react.ts");
+  // The React sibling is a `.tsx` file (real JSX), not `.ts`. Strip
+  // the main file's `.ts` extension and append `.react.tsx`.
+  return standaloneOutput.replace(/\.ts$/, ".react.tsx");
 }
 
 /**
@@ -440,63 +442,61 @@ async function runGenerate(argv: string[]): Promise<void> {
   });
 
   if (args.standalone) {
-    // Standalone mode is intentionally narrow: pluck only the source files
-    // off the generated package and drop them at --output. Skipping the
-    // package scaffold (package.json, tsup.config.ts, tsconfig.json) keeps
-    // the emitter as the single source of truth for what a typed client
+    // Standalone mode is intentionally narrow: pluck only the source
+    // files off the generated package and drop them at --output.
+    // Skipping the package scaffold (package.json, tsup.config.ts,
+    // tsconfig.json, the `src/index.ts` re-export hub) keeps the
+    // emitter as the single source of truth for what a typed client
     // looks like — we never diverge the "drop-in .ts" from the "full
     // package" output.
     //
-    // With --react we also emit the sibling React file. The emitter's
-    // default cross-imports use the full-package filenames
-    // (`./index.js`, `./react.js`); in standalone mode the chosen
-    // basename can be anything, so both sides of the pair are rewritten
-    // to the sibling's actual basename before writing.
-    const indexFile = pkg.files.find((f) => f.path === "src/index.ts");
-    if (!indexFile) {
-      // Defensive: the emitter always emits src/index.ts first; if that
-      // ever changes, fail loudly rather than silently write an empty file.
+    // The "core" file (`src/core.ts` in the package) IS the standalone
+    // file's content — the package-mode re-export hub is unnecessary
+    // when the consumer controls the import path themselves.
+    //
+    // With --react we also emit the sibling React file. The
+    // emitter's default cross-import uses the package-mode path
+    // `./core.js`; in standalone mode the chosen basename can be
+    // anything, so we rewrite the import to point at the actual
+    // sibling.
+    const coreFile = pkg.files.find((f) => f.path === "src/core.ts");
+    if (!coreFile) {
+      // Defensive: the emitter always emits src/core.ts; if that
+      // ever changes, fail loudly rather than silently write an
+      // empty file.
       throw new Error(
-        "Internal error: generated package is missing src/index.ts",
+        "Internal error: generated package is missing src/core.ts",
       );
     }
 
     const outputFile = path.resolve(resolveStandaloneOutputPath(args.output));
     const reactFile = args.react
-      ? pkg.files.find((f) => f.path === "src/react.ts")
+      ? pkg.files.find((f) => f.path === "src/react.tsx")
       : undefined;
     const reactOutputFile = args.react
       ? resolveStandaloneReactPath(outputFile)
       : undefined;
     const mainBasename = path.basename(outputFile).replace(/\.ts$/, "");
-    const reactBasename = reactOutputFile
-      ? path.basename(reactOutputFile).replace(/\.ts$/, "")
-      : undefined;
-    // `resolveStandaloneReactPath` always produces `<main>.react.ts`,
-    // so in standalone mode the sibling's basename is never literally
-    // `react` — we can unconditionally rewrite the main file's
-    // re-export path. The React-side back-import (`./index.js`) is
-    // also unconditionally rewritten so the `.js` extension gets
-    // stripped even when the main basename is the default `index`
-    // (see `resolveStandaloneReactPath` for why standalone never
-    // emits `.js`).
-    const indexContent =
-      args.react && reactBasename
-        ? indexFile.content.replace(
-            /export \* from "\.\/react\.js";/g,
-            `export * from "./${reactBasename}";`,
-          )
-        : indexFile.content;
+
+    // The main standalone file is the core content verbatim — no
+    // rewriting needed, since the core file never imports from a
+    // sibling (only from `@reactor-team/js-sdk`). The React file,
+    // when present, imports from `./core.js` in package mode; in
+    // standalone we rewrite that to point at the actual main file's
+    // basename. Dropping the `.js` extension lets the consumer's
+    // bundler resolve the sibling `.ts` regardless of `moduleResolution`
+    // setting (see `resolveStandaloneReactPath` for the same logic).
+    const mainContent = coreFile.content;
     const reactContent = reactFile
       ? reactFile.content.replace(
-          /from "\.\/index\.js"/g,
+          /from "\.\/core\.js"/g,
           `from "./${mainBasename}"`,
         )
       : undefined;
 
     if (args.dryRun) {
       console.log(`--- ${outputFile} ---`);
-      console.log(indexContent);
+      console.log(mainContent);
       console.log();
       if (reactContent && reactOutputFile) {
         console.log(`--- ${reactOutputFile} ---`);
@@ -508,7 +508,7 @@ async function runGenerate(argv: string[]): Promise<void> {
     }
 
     fs.mkdirSync(path.dirname(outputFile), { recursive: true });
-    fs.writeFileSync(outputFile, indexContent, "utf-8");
+    fs.writeFileSync(outputFile, mainContent, "utf-8");
     console.log(`Generated standalone source at ${outputFile}`);
     if (reactContent && reactOutputFile) {
       fs.writeFileSync(reactOutputFile, reactContent, "utf-8");
@@ -524,12 +524,12 @@ async function runGenerate(argv: string[]): Promise<void> {
         `  react >=18 is required (the hooks file imports from "react")`,
       );
     }
-    console.log(
-      `  Import the Model class` +
-        (args.react ? ", Provider, and hooks " : " ") +
-        `from ${outputFile}` +
-        (args.react ? " — the main file re-exports the React bindings" : ""),
-    );
+    if (args.react && reactOutputFile) {
+      console.log(`  Import the Model class from ${outputFile}`);
+      console.log(`  Import the Provider and hooks from ${reactOutputFile}`);
+    } else {
+      console.log(`  Import the Model class from ${outputFile}`);
+    }
     return;
   }
 

--- a/packages/codegen/src/emitter.ts
+++ b/packages/codegen/src/emitter.ts
@@ -736,18 +736,23 @@ function generateClientClass(
 //
 // Design choices, in case you're reviewing and wondering:
 //
-//   - We use `React.createElement` rather than JSX so the emitter stays a
-//     pure string builder with no JSX-escaping concerns and the generated
-//     file can stay `.ts` (not `.tsx`). tsup/TS handle this fine.
+//   - We emit real JSX (file is `.tsx`). The Provider and per-track
+//     wrapper components use `<Tag {...spread} prop={value} />` syntax;
+//     children flow as the JSX body, never as a prop key, so the
+//     `react/no-children-prop` lint stays clean automatically.
 //
 //   - The provider is a thin wrapper around `ReactorProvider` that bakes in
 //     `modelName: MODEL_NAME` and `modelTracks: [...<Prefix>Tracks]`, so
-//     consumers never have to wire those up themselves.
+//     consumers never have to wire those up themselves. Everything else
+//     (props from `ReactorProvider`'s own signature) is forwarded via
+//     `{...rest}` spread.
 //
-//   - The `use<Prefix>()` hook exposes typed `sendCommand`-bound methods
-//     (one per event), plus `status`, and — when any event takes an upload
-//     reference — `uploadFile`. It selects state from the store via
-//     `useReactor` so it re-renders on `status` changes.
+//   - The `use<Prefix>()` hook emits one `useReactor((s) => s.X)`
+//     selector per field on the SDK's `ReactorStore` (derived from
+//     `js-sdk`'s d.ts via `loadReactorStoreFieldsFromDts`), then
+//     layers schema-derived typed event methods on top. New SDK
+//     store fields flow through automatically on the next
+//     `defaultSdkVersion` bump.
 //
 //   - Per-message hooks (`use<Prefix><Msg>`) filter by the discriminator
 //     (`type: "..."`) inside `useReactorMessage` and hand the handler the
@@ -917,28 +922,14 @@ function generateProviderComponent(
     0,
   );
 
-  // `children` is passed as `createElement`'s third positional
-  // argument rather than as a key inside the props object. Both forms
-  // are equivalent at runtime — React folds the variadic
-  // `...children: ReactNode[]` rest into the `children` prop — but
-  // `eslint-plugin-react`'s `react/no-children-prop` rule (in the
-  // recommended config and the Next.js shareable config) flags any
-  // `createElement` call that passes `children` as a prop key.
-  //
-  // The third-arg form only compiles against @types/react's
-  // overloads when the component's prop type doesn't declare
-  // `children` as a required field. The SDK's `ReactorProviderProps`
-  // declares `children?: ReactNode` (since js-sdk 2.9.3); if that's
-  // ever tightened back to required, this emitter has to fall back to
-  // the in-props form with a targeted `eslint-disable-next-line
-  // react/no-children-prop` comment. Pinned by a regression test in
-  // `emitter.test.ts`.
-  //
-  // Everything other than `children` is forwarded via `...rest`
-  // spread, so a future `ReactorProvider` prop addition reaches
-  // through without renaming each field by hand.
-  const tracksProp = hasTracks
-    ? `\n      modelTracks: [...${modelPrefix}Tracks],`
+  // JSX form: pass `children` between the open/close tags so React's
+  // implicit `children` prop folding fills it in, and the
+  // `react/no-children-prop` lint stays clean automatically. The
+  // `{...rest}` spread is the bit that future-proofs forwarding —
+  // any new prop `ReactorProvider` gains flows through without
+  // renaming each field here.
+  const tracksAttr = hasTracks
+    ? `\n      modelTracks={[...${modelPrefix}Tracks]}`
     : "";
 
   return `${propsDoc}export type ${providerName}Props = Omit<
@@ -950,13 +941,13 @@ ${doc}export function ${providerName}({
   children,
   ...rest
 }: ${providerName}Props): ReactElement {
-  return createElement(
-    ReactorProvider,
-    {
-      ...rest,
-      modelName: MODEL_NAME,${tracksProp}
-    },
-    children,
+  return (
+    <ReactorProvider
+      {...rest}
+      modelName={MODEL_NAME}${tracksAttr}
+    >
+      {children}
+    </ReactorProvider>
   );
 }`;
 }
@@ -1015,12 +1006,12 @@ function generateReactFile(options: CodegenOptions): string {
   sections.push(`"use client";`);
   sections.push("");
 
-  // React imports. `createElement` lets us stay in `.ts` (no JSX).
-  // `ReactNode` is no longer named in the emitted source — the
-  // `<Prefix>ProviderProps` type derives from `ReactorProvider`'s
-  // own props, so `children` lives inside that resolved type and we
-  // don't need a separate alias here.
-  sections.push(`import { createElement, type ReactElement } from "react";`);
+  // React imports. The file is `.tsx` so we emit real JSX, not
+  // `createElement` calls. `ReactElement` is still imported as the
+  // return type of the Provider + per-track wrapper components, so
+  // the emitted source stays explicit about its return shape without
+  // relying on JSX namespace defaults.
+  sections.push(`import { type ReactElement } from "react";`);
 
   // SDK imports. We only import what the emitted surface actually uses so
   // tree-shaking in the consumer project stays tight. `Parameters<typeof
@@ -1041,9 +1032,9 @@ function generateReactFile(options: CodegenOptions): string {
     `import {\n  ${sdkImports.join(",\n  ")},\n} from "@reactor-team/js-sdk";`,
   );
 
-  // Pull the generated constants and types from the sibling index.ts.
-  // The `.js` extension is required for Node's ESM resolver and matches
-  // what tsup produces.
+  // Pull the generated constants and types from the sibling core.ts.
+  // The `.js` extension is required for Node's ESM resolver and
+  // matches what tsup produces.
   const localImports: string[] = ["MODEL_NAME"];
   if (hasTracks) localImports.push(`${modelPrefix}Tracks`);
   localImports.push(`type ${modelPrefix}Options`);
@@ -1065,7 +1056,7 @@ function generateReactFile(options: CodegenOptions): string {
     localImports.push(`type ${modelPrefix}RecvTrackName`);
   }
   sections.push(
-    `import {\n  ${localImports.join(",\n  ")},\n} from "./index.js";`,
+    `import {\n  ${localImports.join(",\n  ")},\n} from "./core.js";`,
   );
   sections.push("");
 
@@ -1222,10 +1213,7 @@ ${generateJsDoc(
 )}export function ${componentName}(
   props: ${propsName},
 ): ReactElement {
-  return createElement(ReactorView, {
-    ...props,
-    track: ${JSON.stringify(track.name)},
-  });
+  return <ReactorView {...props} track=${JSON.stringify(track.name)} />;
 }`,
     );
   }
@@ -1247,10 +1235,7 @@ ${generateJsDoc(
 )}export function ${componentName}(
   props: ${propsName},
 ): ReactElement {
-  return createElement(WebcamStream, {
-    ...props,
-    track: ${JSON.stringify(track.name)},
-  });
+  return <WebcamStream {...props} track=${JSON.stringify(track.name)} />;
 }`,
     );
   }
@@ -1260,15 +1245,86 @@ ${generateJsDoc(
 
 // ---------------------------------------------------------------------------
 // Full source file assembly
+//
+// The generated package is structured as:
+//
+//   src/index.ts   — re-export hub (`export * from "./core.js"` and,
+//                    when --react, also `export * from "./react.js"`).
+//                    No `"use client"`; that directive sits on the
+//                    `react.tsx` file where it belongs so RSC consumers
+//                    importing from `<pkg>/core` aren't dragged into a
+//                    client boundary.
+//
+//   src/core.ts    — types, constants, generated `<Prefix>Model`
+//                    class, `_unwrapMessage` helper. No React. Always
+//                    emitted.
+//
+//   src/react.tsx  — `<Prefix>Provider`, `use<Prefix>()`, message
+//                    hooks, track hooks, track-component wrappers.
+//                    Real JSX. Emitted only when --react.
+//
+// In standalone mode the index hub collapses (`<base>.ts` IS the core
+// content) and the React file, when emitted, lives at
+// `<base>.react.tsx` next to it.
 // ---------------------------------------------------------------------------
 
-function generateSourceFile(options: CodegenOptions): string {
+/**
+ * Emit `src/index.ts` — a thin re-export hub.
+ *
+ * Always re-exports the core; when `--react` is on, also re-exports
+ * the React layer. Consumers using `@reactor-models/<name>` keep
+ * working unchanged; consumers who want React-free bundle scope can
+ * import from `@reactor-models/<name>/core` directly (subpath export
+ * wired in `generatePackageJson`).
+ *
+ * No `"use client"` here. The directive lives on `react.tsx` so the
+ * RSC boundary is scoped to the React module only.
+ */
+function generateIndexFile(options: CodegenOptions): string {
+  const { schema } = options;
+  const withReact = !!options.react;
+
+  const sections: string[] = [];
+
+  sections.push(
+    `// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.`,
+  );
+  sections.push("");
+  sections.push(`// Auto-generated by @reactor-team/codegen — DO NOT EDIT`);
+  sections.push(
+    `// Model: ${schema.modelName} ${formatVersionForHeader(schema.modelVersion)}`,
+  );
+  sections.push("");
+  sections.push(`export * from "./core.js";`);
+  if (withReact) {
+    sections.push(`export * from "./react.js";`);
+  }
+  sections.push("");
+  return sections.join("\n");
+}
+
+/**
+ * Emit `src/core.ts` — the imperative + type surface of the generated
+ * package. Contains the SDK imports, `MODEL_NAME` / `MODEL_VERSION`
+ * constants, track constants + types, event param interfaces,
+ * message interfaces + discriminated union, `<Prefix>Options` derived
+ * type, the `_unwrapMessage` helper (when messages exist), and the
+ * generated `<Prefix>Model extends Reactor` class.
+ *
+ * Never references React. Safe to import from server components and
+ * non-React environments.
+ *
+ * Also used as the body of standalone-mode emissions — in
+ * `--standalone` the consumer's single `<base>.ts` file is exactly
+ * this content (the index re-export hub is unnecessary when the
+ * consumer controls the import path).
+ */
+function generateCoreFile(options: CodegenOptions): string {
   const { schema } = options;
   const modelPrefix = toPascalCase(schema.modelName);
   const events = schema.events;
   const messages = schema.messages;
   const tracks = schema.tracks;
-  const withReact = !!options.react;
 
   const needsFileRef = events.some(hasUploadRefParam);
 
@@ -1283,20 +1339,6 @@ function generateSourceFile(options: CodegenOptions): string {
     `// Model: ${schema.modelName} ${formatVersionForHeader(schema.modelVersion)}`,
   );
   sections.push("");
-
-  // `"use client";` goes at the very top of `src/index.ts` when React
-  // output is on, because the file re-exports from `./react.js` below
-  // — i.e. the bundled `dist/index.js` contains the Provider + hooks,
-  // so the whole module is a client-only boundary in the React Server
-  // Components world. The plain-JS `Reactor` client below already only
-  // runs in the browser (WebRTC doesn't exist server-side), so nothing
-  // legitimate is lost by marking it client-only; consumers can still
-  // import `MODEL_NAME` / types / the `Model` class from server
-  // components via Next.js's client-reference passthrough.
-  if (withReact) {
-    sections.push(`"use client";`);
-    sections.push("");
-  }
 
   const imports = ["Reactor"];
   if (needsFileRef) imports.push("FileRef");
@@ -1364,16 +1406,6 @@ function generateSourceFile(options: CodegenOptions): string {
   sections.push("");
   sections.push(generateClientClass(modelPrefix, events, messages, tracks));
 
-  // Re-export everything the React file defines so consumers only ever
-  // import from `@reactor-models/<name>` — no `/react` subpath. The
-  // re-export must come *after* every value declaration above, so the
-  // circular `react.ts → index.ts` imports (for `MODEL_NAME`,
-  // `<Prefix>Tracks`, etc.) resolve to fully-initialised bindings.
-  if (withReact) {
-    sections.push("");
-    sections.push(`export * from "./react.js";`);
-  }
-
   sections.push("");
   return sections.join("\n");
 }
@@ -1383,16 +1415,37 @@ function generateSourceFile(options: CodegenOptions): string {
 // ---------------------------------------------------------------------------
 
 function generatePackageJson(options: CodegenOptions): string {
-  // Single entry at the package root — the Provider + hooks (when
-  // `options.react`) live in `src/index.ts` alongside the plain-JS
-  // client, so consumers never need a `/react` subpath.
+  // Three entries when --react: the root combined entry plus two
+  // subpath entries (`/core` and `/react`) so consumers can opt out
+  // of React in environments that don't want it (server-side
+  // scripts, RSC, bundle-size-sensitive client builds). The root
+  // entry re-exports both via `src/index.ts` so existing
+  // `import { ... } from "@reactor-models/<name>"` call sites keep
+  // working unchanged.
+  //
+  // Without --react there's only `core.ts` to ship, but we still
+  // expose `/core` as a subpath alias of the root entry — the
+  // codegen output shape (and consumer mental model) stays uniform
+  // across the --react toggle.
   const exports: Record<string, Record<string, string>> = {
     ".": {
       types: "./dist/index.d.ts",
       import: "./dist/index.mjs",
       require: "./dist/index.js",
     },
+    "./core": {
+      types: "./dist/core.d.ts",
+      import: "./dist/core.mjs",
+      require: "./dist/core.js",
+    },
   };
+  if (options.react) {
+    exports["./react"] = {
+      types: "./dist/react.d.ts",
+      import: "./dist/react.mjs",
+      require: "./dist/react.js",
+    };
+  }
 
   // React is only a peer dependency when React emission is on. We list it
   // here (not `dependencies`) so consumers resolve to their own React
@@ -1438,11 +1491,19 @@ function generatePackageJson(options: CodegenOptions): string {
   return JSON.stringify(pkg, null, 2) + "\n";
 }
 
-function generateTsupConfig(_options: CodegenOptions): string {
+function generateTsupConfig(options: CodegenOptions): string {
+  // Two entries by default (`index.ts` + `core.ts`) so the
+  // `@reactor-models/<name>/core` subpath export resolves to a real
+  // built artifact, not a re-export hop through `index.js`. With
+  // --react the third entry (`react.tsx`) is added; tsup picks up
+  // `.tsx` and emits both CJS and ESM bundles with JSX compiled.
+  const entries = [`"src/index.ts"`, `"src/core.ts"`];
+  if (options.react) entries.push(`"src/react.tsx"`);
+
   return `import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: [${entries.join(", ")}],
   format: ["cjs", "esm"],
   dts: true,
   sourcemap: true,
@@ -1451,20 +1512,30 @@ export default defineConfig({
 `;
 }
 
-function generateTsConfig(): string {
+function generateTsConfig(options: CodegenOptions): string {
+  // `jsx: "react-jsx"` is added only when --react is on so the
+  // generated `react.tsx` compiles. The new JSX transform (React 17+)
+  // means consumers don't need to `import React` at the top of the
+  // file — the runtime helpers are injected by the compiler. Without
+  // --react there's no `.tsx` in `rootDir`, so the `jsx` field stays
+  // absent for a tidy tsconfig.
+  const compilerOptions: Record<string, unknown> = {
+    target: "ES2022",
+    module: "ESNext",
+    moduleResolution: "bundler",
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    forceConsistentCasingInFileNames: true,
+    outDir: "dist",
+    rootDir: "src",
+    declaration: true,
+  };
+  if (options.react) {
+    compilerOptions.jsx = "react-jsx";
+  }
   const config = {
-    compilerOptions: {
-      target: "ES2022",
-      module: "ESNext",
-      moduleResolution: "bundler",
-      strict: true,
-      esModuleInterop: true,
-      skipLibCheck: true,
-      forceConsistentCasingInFileNames: true,
-      outDir: "dist",
-      rootDir: "src",
-      declaration: true,
-    },
+    compilerOptions,
     include: ["src"],
     exclude: ["node_modules", "dist"],
   };
@@ -1485,25 +1556,33 @@ function generateTsConfig(): string {
 
 export const generator = {
   generate(options: CodegenOptions): GeneratedPackage {
-    const files = [
-      { path: "src/index.ts", content: generateSourceFile(options) },
+    // Package layout:
+    //   - `src/index.ts`  — thin re-export hub. Always.
+    //   - `src/core.ts`   — types + class + constants. Always.
+    //   - `src/react.tsx` — Provider + hooks + JSX track components.
+    //                       Only when `options.react`.
+    //
+    // The re-export hub + per-file subpath exports in package.json
+    // let consumers pick their import scope: `@reactor-models/<name>`
+    // for everything, `/core` for React-free bundle scope,
+    // `/react` for React-only isolation.
+    const files: GeneratedPackage["files"] = [
+      { path: "src/index.ts", content: generateIndexFile(options) },
+      { path: "src/core.ts", content: generateCoreFile(options) },
       { path: "package.json", content: generatePackageJson(options) },
       { path: "tsup.config.ts", content: generateTsupConfig(options) },
-      { path: "tsconfig.json", content: generateTsConfig() },
+      { path: "tsconfig.json", content: generateTsConfig(options) },
       // README sits at the package root, not under `src/`, per npm
       // convention. `package.json`'s `files` array already lists it, so
       // `npm pack` picks it up automatically.
       { path: "README.md", content: generateReadme(options) },
     ];
 
-    // When React output is on, emit `src/react.ts` as a sibling of
-    // `src/index.ts`. The main file re-exports everything from it, so
-    // the public surface is still a single root import — the split is
-    // purely a source-layout concern. Slotted right after `src/index.ts`
-    // for readable dry-run output.
+    // `src/react.tsx` slotted between `core.ts` and `package.json`
+    // for readable dry-run output (source files grouped together).
     if (options.react) {
-      files.splice(1, 0, {
-        path: "src/react.ts",
+      files.splice(2, 0, {
+        path: "src/react.tsx",
         content: generateReactFile(options),
       });
     }


### PR DESCRIPTION
Why
---
The generated package previously had a single `src/index.ts` containing
the class, types, and (with --react) the Provider + hooks. Three issues
that's grown into:

  1. Non-React consumers couldn't avoid React in their bundle scope —
     `import { HeliosModel } from "@reactor-models/helios"` pulled in
     the Provider chain even when the consumer never touched it.

  2. The `"use client"` directive sat on the top of `src/index.ts`
     when --react was on, which marks the whole module as client-only.
     Next.js / RSC consumers couldn't `import { HeliosModel }` from a
     server component without the codegen forcing them into a client
     boundary.

  3. The React file used `createElement(...)` everywhere instead of
     real JSX, because the file extension was `.ts`. That was a
     pragmatic choice to avoid JSX-escaping concerns in the emitter,
     but it produced a non-idiomatic generated source.

What changed
------------
The generated package is now structured as:

    src/index.ts    — thin re-export hub. Always emitted.
                      `export * from "./core.js";`
                      `export * from "./react.js";` (only with --react)
                      No `"use client"`.

    src/core.ts     — imperative + types surface (the class, the
                      MODEL_NAME constants, the track constants, the
                      param/message interfaces, the discriminated
                      union, the deprecated `get reactor()` accessor,
                      the `_unwrapMessage` helper). Always emitted.
                      Never imports from "react".

    src/react.tsx   — Provider + hooks + JSX track components. Only
                      emitted with --react. Carries `"use client"` at
                      the top. Imports types from `./core.js`.

Package.json `exports` field gains two subpath entries:

    "./core"  → built artifact of src/core.ts
    "./react" → built artifact of src/react.tsx (only with --react)

so consumers can pick their bundle / RSC scope:

    import { HeliosModel, HeliosProvider } from "@reactor-models/helios";       // root
    import { HeliosModel } from "@reactor-models/helios/core";                   // React-free
    import { HeliosProvider, useHelios } from "@reactor-models/helios/react";   // React-only

`tsconfig.json` now sets `jsx: "react-jsx"` when --react is on (the new
JSX transform, no `import React` needed). `tsup.config.ts` `entry`
array grows to match — two entries by default, three with --react.

JSX conversion: every `createElement(...)` call in the React emission
becomes real JSX. Provider body uses `{...rest}` spread to forward
every prop ReactorProvider supports, with `{children}` inside the JSX
body so `react/no-children-prop` stays lint-clean automatically (no
eslint-disable comment, no order-of-arguments fragility).

Standalone mode
---------------
Standalone (single-file, drop-in) preserves the minimal-file ethos:

  `--standalone`           → 1 file: `<base>.ts` (core content
                              verbatim; no re-export hub).
  `--standalone --react`   → 2 files: `<base>.ts` + `<base>.react.tsx`.
                              The React file's cross-import is
                              rewired from `./core.js` to `./<base>`
                              (no `.js` extension so the consumer's
                              bundler resolves the sibling `.ts`
                              regardless of moduleResolution).

The 3-file split that package mode uses (index + core + react) would
add a re-export-hub file with no purpose in standalone, since the
consumer controls the import path themselves.

Tests
-----
Layout change required updating every test that pinned a file path.
The bulk renames:
  - `src/index.ts` content assertions → `src/core.ts` (where the
    imperative content moved). The handful that legitimately tested
    the re-export hub stay on `src/index.ts`.
  - `src/react.ts` → `src/react.tsx`.
  - `createElement(...)` regex pins → JSX equivalents
    (`<ReactorProvider modelName={...}>{children}</ReactorProvider>`).

New tests added:
  - `index.ts re-exports both core and react in that order` — pins
    the ordering so the React file's back-imports resolve cleanly.
  - `puts "use client" only on react.tsx — never on index.ts or
    core.ts` — pins the RSC-friendly scope.
  - `src/react.tsx emits real JSX (file is .tsx, no createElement)`.
  - `package.json exposes root + /core + /react subpath exports`.
  - `tsconfig.json sets "jsx": "react-jsx" when --react is on`.
  - `tsup.config.ts has three entries when --react`.

CLI runner messaging updated: `--standalone --react` now prints
separate "Import the Model class from <main>" and "Import the
Provider and hooks from <react>" lines (the previous "main file
re-exports the React bindings" wording no longer applies — there's
no main-file re-export in standalone mode).

README updated: the package layout diagram now lists three files,
the subpath-import table covers /core and /react, and the standalone
mode section documents the 1-file / 2-file split and the `.tsx`
extension on the React sibling.

Tests: `pnpm --filter @reactor-team/codegen test` (347 pass, +2 new)
and `pnpm --filter @reactor-team/js-sdk test:unit` (284 pass).
E2E: package mode (with and without --react) and standalone mode
(both variants) generate + build cleanly against the published 2.9.3
js-sdk; the --react package mode produces three DTS bundles
(index.d.ts, core.d.ts, react.d.ts).

Co-authored-by: Cursor <cursoragent@cursor.com>