### PR TITLE
[REA-2201] sdk: trim dead deps + rewrite README to match public docs

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -106,7 +106,11 @@ videoEl.srcObject = stream;
 Snap the last N seconds or capture the full session, then play it back and offer a download:
 
 ```tsx
-import { ClipPlayer, ClipDownloadButton, useReactor } from "@reactor-team/js-sdk";
+import {
+  ClipPlayer,
+  ClipDownloadButton,
+  useReactor,
+} from "@reactor-team/js-sdk";
 import type { Clip } from "@reactor-team/js-sdk";
 
 function Snap({ jwt }: { jwt: string }) {
@@ -132,13 +136,13 @@ Full walkthrough: [Recordings](https://docs.reactor.inc/concepts/recordings).
 
 ## API at a glance
 
-| Surface | Import |
-|---|---|
-| `Reactor` — imperative class | `@reactor-team/js-sdk` |
-| `<ReactorProvider>`, `<ReactorView>`, `<ReactorController>`, `<WebcamStream>` | React components |
-| `useReactor`, `useReactorMessage`, `useReactorInternalMessage`, `useStats` | React hooks |
-| `<ClipPlayer>`, `<ClipDownloadButton>`, `useClipDownload` | Recording UI |
-| `RecordingClient`, `RecordingError`, `fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`, `createPlayableManifestUrl` | Recording primitives |
+| Surface                                                                                                                  | Import                 |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `Reactor` — imperative class                                                                                             | `@reactor-team/js-sdk` |
+| `<ReactorProvider>`, `<ReactorView>`, `<ReactorController>`, `<WebcamStream>`                                            | React components       |
+| `useReactor`, `useReactorMessage`, `useReactorInternalMessage`, `useStats`                                               | React hooks            |
+| `<ClipPlayer>`, `<ClipDownloadButton>`, `useClipDownload`                                                                | Recording UI           |
+| `RecordingClient`, `RecordingError`, `fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`, `createPlayableManifestUrl` | Recording primitives   |
 
 Full prop tables, event signatures, and error codes are documented at [docs.reactor.inc](https://docs.reactor.inc).
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -1,20 +1,164 @@
-# Reactor Frontend SDK
+# @reactor-team/js-sdk
 
-## Overview
+The official JavaScript/TypeScript SDK for [Reactor](https://reactor.inc) — the developer platform for building real-time, interactive AI video applications.
 
-This is the frontend SDK for Reactor. It provides a set of tools and utilities to build frontend applications that can use the Reactor platform.
+Use it to connect your frontend to a Reactor session over WebRTC, stream video (and optional audio) to and from a real-time model, send typed control events, and record clips of the live stream.
 
-There are two main ways to use the frontend SDK:
+Full reference and guides live at **[docs.reactor.inc](https://docs.reactor.inc)**.
 
-1. **Imperative API**: Use it in any TS/JS application.
-2. **React API**: Use it in a React applications.
+---
 
-## Building the SDK
+## Install
 
 ```bash
