### PR TITLE
[REA-2201] codegen: bump pinned js-sdk version to 2.10.0

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -40,7 +40,7 @@ The codegen reads a model's OpenAPI schema (events, messages, tracks) and produc
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output ./out/helios
 ```
 
@@ -106,7 +106,7 @@ Use `--standalone` when you want the typed client as a single `.ts` file inside 
 # Drop a typed Helios client into an existing project's src/ folder.
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output ./src/helios.ts \
   --standalone
 ```
@@ -120,7 +120,7 @@ Pass `--react` to additionally emit a React entry point. In package mode the Rea
 ```bash
 reactor-codegen \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output ./out/helios \
   --react
 ```
@@ -271,20 +271,20 @@ The generated `package.json` strips a leading `v` from the schema's `info.versio
 # Run codegen against the test schema (Helios)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output .generated/helios
 
 # Dry-run to preview output without writing files
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output .generated/helios \
   --dry-run
 
 # With React hooks (adds src/react.ts; root re-export — no `/react` subpath)
 pnpm tsx src/cli.ts \
   --schema schema.json \
-  --sdk-version 2.9.3 \
+  --sdk-version 2.10.0 \
   --output .generated/helios \
   --react
 
@@ -328,7 +328,7 @@ const schema = parseSchema(rawSchema);
 const pkg = generateModelSdk({
   modelName: schema.modelName,
   modelVersion: schema.modelVersion,
-  sdkVersion: "2.9.3",
+  sdkVersion: "2.10.0",
   schema,
   outputDir: "./out/helios",
 });

--- a/packages/codegen/__tests__/cli.test.ts
+++ b/packages/codegen/__tests__/cli.test.ts
@@ -71,7 +71,7 @@ describe("reactor-codegen CLI — argument validation", () => {
           "utf-8",
         ),
       );
-      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.9.3");
+      expect(pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.10.0");
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -25,18 +25,18 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.9.3 --output .generated/example"
+    "codegen:test": "tsx src/cli.ts --schema schema.json --sdk-version 2.10.0 --output .generated/example"
   },
   "keywords": [
     "reactor",
     "codegen",
     "sdk"
   ],
-  "defaultSdkVersion": "2.9.3",
+  "defaultSdkVersion": "2.10.0",
   "author": "Reactor Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@reactor-team/js-sdk": "^2.9.3"
+    "@reactor-team/js-sdk": "^2.10.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   packages/codegen:
     dependencies:
       '@reactor-team/js-sdk':
-        specifier: ^2.9.3
-        version: 2.9.3(@types/node@20.19.37)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))
+        specifier: ^2.10.0
+        version: 2.10.0(hls.js@1.6.16)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -292,14 +292,19 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@reactor-team/js-sdk@2.7.0':
-    resolution: {integrity: sha512-hDvWCef3PqHe9lQqBYar/1h4eqO3tqqkf8g3n74NQf8YMtuccwuUvjErJ2KdSfmAqLhW/fychg8atSe3MS1glA==}
+  '@reactor-team/js-sdk@2.10.0':
+    resolution: {integrity: sha512-kJd+n82bsisz1k/yz0AkzvusJ2gpFn8BmvCvQPhEFj3m2NvtTTL4I9CbVZDd7gcDwGSLmoGf2Gl+SYHomDg5Qg==}
+    engines: {node: '>=18'}
     peerDependencies:
+      hls.js: ^1.6.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       zustand: ^5.0.6
+    peerDependenciesMeta:
+      hls.js:
+        optional: true
 
-  '@reactor-team/js-sdk@2.9.3':
-    resolution: {integrity: sha512-pso2mGwzRginJs7j5zRE+CLtESRc6VRR4GBQIzbGoESNRJkNFvYW+zfJAIRhF8t009xtpYSb6jRu6pJYz1SkuQ==}
+  '@reactor-team/js-sdk@2.7.0':
+    resolution: {integrity: sha512-hDvWCef3PqHe9lQqBYar/1h4eqO3tqqkf8g3n74NQf8YMtuccwuUvjErJ2KdSfmAqLhW/fychg8atSe3MS1glA==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       zustand: ^5.0.6
@@ -1192,13 +1197,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@20.19.37)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 20.19.37
-
   '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
     dependencies:
       chardet: 2.1.1
