### PR TITLE
[REA-1956] sdk recording: React ClipPlayer + ClipDownloadButton

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "Reactor JavaScript frontend SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -49,6 +49,7 @@
     "@types/react": "^18.2.8",
     "@types/sdp-transform": "^2.15.0",
     "@types/ws": "^8.18.1",
+    "hls.js": "^1.6.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
@@ -64,7 +65,13 @@
     "zod": "^4.0.5"
   },
   "peerDependencies": {
+    "hls.js": "^1.6.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zustand": "^5.0.6"
+  },
+  "peerDependenciesMeta": {
+    "hls.js": {
+      "optional": true
+    }
   }
 }

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -3,6 +3,9 @@ export * from "./react/ReactorProvider";
 export * from "./react/ReactorView";
 export * from "./react/ReactorController";
 export * from "./react/WebcamStream";
+export * from "./react/ClipPlayer";
+export * from "./react/ClipDownloadButton";
+export * from "./react/useClipDownload";
 export * from "./react/hooks";
 export * from "./types";
 // Stateless recording primitives (helpers, types, schemas).

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -3,10 +3,7 @@
 
 import React from "react";
 import type { Clip } from "../utils/recording";
-import {
-  useClipDownload,
-  type ClipDownloadState,
-} from "./useClipDownload";
+import { useClipDownload, type ClipDownloadState } from "./useClipDownload";
 
 /**
  * Standalone download button for a captured {@link Clip}.
@@ -58,9 +55,7 @@ export interface ClipDownloadButtonProps {
    * - **`(state) => ReactNode`** — state-aware render function;
    *   use for custom progress strings, spinners, etc.
    */
