### PR TITLE
[REA-2219] [codegen] README template: React 19 `use()` for the token promise

### DIFF
--- a/packages/codegen/__tests__/readme-emitter.test.ts
+++ b/packages/codegen/__tests__/readme-emitter.test.ts
@@ -94,6 +94,70 @@ describe("README emission", () => {
     // invariant that {{ ... }} object literals survive substitution.
   });
 
+  it("advertises React 19's `use()` pattern for the token promise (REA-2219)", () => {
+    // The template documents a single canonical token-fetch pattern,
+    // aligned with the public docs at https://docs.reactor.inc:
+    //
+    //     async function getToken() {
+    //       const r = await fetch("/api/reactor/token", { method: "POST" });
+    //       const { jwt } = await r.json();
+    //       return jwt;
+    //     }
+    //     const tokenPromise = getToken();
+    //
+    //     export default function App() {
+    //       const token = use(tokenPromise);
+    //       return <Provider jwtToken={token}>…</Provider>;
+    //     }
+    //
+    // This:
+    //   - removes the `useEffect` + `useState` + null-check dance
+    //     consumers were copy-pasting from the old template
+    //   - leans on the consumer's existing Suspense boundary (Next.js
+    //     app dir / React Router data router / framework default)
+    //     rather than wiring one inside our snippet
+    //   - is the contemporary React 19 idiom for sync data
+    //
+    // A regression to the old `useEffect` pattern would silently break
+    // the contract — both branches of the docs (Authenticate +
+    // Connect) need to stay aligned, so we pin both.
+    const md = readmeFor();
+
+    // Imports: just `use` from "react", not `useEffect`/`useState`.
+    expect(md).toContain('import { use } from "react";');
+
+    // No `useEffect` / `useState` in the emitted CODE BLOCKS — the
+    // prose note above the examples is allowed to reference them as
+    // the React 18 fallback path, but a code-block occurrence would
+    // mean the old pattern crept back into the canonical example.
+    // Extract every fenced code block and assert on those, not the
+    // whole document.
+    const codeBlocks = [...md.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map(
+      (m) => m[1],
+    );
+    expect(codeBlocks.length).toBeGreaterThan(0);
+    for (const block of codeBlocks) {
+      expect(block).not.toContain("useEffect");
+      expect(block).not.toContain("useState");
+    }
+
+    // The promise comes from an `async function getToken()` helper at
+    // module scope; the canonical fetch call stays
+    // `/api/reactor/token` (matches the Next.js route handler above).
+    expect(md).toContain("async function getToken() {");
+    expect(md).toContain('fetch("/api/reactor/token", { method: "POST" })');
+    expect(md).toContain("const tokenPromise = getToken();");
+
+    // `use(tokenPromise)` is read inside the component body and the
+    // result is bound to `token`.
+    expect(md).toContain("const token = use(tokenPromise);");
+
+    // The note above the examples calls out the React 19 requirement
+    // and points React 18 users back at the older pattern.
+    expect(md).toMatch(/React 19/);
+    expect(md).toMatch(/React 18/);
+  });
+
   it("renders one section per event with a param table + JS/React snippets", () => {
     const md = readmeFor({
       events: [

--- a/packages/codegen/templates/readme.md
+++ b/packages/codegen/templates/readme.md
@@ -24,7 +24,7 @@ import { {{MODEL_PREFIX}}Model } from "@reactor-models/{{MODEL_NAME}}";
 import { {{MODEL_PREFIX}}Provider, use{{MODEL_PREFIX}} } from "@reactor-models/{{MODEL_NAME}}";
 ```
 
-React 18 or later is required when using the provider and hooks.
+React 18 or later is required when using the provider and hooks. The token-loading examples below use [React 19's `use()`](https://react.dev/reference/react/use); on React 18, fetch the JWT in a `useEffect` and pass it to the provider once it resolves.
 
 ---
 
@@ -56,23 +56,23 @@ Call the `/api/reactor/token` route above from a client component and pass the r
 
 ```tsx
 "use client";
-import { useEffect, useState } from "react";
+
+import { use } from "react";
 import { {{MODEL_PREFIX}}Provider } from "@reactor-models/{{MODEL_NAME}}";
 import { ReactorView } from "@reactor-team/js-sdk";
 
+async function getToken() {
+  const r = await fetch("/api/reactor/token", { method: "POST" });
+  const { jwt } = await r.json();
+  return jwt;
+}
+
+const tokenPromise = getToken();
+
 export default function App() {
-  const [jwt, setJwt] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch("/api/reactor/token", { method: "POST" })
-      .then((r) => r.json())
-      .then((d) => setJwt(d.jwt));
-  }, []);
-
-  if (!jwt) return null;
-
+  const token = use(tokenPromise);
   return (
-    <{{MODEL_PREFIX}}Provider jwtToken={jwt} connectOptions={{ autoConnect: true }}>
+    <{{MODEL_PREFIX}}Provider jwtToken={token} connectOptions={{ autoConnect: true }}>
       <ReactorView className="w-full aspect-video" />
     </{{MODEL_PREFIX}}Provider>
   );
@@ -94,12 +94,21 @@ await {{MODEL_NAME}}.connect(jwt);
 
 ### React
 
-The provider takes the JWT as a prop; fetch it from the same `/api/reactor/token` route the Authenticate example mints.
+The provider takes the JWT as a prop; fetch it from the same `/api/reactor/token` route the Authenticate example mints:
 
 ```tsx
 "use client";
-import { useEffect, useState } from "react";
+
+import { use } from "react";
 import { {{MODEL_PREFIX}}Provider, use{{MODEL_PREFIX}} } from "@reactor-models/{{MODEL_NAME}}";
+
+async function getToken() {
+  const r = await fetch("/api/reactor/token", { method: "POST" });
+  const { jwt } = await r.json();
+  return jwt;
+}
+
+const tokenPromise = getToken();
 
 function Controller() {
   const { status } = use{{MODEL_PREFIX}}();
@@ -107,18 +116,9 @@ function Controller() {
 }
 
 export default function App() {
-  const [jwt, setJwt] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch("/api/reactor/token", { method: "POST" })
-      .then((r) => r.json())
-      .then((d) => setJwt(d.jwt));
-  }, []);
-
-  if (!jwt) return null;
-
+  const token = use(tokenPromise);
   return (
-    <{{MODEL_PREFIX}}Provider jwtToken={jwt}>
+    <{{MODEL_PREFIX}}Provider jwtToken={token}>
       <Controller />
     </{{MODEL_PREFIX}}Provider>
   );


### PR DESCRIPTION
## Why

The generated `@reactor-models/<name>` README templated the React auth example with the verbose `useEffect` + `useState` + null-guard dance:

```tsx
const [jwt, setJwt] = useState<string | null>(null);
useEffect(() => {
  fetch("/api/reactor/token", { method: "POST" })
    .then((r) => r.json())
    .then((d) => setJwt(d.jwt));
}, []);
if (!jwt) return null;
return <HeliosProvider jwtToken={jwt}>...</HeliosProvider>;
```

That's the React 18 idiom and it's what consumers ended up copy-pasting into their own apps. React 19's [`use()`](https://react.dev/reference/react/use) reads a promise's resolved value directly inside the render — half the lines, no null-state branch, no re-render flash between "no JWT yet" and "JWT ready".

This PR aligns the model READMEs with the canonical pattern already documented at [docs.reactor.inc/authentication](https://docs.reactor.inc/authentication) and [/quickstart](https://docs.reactor.inc/quickstart), so the surface a consumer sees on `npmjs.com/package/@reactor-models/<name>` matches what they read in the docs.

## What changed

### `packages/codegen/templates/readme.md`

Both React examples (Authenticate + Connect) now use the docs-aligned shape:

```tsx
"use client";

import { use } from "react";
import { HeliosProvider } from "@reactor-models/helios";
import { ReactorView } from "@reactor-team/js-sdk";

async function getToken() {
  const r = await fetch("/api/reactor/token", { method: "POST" });
  const { jwt } = await r.json();
  return jwt;
}

const tokenPromise = getToken();

export default function App() {
  const token = use(tokenPromise);
  return (
    <HeliosProvider jwtToken={token} connectOptions={{ autoConnect: true }}>
      <ReactorView className="w-full aspect-video" />
    </HeliosProvider>
  );
}
```

Specifically:

- Named `async function getToken()` helper, module-scope `const tokenPromise = getToken()`, `const token = use(tokenPromise)` directly inside the component — verbatim match for the docs idiom.
- **No `<Suspense>` wrapper inside the snippet.** The consumer's framework (Next.js app dir, React Router data router, etc.) already supplies one; making the snippet stand alone with its own `<Suspense>` boundary was unnecessary plumbing.
- **No `ReactorRoot` subcomponent.** Single `App` component, one job.
- The "React 18 or later is required" note above the examples now calls out the React 19 requirement for `use()` and points React 18 users back at the older `useEffect` pattern in one sentence.

### `packages/codegen/__tests__/readme-emitter.test.ts`

New test `advertises React 19's `use()` pattern for the token promise (REA-2219)` pins the canonical shape:

- `import { use } from "react";`
- `async function getToken() {` named helper present at module scope
- `const tokenPromise = getToken();` at module scope
- `const token = use(tokenPromise);` inside the component body
- Zero `useEffect` / `useState` references in any fenced code block (the React 18 fallback hint in the prose stays in place — the assertion is scoped to code blocks only via a fenced-block extractor)
- The note above the examples references both React 19 and React 18

## Verification

End-to-end regenerated the README against the helios prod schema (`v0.8.8`) via the codegen CLI's `--coordinator-url --model helios --react` path. Both the Authenticate and Connect sections render the new pattern with `HeliosProvider` / `useHelios` interpolated correctly. Tests: 348 passing (codegen) + 284 passing (js-sdk). Format check clean.

## Linear

https://linear.app/reactor-team/issue/REA-2219