@@ -1230,29 +1228,21 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@reactor-team/js-sdk@2.10.0(hls.js@1.6.16)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))':
+    dependencies:
+      react: 19.2.4
+      sdp-transform: 3.0.0
+      zod: 4.3.6
+      zustand: 5.0.12(@types/react@18.3.28)(react@19.2.4)
+    optionalDependencies:
+      hls.js: 1.6.16
+
   '@reactor-team/js-sdk@2.7.0(@types/node@22.19.15)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       chalk: 5.6.2
       inquirer: 9.3.8(@types/node@22.19.15)
       react: 19.2.4
-      simple-git: 3.33.0
-      ws: 8.20.0
-      zod: 4.3.6
-      zustand: 5.0.12(@types/react@18.3.28)(react@19.2.4)
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@reactor-team/js-sdk@2.9.3(@types/node@20.19.37)(react@19.2.4)(zustand@5.0.12(@types/react@18.3.28)(react@19.2.4))':
-    dependencies:
-      '@bufbuild/protobuf': 2.11.0
-      chalk: 5.6.2
-      inquirer: 9.3.8(@types/node@20.19.37)
-      react: 19.2.4
-      sdp-transform: 3.0.0
       simple-git: 3.33.0
       ws: 8.20.0
       zod: 4.3.6
@@ -1593,23 +1583,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
-
-  inquirer@9.3.8(@types/node@20.19.37):
-    dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@20.19.37)
-      '@inquirer/figures': 1.0.15
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 1.0.0
-      ora: 5.4.1
-      run-async: 3.0.0
-      rxjs: 7.8.2
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    transitivePeerDependencies:
-      - '@types/node'
 
   inquirer@9.3.8(@types/node@22.19.15):
     dependencies:


### PR DESCRIPTION
## Why

Generated `@reactor-models/*` packages currently pin to `@reactor-team/js-sdk@^2.9.3`. That version predates the recording surface (`requestClip`, `requestRecording`, `downloadClipAsFile`, `<ClipPlayer>`, `<ClipDownloadButton>`, `useClipDownload`). Bumping the default to `2.10.0` makes every freshly-generated typed SDK ship with recording from day one — no codegen logic changes needed thanks to the `extends Reactor` inheritance contract.

## What changed

- `packages/codegen/package.json`
  - `defaultSdkVersion`: `2.9.3` → `2.10.0`
  - `dependencies."@reactor-team/js-sdk"`: `^2.9.3` → `^2.10.0`
  - `codegen:test` script flag: `--sdk-version 2.9.3` → `--sdk-version 2.10.0`
- `packages/codegen/__tests__/cli.test.ts` — the one assertion that pins the default (`pkgJson.dependencies["@reactor-team/js-sdk"]).toBe("^2.10.0")`).
- `packages/codegen/README.md` — the example invocations now show `2.10.0`.
- `pnpm-lock.yaml` — resolved `@reactor-team/js-sdk@2.10.0` (including the new optional `hls.js` peer).

The `keeps defaultSdkVersion in lockstep with the runtime js-sdk dep` test still passes because both fields move together.

## Verification — recording surface flows into typed SDKs

Ran codegen end-to-end against prod Helios (`v0.8.11-gabc773fd`):

```bash
REACTOR_API_KEY=... pnpm --filter @reactor-team/codegen exec tsx src/cli.ts \
  --coordinator-url https://api.reactor.inc \
  --model-id 75c908ff-ffa2-4360-9fd6-85b181dd2d43 \
  --output /tmp/codegen-helios-verify \
  --react --no-build
```

Output:

```
SDK pin:  @reactor-team/js-sdk@^2.10.0
Events:   10
Messages: 9
Tracks:   1
```

Then wrote a smoke TS file that calls the recording API on the generated `HeliosModel`:

```ts
import { HeliosModel } from "./src/core";
import type { Clip } from "@reactor-team/js-sdk";

const helios = new HeliosModel();
await helios.connect(jwt);

const snap: Clip = await helios.requestClip(10);
const full: Clip = await helios.requestRecording();
const blob: Blob = await helios.downloadClipAsFile(snap, null);

await helios.setPrompt({ prompt: "a forest at dawn" });
```

`tsc --noEmit --strict` exits clean: the recording methods type-resolve through the `class HeliosModel extends Reactor` inheritance with no codegen wrapping required, and they coexist with the codegen-emitted typed `setPrompt`. This is the contract documented in `packages/codegen/README.md` under "Inheritance from `Reactor`" — bumping the SDK pin is the only knob needed to widen the surface.

## Test plan

- [x] `pnpm --filter @reactor-team/codegen build` succeeds
- [x] `pnpm --filter @reactor-team/codegen test` passes (352/352)
- [x] End-to-end: generate Helios SDK, compile a smoke file that uses recording, `tsc --noEmit` exits 0
- [ ] CI green