-  children?:
-    | React.ReactNode
-    | ((state: ClipDownloadState) => React.ReactNode);
+  children?: React.ReactNode | ((state: ClipDownloadState) => React.ReactNode);
   /** Forwarded to the underlying ``<button>``. */
   className?: string;
   /** Forwarded to the underlying ``<button>`` — merges *after* the defaults so each property overrides. */

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+"use client";
+
+import React from "react";
+import type { Clip } from "../utils/recording";
+import {
+  useClipDownload,
+  type ClipDownloadState,
+} from "./useClipDownload";
+
+/**
+ * Standalone download button for a captured {@link Clip}.
+ *
+ * Drops anywhere in your UI — modal headers, list rows, hover menus,
+ * floating action buttons — and is responsible for nothing more than
+ * triggering a download and reflecting its state.  Internally wraps
+ * {@link useClipDownload}; for completely custom UIs (progress bars,
+ * menu items, post-download blob handling) call that hook directly.
+ *
+ * Styling is intentionally minimal.  Override via ``className``,
+ * ``style``, or replace the inner content with the ``children``
+ * render-prop.  No CSS file is shipped — every default style is
+ * inline so it loses to anything the consumer provides.
+ *
+ * @example Default label, state-aware:
+ * ```tsx
+ * <ClipDownloadButton clip={clip} getJwt={() => jwt} />
+ * ```
+ *
+ * @example Custom label that follows the state:
+ * ```tsx
+ * <ClipDownloadButton clip={clip} getJwt={() => jwt}>
+ *   {(s) => (s.kind === "downloading" ? `${s.fetched}/${s.total}` : "Save MP4")}
+ * </ClipDownloadButton>
+ * ```
+ *
+ * @example Static label:
+ * ```tsx
+ * <ClipDownloadButton clip={clip} getJwt={() => jwt}>Save</ClipDownloadButton>
+ * ```
+ */
+export interface ClipDownloadButtonProps {
+  /** The clip to download. */
+  clip: Clip;
+  /**
+   * Lazy JWT resolver.  See {@link ClipPlayerProps.getJwt} for the
+   * production / local-dev distinction.  Omit in local-dev mode.
+   */
+  getJwt?: () => string | Promise<string>;
+  /** Filename for the saved MP4.  Default ``"reactor-clip.mp4"``. */
+  filename?: string;
+  /**
+   * Inner content of the button.  Three forms:
+   *
+   * - **Omitted** — renders a sensible default label that follows
+   *   the state (``"Download"`` / ``"Downloading 3/8…"`` / etc.).
+   * - **`ReactNode`** — static label.  No state-driven text.
+   * - **`(state) => ReactNode`** — state-aware render function;
+   *   use for custom progress strings, spinners, etc.
+   */
+  children?:
+    | React.ReactNode
+    | ((state: ClipDownloadState) => React.ReactNode);
+  /** Forwarded to the underlying ``<button>``. */
+  className?: string;
+  /** Forwarded to the underlying ``<button>`` — merges *after* the defaults so each property overrides. */
+  style?: React.CSSProperties;
+  /** Forwarded to the underlying ``<button>``.  ORed with the internal "downloading" state. */
+  disabled?: boolean;
+}
+
+export function ClipDownloadButton({
+  clip,
+  getJwt,
+  filename = "reactor-clip.mp4",
+  children,
+  className,
+  style,
+  disabled,
+}: ClipDownloadButtonProps) {
+  const { state, download } = useClipDownload(clip, { filename, getJwt });
+  const downloading = state.kind === "downloading";
+  const isDisabled = downloading || !!disabled;
+
+  const content =
+    typeof children === "function"
+      ? children(state)
+      : children !== undefined
+        ? children
+        : defaultLabel(state);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void download();
+      }}
+      disabled={isDisabled}
+      title={state.kind === "error" ? state.message : undefined}
+      className={className}
+      style={{
+        padding: "5px 12px",
+        borderRadius: 4,
+        border: "1px solid rgba(255,255,255,0.15)",
+        background: "rgba(255,255,255,0.05)",
+        color: "#fff",
+        font: "11px ui-monospace, SFMono-Regular, Menlo, monospace",
+        cursor: isDisabled ? "default" : "pointer",
+        opacity: isDisabled ? 0.6 : 1,
+        transition: "background-color 120ms ease",
+        ...style,
+      }}
+    >
+      {content}
+    </button>
+  );
+}
+
+function defaultLabel(state: ClipDownloadState): React.ReactNode {
+  if (state.kind === "downloading") {
+    if (state.total > 0) {
+      return `Downloading ${state.fetched}/${state.total}…`;
+    }
+    return "Downloading…";
+  }
+  return "Download";
+}

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import React from "react";
+import {
+  RecordingError,
+  createPlayableManifestUrl,
+  fetchPlaylist,
+  type Clip,
+} from "../utils/recording";
+
+/**
+ * Video preview for a captured {@link Clip}.
+ *
+ * Renders an HLS manifest through the browser's native
+ * ``<video controls>`` element.  On Safari / iOS the manifest is
+ * attached directly (native HLS support).  On Chrome / Firefox / Edge
+ * ``hls.js`` is dynamically imported — declared as an **optional peer
+ * dependency** so consumers who don't use this component aren't billed
+ * the ~80 KB.  If ``hls.js`` isn't installed and native HLS isn't
+ * available the player surfaces an inline error overlay; the
+ * underlying chunks remain downloadable via {@link useClipDownload} /
+ * {@link ClipDownloadButton} (which don't depend on hls.js at all).
+ *
+ * **Preview only.**  This component intentionally does *not* render a
+ * download UI.  Compose it with {@link ClipDownloadButton} or build
+ * your own download surface around {@link useClipDownload} — the
+ * separation keeps both pieces independently extendible and avoids
+ * baking layout decisions into the SDK.
+ *
+ * Unlike {@link ReactorView} / {@link WebcamStream} this component
+ * **does not require a ``ReactorProvider``** in the tree.  It
+ * operates on the ``Clip`` value alone, so it stays usable after
+ * ``reactor.disconnect()`` and works with clips loaded from
+ * fixtures, server logs, or any other source.
+ *
+ * @example Compose with the download button:
+ * ```tsx
+ * <div>
+ *   <ClipPlayer clip={clip} getJwt={() => jwt} />
+ *   <ClipDownloadButton clip={clip} getJwt={() => jwt} />
+ * </div>
+ * ```
+ *
+ * @example Local dev (HttpRuntime, no auth on /clips):
+ * ```tsx
+ * <ClipPlayer clip={clip} />
+ * ```
+ */
+export interface ClipPlayerProps {
+  /**
+   * The captured clip to play.  When this prop changes by reference
+   * the player re-fetches the manifest and re-attaches the player.
+   */
+  clip: Clip;
+  /**
+   * Lazy resolver for the Coordinator JWT used on the ``/clips``
+   * manifest GET.
+   *
+   * - **Production / Coordinator:** required.  Should return the
+   *   same JWT your app already passes to ``ReactorProvider`` /
+   *   ``reactor.connect()``.  Called at request time (not at render
+   *   time) so token refreshes are picked up automatically.
+   * - **Local-dev / HttpRuntime:** omit — the local ``/clips``
+   *   endpoint serves manifests without auth.
+   *
+   * The chunks referenced *inside* the manifest are S3 presigned
+   * GETs (prod) or unauthenticated runtime URLs (local), and are
+   * fetched without an ``Authorization`` header in either case.
+   */
+  getJwt?: () => string | Promise<string>;
+  /** Play automatically once the manifest is attached. Default ``true``. */
+  autoPlay?: boolean;
+  /**
+   * Start muted.  Default ``true`` because browser autoplay policies
+   * block audio-bearing video from playing without a user gesture;
+   * the user can unmute via the native ``<video controls>``.
+   */
+  muted?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+type Phase =
+  | { kind: "waiting" }
+  | { kind: "loading" }
+  | { kind: "ready" }
+  | { kind: "error"; message: string };
+
+export function ClipPlayer({
+  clip,
+  getJwt,
+  autoPlay = true,
+  muted = true,
+  className,
+  style,
+}: ClipPlayerProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
+
+  // The playback effect intentionally depends only on `clip`.  Callers
+  // typically pass an inline `getJwt={() => token}` that changes
+  // identity on every render — using it directly in the effect deps
+  // would tear down the player and re-fetch the manifest on every
+  // parent re-render (visible to the user as "keeps fetching, never
+  // shows").  Same reasoning for `autoPlay`: it's only read at the
+  // moment of attach.  Refs keep the latest values reachable from
+  // inside the effect without forcing it to re-run.
+  const getJwtRef = useRef(getJwt);
+  const autoPlayRef = useRef(autoPlay);
+  useEffect(() => {
+    getJwtRef.current = getJwt;
+    autoPlayRef.current = autoPlay;
+  });
+
+  // Playback pipeline: fetch manifest (with optional JWT) → wrap in
+  // blob URL → attach via native HLS (Safari) or hls.js (everyone
+  // else).  Re-runs only when `clip` changes by reference.  The
+  // cleanup closure tears every piece down deterministically.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const abort = new AbortController();
+    let cancelled = false;
+    let hlsInstance: { destroy: () => void } | null = null;
+    let manifestBlobUrl: string | null = null;
+
+    const fail = (message: string) => {
+      if (cancelled) return;
+      setPhase({ kind: "error", message });
+    };
+
+    const attachPlayer = async (manifestUrl: string) => {
+      const canPlayNative =
+        video.canPlayType("application/vnd.apple.mpegurl") !== "";
+      if (canPlayNative) {
+        // Safari / iOS path — attach the blob: URL and let the
+        // browser parse HLS natively.
+        video.src = manifestUrl;
+        if (autoPlayRef.current) {
+          video.play().catch(() => {
+            // Autoplay may be blocked by the browser; native controls still work.
+          });
+        }
+        if (!cancelled) setPhase({ kind: "ready" });
+        return;
+      }
+
+      // Non-Safari path — dynamic import of the optional peer
+      // dependency.  Bundlers preserve `import()` so the chunk is
+      // only fetched when this branch executes.
+      let HlsCtor: HlsConstructor;
+      try {
+        const mod = (await import("hls.js")) as { default: HlsConstructor };
+        HlsCtor = mod.default;
+      } catch {
+        fail(
+          "HLS playback unavailable in this browser. Install `hls.js` as a peer dependency, or use Download."
+        );
+        return;
+      }
+      if (cancelled) return;
+      if (!HlsCtor.isSupported()) {
+        fail("This browser cannot play HLS clips. Use Download instead.");
+        return;
+      }
+      const hls = new HlsCtor();
+      hls.loadSource(manifestUrl);
+      hls.attachMedia(video);
+      hls.on(HlsCtor.Events.MANIFEST_PARSED, () => {
+        if (cancelled) return;
+        setPhase({ kind: "ready" });
+        if (autoPlayRef.current) {
+          video.play().catch(() => {
+            // Autoplay may be blocked.
+          });
+        }
+      });
+      hls.on(HlsCtor.Events.ERROR, (_evt: unknown, data: HlsErrorData) => {
+        if (cancelled) return;
+        // Surface non-fatal errors via `console.warn` — they often
+        // explain "fetches but nothing renders" symptoms (e.g.
+        // `bufferAppendingError`, `fragParsingError`,
+        // `levelLoadError`) that the user-facing overlay would
+        // otherwise hide.  Fatal errors still hard-fail the player.
+        if (data.fatal) {
+          fail(`Playback error: ${data.details ?? "unknown"}`);
+          return;
+        }
+        console.warn("[Reactor.ClipPlayer] hls.js non-fatal error", data);
+      });
+      hlsInstance = hls;
+    };
+
+    const setup = async () => {
+      try {
+        setPhase({ kind: "waiting" });
+        const jwt = getJwtRef.current
+          ? await getJwtRef.current()
+          : undefined;
+        if (cancelled) return;
+        const body = await fetchPlaylist(clip.playlistUrl, {
+          predictedReadyAtMs: clip.predictedReadyAtMs,
+          jwt,
+          signal: abort.signal,
+        });
+        if (cancelled) return;
+        setPhase({ kind: "loading" });
+        manifestBlobUrl = createPlayableManifestUrl(body, clip.playlistUrl);
+        await attachPlayer(manifestBlobUrl);
+      } catch (err) {
+        if (cancelled) return;
+        // `AbortError` from teardown is expected — don't paint it as
+        // a failure to the user.
+        if (
+          err instanceof DOMException &&
+          err.name === "AbortError"
+        ) {
+          return;
+        }
+        const message =
+          err instanceof RecordingError
+            ? `${err.code}: ${err.reason}`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        fail(message);
+      }
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      abort.abort();
+      hlsInstance?.destroy();
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+      if (manifestBlobUrl) URL.revokeObjectURL(manifestBlobUrl);
+    };
+  }, [clip]);
+
+  const overlayText =
+    phase.kind === "waiting"
+      ? "Waiting for clip…"
+      : phase.kind === "loading"
+        ? "Loading player…"
+        : null;
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: "relative",
+        background: "#000",
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        ...style,
+      }}
+    >
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video
+        ref={videoRef}
+        controls
+        playsInline
+        muted={muted}
+        style={{
+          display: "block",
+          width: "100%",
+          height: "auto",
+          maxHeight: "100%",
+        }}
+      />
+
+      {overlayText && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "rgba(255,255,255,0.6)",
+            font: "11px ui-monospace, SFMono-Regular, Menlo, monospace",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            pointerEvents: "none",
+          }}
+        >
+          {overlayText}
+        </div>
+      )}
+
+      {phase.kind === "error" && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 24,
+            background: "rgba(0,0,0,0.8)",
+            color: "#ef4444",
+            font: "11px ui-monospace, SFMono-Regular, Menlo, monospace",
+            textAlign: "center",
+          }}
+        >
+          {phase.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal local typings for the optional `hls.js` peer dep.  We
+// can't `import type { Hls } from "hls.js"` because the dep is
+// optional — that import would fail in environments where it
+// isn't installed.  The structural type below covers exactly the
+// surface this component uses.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface HlsInstance {
+  loadSource: (url: string) => void;
+  attachMedia: (el: HTMLMediaElement) => void;
+  on: (event: string, cb: (evt: unknown, data: HlsErrorData) => void) => void;
+  destroy: () => void;
+}
+
+interface HlsConstructor {
+  new (): HlsInstance;
+  isSupported: () => boolean;
+  readonly Events: {
+    readonly MANIFEST_PARSED: string;
+    readonly ERROR: string;
+  };
+}
+
+interface HlsErrorData {
+  fatal?: boolean;
+  details?: string;
+}

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -197,9 +197,7 @@ export function ClipPlayer({
     const setup = async () => {
       try {
         setPhase({ kind: "waiting" });
-        const jwt = getJwtRef.current
-          ? await getJwtRef.current()
-          : undefined;
+        const jwt = getJwtRef.current ? await getJwtRef.current() : undefined;
         if (cancelled) return;
         const body = await fetchPlaylist(clip.playlistUrl, {
           predictedReadyAtMs: clip.predictedReadyAtMs,
@@ -214,10 +212,7 @@ export function ClipPlayer({
         if (cancelled) return;
         // `AbortError` from teardown is expected — don't paint it as
         // a failure to the user.
-        if (
-          err instanceof DOMException &&
-          err.name === "AbortError"
-        ) {
+        if (err instanceof DOMException && err.name === "AbortError") {
           return;
         }
         const message =

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -70,6 +70,19 @@ export interface ClipPlayerProps {
    * fetched without an ``Authorization`` header in either case.
    */
   getJwt?: () => string | Promise<string>;
+  /**
+   * Override the grace period beyond ``clip.predictedReadyAtMs``
+   * before the SDK gives up polling the ``/clips`` manifest endpoint
+   * with ``CLIP_NOT_READY``.  Defaults to
+   * {@link DEFAULT_PLAYLIST_POLL_SLACK_MS} (15 s) — enough for snap
+   * clips, but long-running session recordings may legitimately need
+   * a minute or more for the final boundary chunk to finish encoding
+   * + uploading, in which case pass a larger value (e.g. ``120_000``
+   * for two-minute grace).  Forwarded directly to
+   * {@link fetchPlaylist}'s ``slackMs`` option — see that helper for
+   * the polling semantics.
+   */
+  slackMs?: number;
   /** Play automatically once the manifest is attached. Default ``true``. */
   autoPlay?: boolean;
   /**
@@ -91,6 +104,7 @@ type Phase =
 export function ClipPlayer({
   clip,
   getJwt,
+  slackMs,
   autoPlay = true,
   muted = true,
   className,
@@ -109,9 +123,11 @@ export function ClipPlayer({
   // inside the effect without forcing it to re-run.
   const getJwtRef = useRef(getJwt);
   const autoPlayRef = useRef(autoPlay);
+  const slackMsRef = useRef(slackMs);
   useEffect(() => {
     getJwtRef.current = getJwt;
     autoPlayRef.current = autoPlay;
+    slackMsRef.current = slackMs;
   });
 
   // Playback pipeline: fetch manifest (with optional JWT) → wrap in
@@ -201,6 +217,7 @@ export function ClipPlayer({
         if (cancelled) return;
         const body = await fetchPlaylist(clip.playlistUrl, {
           predictedReadyAtMs: clip.predictedReadyAtMs,
+          slackMs: slackMsRef.current,
           jwt,
           signal: abort.signal,
         });

--- a/packages/js-sdk/src/react/useClipDownload.ts
+++ b/packages/js-sdk/src/react/useClipDownload.ts
@@ -109,7 +109,9 @@ export function useClipDownload(
   // This is the same pattern the SDK uses elsewhere (see
   // useReactorMessage in hooks.ts).
   const clipRef = useRef(clip);
-  const filenameRef = useRef<string | null>(options.filename ?? "reactor-clip.mp4");
+  const filenameRef = useRef<string | null>(
+    options.filename ?? "reactor-clip.mp4"
+  );
   const getJwtRef = useRef(options.getJwt);
   useEffect(() => {
     clipRef.current = clip;
@@ -128,9 +130,7 @@ export function useClipDownload(
     inFlightRef.current = true;
     setState({ kind: "downloading", fetched: 0, total: 0 });
     try {
-      const jwt = getJwtRef.current
-        ? await getJwtRef.current()
-        : undefined;
+      const jwt = getJwtRef.current ? await getJwtRef.current() : undefined;
       const blob = await downloadClipAsFile(
         clipRef.current,
         filenameRef.current,

--- a/packages/js-sdk/src/react/useClipDownload.ts
+++ b/packages/js-sdk/src/react/useClipDownload.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  RecordingError,
+  downloadClipAsFile,
+  type Clip,
+} from "../utils/recording";
+
+/**
+ * State machine for an in-progress clip download.
+ *
+ * - ``idle``: no download in flight (initial state, and what the hook
+ *   returns to after a successful save).
+ * - ``downloading``: chunks are being fetched.  ``fetched`` and
+ *   ``total`` count the number of chunks (init segment + media
+ *   segments) — useful for a progress bar.  ``total`` is 0 until the
+ *   manifest is parsed and the chunk count is known.
+ * - ``error``: most recent attempt failed; the ``message`` is suitable
+ *   for surfacing inline.  ``RecordingError`` instances are formatted
+ *   as ``"<CODE>: <reason>"`` for grep-ability.
+ */
+export type ClipDownloadState =
+  | { kind: "idle" }
+  | { kind: "downloading"; fetched: number; total: number }
+  | { kind: "error"; message: string };
+
+export interface UseClipDownloadOptions {
+  /**
+   * Filename used when the browser save dialog opens.  Pass ``null``
+   * to skip the ``<a download>`` trigger entirely — the returned
+   * Blob is still resolved so the caller can ``URL.createObjectURL``
+   * it or re-upload it.  Default ``"reactor-clip.mp4"``.
+   */
+  filename?: string | null;
+  /**
+   * Lazy resolver for the Coordinator JWT used on the ``/clips``
+   * manifest GET.  Called on every {@link download} invocation, so
+   * token refreshes are picked up automatically.  Omit in local-dev
+   * mode (HttpRuntime has no auth on ``/clips``).  See
+   * {@link ClipPlayerProps.getJwt} for the production / local
+   * distinction.
+   */
+  getJwt?: () => string | Promise<string>;
+}
+
+export interface UseClipDownloadResult {
+  /** Current state of the most recent download attempt. */
+  state: ClipDownloadState;
+  /**
+   * Trigger a download.  Resolves with the assembled fragmented-MP4
+   * Blob, or ``undefined`` if a download was already in flight (the
+   * call is a no-op in that case — guarding against double-click is
+   * the hook's responsibility, not the caller's).
+   *
+   * Errors are caught and surfaced via {@link state} — the returned
+   * Promise still resolves to ``undefined`` rather than rejecting,
+   * because the typical caller is a click handler that doesn't await.
+   * Use ``state.kind === "error"`` to drive failure UI.
+   */
+  download: () => Promise<Blob | undefined>;
+  /** Reset to ``idle``.  Does *not* cancel an in-flight download. */
+  reset: () => void;
+}
+
+/**
+ * Headless download primitive for a {@link Clip}.
+ *
+ * Wraps {@link downloadClipAsFile} in a React state machine so the
+ * consumer can render any button they want, anywhere they want, and
+ * still get progress + error feedback.  Used internally by
+ * {@link ClipPlayer}'s built-in download button — when you need
+ * custom placement or styling, set ``showDownloadButton={false}`` on
+ * the player and call this hook directly.
+ *
+ * Stable callback identity: ``download`` and ``reset`` are the same
+ * function reference across renders, so they're safe to pass through
+ * memoized children without forcing re-renders.
+ *
+ * @example Render a download button anywhere in your tree:
+ * ```tsx
+ * function ClipCard({ clip }: { clip: Clip }) {
+ *   const jwt = useReactor((s) => s.jwtToken);
+ *   const { state, download } = useClipDownload(clip, {
+ *     filename: `snap-${clip.sessionId}.mp4`,
+ *     getJwt: jwt ? () => jwt : undefined,
+ *   });
+ *   return (
+ *     <button onClick={download} disabled={state.kind === "downloading"}>
+ *       {state.kind === "downloading"
+ *         ? `${state.fetched}/${state.total}`
+ *         : state.kind === "error"
+ *           ? "Retry"
+ *           : "Download"}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useClipDownload(
+  clip: Clip,
+  options: UseClipDownloadOptions = {}
+): UseClipDownloadResult {
+  const [state, setState] = useState<ClipDownloadState>({ kind: "idle" });
+
+  // Latest-value refs so `download` can be a stable callback (empty
+  // deps) without forcing the caller to memoize `clip` / `options`.
+  // This is the same pattern the SDK uses elsewhere (see
+  // useReactorMessage in hooks.ts).
+  const clipRef = useRef(clip);
+  const filenameRef = useRef<string | null>(options.filename ?? "reactor-clip.mp4");
+  const getJwtRef = useRef(options.getJwt);
+  useEffect(() => {
+    clipRef.current = clip;
+    filenameRef.current =
+      options.filename === undefined ? "reactor-clip.mp4" : options.filename;
+    getJwtRef.current = options.getJwt;
+  });
+
+  // Re-entrancy guard.  Lives in a ref (not state) so back-to-back
+  // synchronous clicks before the first `setState` flushes are still
+  // handled correctly.
+  const inFlightRef = useRef(false);
+
+  const download = useCallback(async (): Promise<Blob | undefined> => {
+    if (inFlightRef.current) return undefined;
+    inFlightRef.current = true;
+    setState({ kind: "downloading", fetched: 0, total: 0 });
+    try {
+      const jwt = getJwtRef.current
+        ? await getJwtRef.current()
+        : undefined;
+      const blob = await downloadClipAsFile(
+        clipRef.current,
+        filenameRef.current,
+        {
+          jwt,
+          onProgress: ({ fetched, total }) =>
+            setState({ kind: "downloading", fetched, total }),
+        }
+      );
+      setState({ kind: "idle" });
+      return blob;
+    } catch (err) {
+      const message =
+        err instanceof RecordingError
+          ? `${err.code}: ${err.reason}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setState({ kind: "error", message });
+      return undefined;
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const reset = useCallback(() => setState({ kind: "idle" }), []);
+
+  return { state, download, reset };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      hls.js:
+        specifier: ^1.6.0
+        version: 1.6.16
       prettier:
         specifier: ^3.6.2
         version: 3.8.1
@@ -705,6 +708,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1628,6 +1634,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   has-flag@4.0.0: {}
+
+  hls.js@1.6.16: {}
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
Part 4 of the recording feature stack (#132 → #133 → #134 → here).
Those PRs delivered the wire contract, the helpers, and the tests;
this adds the user-facing React surface so consumers don't have to
build the playback / download UI themselves.

Three small primitives, each does one job, designed to compose:

- **`<ClipPlayer />`** — pure video preview. Native `<video controls>`,
  with `hls.js` (an optional peer dep) dynamically imported on
  non-Safari browsers. No download UI. No `ReactorProvider` required —
  operates on the `Clip` value alone, so it stays usable after
  `disconnect()` and against fixtures / saved logs.
- **`<ClipDownloadButton />`** — standalone button. State-aware default
  label (`Download` / `Downloading 3/8…`); fully customizable via
  `className`, `style`, or the `children` render-prop (static node or
  ``(state) => ReactNode``). Drops anywhere — modal headers, list
  rows, hover menus, FAB. Wraps `useClipDownload` internally.
- **`useClipDownload(clip, options)`** — headless hook for everything
  the button doesn't cover (progress bars, menu items, post-download
  Blob handling). Returns `{ state, download, reset }` with stable
  callback identities, so it's safe to pass through memoized children.
  The button is built on top of this hook.

## How it feels

```tsx
function ClipModal({ clip }: { clip: Clip }) {
  const jwt = useReactor((s) => s.jwtToken);
  const getJwt = jwt ? () => jwt : undefined;

  return (
    <Modal>
      <Header>
        <span>Snap {(clip.endMarker - clip.startMarker).toFixed(1)}s</span>
        <ClipDownloadButton clip={clip} getJwt={getJwt} />
      </Header>
      <ClipPlayer clip={clip} getJwt={getJwt} />
    </Modal>
  );
}
```

For a custom progress bar instead of a button:

```tsx
const { state, download } = useClipDownload(clip, { getJwt });
return state.kind === \"downloading\"
  ? <ProgressBar value={state.fetched} max={state.total} />
  : <Button onClick={download}>Save</Button>;
```

## Design notes worth knowing

- **JWT is a per-call resolver, not a stored field.** ``getJwt: () =>
  string | Promise<string>`` is the same shape on both ``<ClipPlayer />``
  and ``<ClipDownloadButton />``. Called lazily at trigger time, so
  token refreshes are picked up automatically. Consistent with the
  per-call ``jwt`` field on ``downloadClipAsFile`` from #133. In
  local-dev / HttpRuntime mode, just omit it — the runtime serves
  ``/clips`` without auth.
- **\`hls.js\` is an optional peer dep, not a hard dep.** Dynamically
  ``import(\"hls.js\")`` at runtime so bundlers don't inline it. Native
  HLS (Safari) needs no peer at all. If a Chrome consumer forgets to
  install ``hls.js``, ``<ClipPlayer />`` surfaces an inline error and
  the download path keeps working (the helpers don't depend on it).
  Also added to ``devDependencies`` for type-checking — standard
  optional-peer pattern.
- **Player and button are decoupled by design.** An earlier iteration
  baked the download button into ``<ClipPlayer />``. The split makes
  composition the consumer's call (header / footer / row / anywhere)
  and lets the player stay opinion-free about chrome. The button can
  also be used without the player at all — e.g. on a clip-list page.
- **Stable callback identity inside the components.** Both
  ``<ClipPlayer />`` and ``useClipDownload`` ref-pin ``getJwt`` /
  ``autoPlay`` / ``filename`` so the playback effect doesn't tear
  down on every parent re-render (the symptom is \"fetches but never
  displays\" — every render aborts the previous load). Same pattern
  the SDK already uses for ``useReactorMessage`` /
  ``useReactorInternalMessage`` in ``hooks.ts``.
- **Bundle impact.** ~+8 KB ESM for the three new files combined.
  ``hls.js`` stays out (verified: ``import(\"hls.js\")`` survives in
  ``dist/index.mjs``).

## Test plan

No unit tests in this PR — a stacked tests-only follow-up will mirror
the #133 → #134 split if/when needed.

Manual verification:

- ``pnpm build`` clean from ``packages/js-sdk``. ``pnpm format:check``
  clean for the three new files (the other warnings are pre-existing
  on the parent branch).
- End-to-end in ``test-frontend``: capture a snap, open the preview
  modal, the player attaches via ``hls.js`` on Chrome and plays; the
  ``ClipDownloadButton`` in the modal header downloads the MP4.
  Token refreshes pick up via the ``getJwt`` callback. Works against
  both a local HttpRuntime (no JWT) and a Coordinator (JWT
  required).

Linear: REA-1956
Plan: https://www.notion.so/reactor-technologies/Video-Recording-Feature-350cacd6a39680d8a77ac39eb37561b0