### PR TITLE
[codegen] consume @reactor-team/js-sdk from npm, not workspace symlink

### DIFF
--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -76,6 +76,30 @@ describe("reactor-codegen CLI — argument validation", () => {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
   });
+
+  it("keeps `defaultSdkVersion` in lockstep with the runtime `@reactor-team/js-sdk` dep", () => {
+    // The codegen reads `@reactor-team/js-sdk`'s d.ts at run time to
+    // derive `RESERVED_CLASS_METHODS` + `RESERVED_HOOK_FIELDS`, and it
+    // ALSO emits that same SDK version into every generated package's
+    // `dependencies["@reactor-team/js-sdk"]` (via `defaultSdkVersion`).
+    // Those two numbers MUST match — otherwise the d.ts the codegen
+    // parses is for one SDK version while the consumer projects pin a
+    // different one, and the generated typed surface drifts from the
+    // actual SDK shape downstream packages compile against.
+    //
+    // To make a single one-line PR the way to bump the SDK target,
+    // pin both knobs to the same number here. A version skew shows up
+    // as a hard failure in CI rather than a silent drift.
+    const pkgJsonPath = path.resolve(__dirname, "..", "package.json");
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    const defaultSdkVersion = pkgJson.defaultSdkVersion as string;
+    const runtimeDep = pkgJson.dependencies["@reactor-team/js-sdk"] as string;
+
+    // The runtime dep is a semver range (`^X.Y.Z`); strip the range
+    // prefix and compare the underlying version.
+    const runtimeVersion = runtimeDep.replace(/^[\^~]/, "");
+    expect(runtimeVersion).toBe(defaultSdkVersion);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -36,7 +36,7 @@
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@reactor-team/js-sdk": "workspace:*"
+    "@reactor-team/js-sdk": "^2.9.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   packages/codegen:
     dependencies:
       '@reactor-team/js-sdk':
-        specifier: workspace:*
-        version: link:../js-sdk
+        specifier: ^2.9.3
+        version: 2.9.3(@types/node@20.19.37)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -315,6 +315,12 @@ packages:
 
   '@reactor-team/js-sdk@2.7.0':
     resolution: {integrity: sha512-hDvWCef3PqHe9lQqBYar/1h4eqO3tqqkf8g3n74NQf8YMtuccwuUvjErJ2KdSfmAqLhW/fychg8atSe3MS1glA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zustand: ^5.0.6
+
+  '@reactor-team/js-sdk@2.9.3':
+    resolution: {integrity: sha512-pso2mGwzRginJs7j5zRE+CLtESRc6VRR4GBQIzbGoESNRJkNFvYW+zfJAIRhF8t009xtpYSb6jRu6pJYz1SkuQ==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       zustand: ^5.0.6
@@ -1260,6 +1266,23 @@ snapshots:
       chalk: 5.6.2
       inquirer: 9.3.8(@types/node@22.19.15)
       react: 19.2.4
+      simple-git: 3.33.0
+      ws: 8.20.0
+      zod: 4.3.6
+      zustand: 5.0.12(@types/react@18.3.28)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@reactor-team/js-sdk@2.9.3(@types/node@20.19.37)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      chalk: 5.6.2
+      inquirer: 9.3.8(@types/node@20.19.37)
+      react: 19.2.4
+      sdp-transform: 3.0.0
       simple-git: 3.33.0
       ws: 8.20.0
       zod: 4.3.6


### PR DESCRIPTION
## Why

PR #144 added a runtime d.ts parse of \`@reactor-team/js-sdk\` inside the codegen (\`loadReactorPublicMethodsFromDts\` / \`loadReactorStoreFieldsFromDts\` in \`sdk-surface.ts\`). At \`require.resolve("@reactor-team/js-sdk")\` the resolver consults the SDK's \`exports\` map and insists on \`./dist/index.js\` existing for the \`require\` condition.

In a workspace setup, that's a problem. pnpm's \`workspace:*\` protocol satisfies the dep by **symlinking** \`packages/codegen/node_modules/@reactor-team/js-sdk\` → \`packages/js-sdk/\`. The symlink points at SOURCE, not BUILT output. \`packages/js-sdk/dist/\` is gitignored and doesn't exist until someone runs \`pnpm --filter @reactor-team/js-sdk build\`. CI does NOT run that — \`--filter <pkg>\` is non-transitive — so the install + codegen-build + run-codegen sequence fails with:

\`\`\`
Cannot find module '/workdir/packages/codegen/node_modules/@reactor-team/js-sdk/dist/index.js'
\`\`\`

This blew up the codegen Buildkite publish flow the day PR #144 landed.

## The fix

The structurally correct answer is for the codegen to **never** consume the workspace's symlinked SDK. The codegen treats the SDK as a *public API contract* — it reads the SDK's d.ts to derive its reserved-method set, and it bakes the SDK version into every generated package's \`dependencies["@reactor-team/js-sdk"]\`. That contract is *published versions of the SDK*. Consuming the workspace symlink means the codegen's behaviour silently depends on whatever uncommitted state the workspace happens to have — exactly the wrong coupling for a tool that ships its output to npm.

The same logic also future-proofs the eventual codegen-out-of-this-repo move: once the codegen is a standalone package consuming js-sdk from npm, this change is already in place. Today it just unblocks CI.

## What changed

- \`packages/codegen/package.json\`: dependency on \`@reactor-team/js-sdk\` flips from \`"workspace:*"\` to \`"^2.9.3"\` — same version already pinned by \`defaultSdkVersion\`. pnpm now downloads the published tarball into \`packages/codegen/node_modules/@reactor-team/js-sdk/\` with \`dist/\` already populated.

- \`pnpm-lock.yaml\`: lockfile entry moves from \`link:../js-sdk\` to \`2.9.3(...)\` with concrete peer-dep resolution. \`require.resolve("@reactor-team/js-sdk")\` now resolves to a real \`dist/index.js\` regardless of whether the workspace SDK has been built.

- \`packages/codegen/__tests__/cli.test.ts\`: new test \`keeps \\\`defaultSdkVersion\\\` in lockstep with the runtime \\\`@reactor-team/js-sdk\\\` dep\` reads the codegen's own \`package.json\` and asserts \`dependencies["@reactor-team/js-sdk"]\` (stripped of the \`^\`/\`~\` prefix) equals \`defaultSdkVersion\`. Without this, the SDK version the codegen *parses* at runtime could drift from the SDK version it *emits into generated manifests* — typed-surface mismatch with zero CI signal. Now the skew is a hard test failure, so bumping the SDK target is a single one-line PR.

## Side effects

- **CI's \`.buildkite/publish-model-step.yml\` is unchanged.** The existing \`pnpm install --frozen-lockfile\` + \`pnpm --filter @reactor-team/codegen build\` sequence now works as-is because the install populates the published SDK tarball (with \`dist/\`) directly.

- **Local dev against an unpublished SDK change** requires bumping the SDK locally, \`pnpm pack\`-ing it, and \`pnpm add ./tarball --filter @reactor-team/codegen\` (or pnpm's \`link:\` protocol). Rare in practice — most codegen changes don't need an unreleased SDK.

## Verification

Codegen tests: **349/349 passing** (one new parity test).

Tested in two scenarios:

1. **Normal install** — \`pnpm install\` + codegen tests pass against the npm-installed SDK.
2. **Workspace SDK \`dist/\` deleted** (\`rm -rf packages/js-sdk/dist\`) — codegen tests **still** pass. Proves the codegen no longer depends on the workspace build state at all.