-pnpm build
+pnpm add @reactor-team/js-sdk
 ```
 
-## Documentation
+`react` and `zustand` are peer dependencies. `hls.js` is an optional peer dependency, used only by the `<ClipPlayer />` component on browsers without native HLS support (Chrome, Firefox, Edge):
 
-- [Getting Started](https://docs.reactor.inc)
+```bash
+pnpm add hls.js
+```
+
+Safari and iOS play HLS natively and do not need it.
+
+---
+
+## Quickstart
+
+The fastest path is `create-reactor-app`, which scaffolds a Next.js app with auth wired up:
+
+```bash
+pnpm create reactor-app my-app
+cd my-app && pnpm install && pnpm dev
+```
+
+To wire it up by hand, exchange your API key for a JWT in a server route, then mount `<ReactorProvider>` in the client:
+
+```ts
+// app/api/token/route.ts
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const r = await fetch("https://api.reactor.inc/tokens", {
+    method: "POST",
+    headers: { "Reactor-API-Key": process.env.REACTOR_API_KEY! },
+  });
+  const { jwt } = await r.json();
+  return NextResponse.json({ jwt });
+}
+```
+
+```tsx
+// app/page.tsx
+"use client";
+import { use } from "react";
+import { ReactorProvider, ReactorView } from "@reactor-team/js-sdk";
+
+async function getToken() {
+  const r = await fetch("/api/token", { method: "POST" });
+  const { jwt } = await r.json();
+  return jwt;
+}
+
+const tokenPromise = getToken();
+
+export default function App() {
+  const token = use(tokenPromise);
+  return (
+    <ReactorProvider modelName="your-model-name" jwtToken={token}>
+      <ReactorView className="w-full aspect-video" />
+    </ReactorProvider>
+  );
+}
+```
+
+See the [Quickstart](https://docs.reactor.inc/quickstart) and [Authentication](https://docs.reactor.inc/authentication) docs for the full walkthrough, including production auth patterns.
+
+---
+
+## Vanilla TypeScript
+
+For non-React apps — Electron shells, game engines, custom frameworks — use the `Reactor` class directly:
+
+```ts
+import { Reactor } from "@reactor-team/js-sdk";
+
+const reactor = new Reactor({
+  apiUrl: "https://api.reactor.inc",
+  modelName: "your-model-name",
+  jwtToken: await fetchJwt(),
+});
+
+reactor.on("statusChange", (status) => console.log("status:", status));
+reactor.on("message", (msg) => console.log("model:", msg));
+
+await reactor.connect();
+
+const stream = reactor.getMediaStream("main_video");
+videoEl.srcObject = stream;
+```
+
+---
+
+## Recording
+
+Snap the last N seconds or capture the full session, then play it back and offer a download:
+
+```tsx
+import { ClipPlayer, ClipDownloadButton, useReactor } from "@reactor-team/js-sdk";
+import type { Clip } from "@reactor-team/js-sdk";
+
+function Snap({ jwt }: { jwt: string }) {
+  const { reactor } = useReactor((s) => ({ reactor: s.internal.reactor }));
+  const [clip, setClip] = useState<Clip | null>(null);
+
+  return clip ? (
+    <>
+      <ClipPlayer clip={clip} getJwt={() => jwt} />
+      <ClipDownloadButton clip={clip} getJwt={() => jwt} />
+    </>
+  ) : (
+    <button onClick={async () => setClip(await reactor.requestClip(10))}>
+      Save last 10s
+    </button>
+  );
+}
+```
+
+Full walkthrough: [Recordings](https://docs.reactor.inc/concepts/recordings).
+
+---
+
+## API at a glance
+
+| Surface | Import |
+|---|---|
+| `Reactor` — imperative class | `@reactor-team/js-sdk` |
+| `<ReactorProvider>`, `<ReactorView>`, `<ReactorController>`, `<WebcamStream>` | React components |
+| `useReactor`, `useReactorMessage`, `useReactorInternalMessage`, `useStats` | React hooks |
+| `<ClipPlayer>`, `<ClipDownloadButton>`, `useClipDownload` | Recording UI |
+| `RecordingClient`, `RecordingError`, `fetchPlaylist`, `parsePlaylist`, `downloadClipAsFile`, `createPlayableManifestUrl` | Recording primitives |
+
+Full prop tables, event signatures, and error codes are documented at [docs.reactor.inc](https://docs.reactor.inc).
+
+For models with a published typed SDK, prefer [`@reactor-models/<name>`](https://www.npmjs.com/org/reactor-models) — it re-exports everything here and adds typed events, messages, and hooks for one specific model.
+
+---
+
+## Local development
+
+```bash
+pnpm install
+pnpm build      # tsup → dist/index.{js,mjs,d.ts}
+pnpm test       # vitest, full suite
+pnpm dev        # tsup --watch
+```
+
+Tests run against a real Node WebRTC stack via `@roamhq/wrtc`; the integration suite spins up an in-process Coordinator stub. No external services required.
+
+---
+
+## License
+
+MIT. © Reactor Technologies, Inc.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,7 +1,23 @@
 {
   "name": "@reactor-team/js-sdk",
   "version": "2.10.0",
-  "description": "Reactor JavaScript frontend SDK",
+  "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reactor-team/js-sdk.git"
+  },
+  "keywords": [
+    "reactor",
+    "sdk",
+    "frontend",
+    "react",
+    "webrtc",
+    "real-time",
+    "video",
+    "ai"
+  ],
+  "author": "Reactor Technologies, Inc.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -11,6 +27,10 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
   },
   "files": [
     "dist",
@@ -26,42 +46,13 @@
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
-  "keywords": [
-    "reactor",
-    "frontend",
-    "sdk"
-  ],
-  "author": "Reactor Technologies, Inc.",
   "reactor": {
     "apiVersion": 1,
     "webrtcVersion": "1.0"
   },
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/reactor-team/js-sdk.git"
-  },
   "packageManager": "pnpm@10.12.1",
-  "devDependencies": {
-    "@roamhq/wrtc": "^0.8.0",
-    "@types/inquirer": "^9.0.9",
-    "@types/node": "^20",
-    "@types/react": "^18.2.8",
-    "@types/sdp-transform": "^2.15.0",
-    "@types/ws": "^8.18.1",
-    "hls.js": "^1.6.0",
-    "prettier": "^3.6.2",
-    "tsup": "^8.5.0",
-    "typescript": "^5.8.3",
-    "vitest": "^3.0.0"
-  },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.0.0",
-    "chalk": "^5.3.0",
-    "inquirer": "^9.3.0",
     "sdp-transform": "^3.0.0",
-    "simple-git": "^3.24.0",
-    "ws": "^8.18.3",
     "zod": "^4.0.5"
   },
   "peerDependencies": {
@@ -73,5 +64,15 @@
     "hls.js": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@roamhq/wrtc": "^0.8.0",
+    "@types/node": "^20",
+    "@types/react": "^18.2.8",
+    "hls.js": "^1.6.0",
+    "prettier": "^3.6.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,27 +61,12 @@ importers:
 
   packages/js-sdk:
     dependencies:
-      '@bufbuild/protobuf':
-        specifier: ^2.0.0
-        version: 2.11.0
-      chalk:
-        specifier: ^5.3.0
-        version: 5.6.2
-      inquirer:
-        specifier: ^9.3.0
-        version: 9.3.8(@types/node@20.19.37)
       react:
         specifier: ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 19.2.4
       sdp-transform:
         specifier: ^3.0.0
         version: 3.0.0
-      simple-git:
-        specifier: ^3.24.0
-        version: 3.33.0
-      ws:
-        specifier: ^8.18.3
-        version: 8.20.0
       zod:
         specifier: ^4.0.5
         version: 4.3.6
@@ -92,21 +77,12 @@ importers:
       '@roamhq/wrtc':
         specifier: ^0.8.0
         version: 0.8.0
-      '@types/inquirer':
-        specifier: ^9.0.9
-        version: 9.0.9
       '@types/node':
         specifier: ^20
         version: 20.19.37
       '@types/react':
         specifier: ^18.2.8
         version: 18.3.28
-      '@types/sdp-transform':
-        specifier: ^2.15.0
-        version: 2.15.0
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       hls.js:
         specifier: ^1.6.0
         version: 1.6.16
@@ -490,9 +466,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/inquirer@9.0.9':
-    resolution: {integrity: sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw==}
-
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
@@ -504,15 +477,6 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
-
-  '@types/sdp-transform@2.15.0':
-    resolution: {integrity: sha512-ikIFF0EaYt/2XetIYYVeMj6SB52oVXFasJUXDzWHgzNJS5ep2Pbsu7f8f3Za+dEie8HQtt3Zr9mHYBpWT0XgxQ==}
-
-  '@types/through@0.0.33':
-    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1407,11 +1371,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/inquirer@9.0.9':
-    dependencies:
-      '@types/through': 0.0.33
-      rxjs: 7.8.2
-
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
@@ -1426,16 +1385,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/sdp-transform@2.15.0': {}
-
-  '@types/through@0.0.33':
-    dependencies:
-      '@types/node': 20.19.37
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 20.19.37
 
   '@vitest/expect@3.2.4':
     dependencies:


### PR DESCRIPTION
## Why

Two parallel cleanups to get `@reactor-team/js-sdk` ready for the open-source split tracked in [REA-2201](https://linear.app/reactor-team/issue/REA-2201): a `package.json` slim-down and a README rewrite. Both are metadata-only; no behaviour changes.

The `package.json` had accumulated a handful of dependencies that no longer have any reference in the source tree, leftovers from earlier iterations of this package — and the README was a 20-line stub that wasn't doing useful work for someone landing on the repo from npm or GitHub.

This PR is a metadata cleanup. The bundle's `require()` set is byte-for-byte identical before and after.

## Trim

Looking at what actually lands in `dist/index.js`, the externalized set is a tiny five-name list (`react`, `react/jsx-runtime`, `sdp-transform`, `zod`, `zustand` + sub-paths). Everything else listed in `dependencies` was disk-footprint-only — installed by every consumer, imported by none.

Where the dead deps came from is straightforward. `chalk` / `inquirer` / `simple-git` belong to a CLI surface that has since moved to `create-reactor-app` (still in this monorepo, still depends on them — correctly). `ws` and `@bufbuild/protobuf` belong to an earlier wire-protocol attempt that has since been replaced by JSON+zod over WebRTC. Each got removed from its call sites long ago but never from the package.json. A fresh `pnpm add @reactor-team/js-sdk` today pulls in roughly 4 MB of dependencies that the SDK doesn't import.

| Removed from | Package | On-disk |
|---|---|---|
| `dependencies` | `chalk` | ~72 KB |
| `dependencies` | `inquirer` | ~152 KB + deps |
| `dependencies` | `simple-git` | ~1.3 MB + deps |
| `dependencies` | `ws` | ~192 KB |
| `dependencies` | `@bufbuild/protobuf` | ~2.2 MB + deps |
| `devDependencies` | `@types/inquirer` | (pairs with `inquirer`) |
| `devDependencies` | `@types/ws` | (pairs with `ws`) |
| `devDependencies` | `@types/sdp-transform` | `sdp-transform@^3` ships its own types |

Verified by:

- Full `vitest run` — **346/346 unit tests pass.**
- `tsup` build clean; bundle size 144.12 KB ESM / 149.99 KB CJS.
- `grep -oE 'require\(.+\)' dist/index.js | sort -u` — identical set before and after.

## Add

A few small entries to round out the manifest for an OSS consumer:

- `sideEffects: false` — unlocks aggressive tree-shaking for consumers. The codebase has no module-init side effects (verified by re-running the integration suite, which would surface broken initialization).
- `engines.node: ">=18"` — matches what `tsup` and `vitest` already require; surfaces a clean message for Node 14/16 consumers instead of cryptic syntax errors.
- A handful of extra keywords (`react`, `webrtc`, `real-time`, `video`, `ai`) for npm search.

Deliberately omitted per request, since this repo is still private:

- No `publishConfig.access: public` — would silently flip future `pnpm publish` runs to public-without-flag, wrong default while the source is closed.
- No `homepage` / `bugs` URLs — fill these in when REA-2201's monorepo split lands and a public `reactor-team/js-sdk` exists.

## README

The first draft of this rewrite pulled in too much internal guidance from the `scaffold-model-example` skill — the cacheable `GET /api/reactor/token` pattern, the slow-conditioning acknowledgement wait, the mandatory clear-on-disconnect snapshot effect. Those are opinions that belong in the per-model docs (where they have context) and the example apps' bundled `skill/SKILL.md` (where extenders need them). On the SDK's npm landing page they're noise.

The shipped version is a thin entry point that mirrors the structure and tone of the published docs at [docs.reactor.inc](https://docs.reactor.inc):

1. **Install** — package + optional `hls.js` peer dep with the one-line "only needed without native HLS" caveat.
2. **Quickstart** — `create-reactor-app` first (since that's what `docs/quickstart.mdx` recommends), then the same simple `POST /api/token → ReactorProvider` flow the docs use. No prescriptive cache-header advice, no opinions about `autoConnect: true`. Links out to `/quickstart` and `/authentication` for the full walkthrough.
3. **Vanilla TS** — short imperative example for non-React consumers.
4. **Recording** — a 12-line snap example and a single link to [`/concepts/recordings`](https://docs.reactor.inc/concepts/recordings) for the full reference (prop tables, error codes, etc. — those already exist there).
5. **API at a glance** — one table mapping every exported surface to its import path, then `→ docs.reactor.inc`.
6. **Local development** + license.

Net: 348 → 164 lines, all internal-only prescription removed, structure aligned with the docs site so readers get a consistent experience moving between the two.

## Test plan

- [ ] CI green (`pnpm test:unit`, `pnpm test:integration`, `pnpm build`).
- [ ] Spot-check `dist/index.{js,mjs}` externals — should be identical to pre-PR.
- [ ] After merge: `pnpm view @reactor-team/js-sdk` shows the trimmed dep list once the next release goes out.

Refs: [REA-2201](https://linear.app/reactor-team/issue/REA-2201).