### PR TITLE
[REA-2512] sdk: thread JWT resolver through Coordinator + WebRTC clients

### DIFF
--- a/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
+++ b/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CoordinatorClient } from "../../src/core/CoordinatorClient";
+import { Reactor } from "../../src/core/Reactor";
 import { WebRTCTransportClient } from "../../src/core/WebRTCTransportClient";
 import { normalizeJwtSource, type JwtResolver } from "../../src/core/auth";
+import { AbortError } from "../../src/types";
 import {
   REACTOR_WEBRTC_VERSION,
   WEBRTC_VERSION_HEADER,
@@ -278,5 +280,99 @@ describe("WebRTCTransportClient with JWT resolver", () => {
     const headers = mockFetch.mock.calls[0][1].headers;
     expect(headers).not.toHaveProperty("Authorization");
     expect(headers[WEBRTC_VERSION_HEADER]).toBe(REACTOR_WEBRTC_VERSION);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reactor.getJwtResolver() exposes the resolver so off-session surfaces
+// (clip-download toast, ClipPlayer / ClipDownloadButton / useClipDownload
+// rendered inside `<ReactorProvider>`) can pick it up without re-threading
+// the prop. The React-side fallback wiring itself isn't exercised by
+// this suite (no @testing-library/react) — these tests cover the
+// underlying Reactor API the fallback relies on.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Reactor.getJwtResolver()", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    // Reject every fetch with an AbortError so `connect()` exits
+    // cleanly via its `if (isAbortError(error)) return;` path —
+    // no unhandled rejections, no error events, no need for the
+    // test to assert on the connect promise. The resolver
+    // assignment we care about happens synchronously *before*
+    // the first awaited fetch.
+    mockFetch.mockImplementation(() =>
+      Promise.reject(new AbortError("test: fetch aborted"))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns undefined before connect()", () => {
+    const reactor = new Reactor({
+      apiUrl: "https://api.test.com",
+      modelName: "echo",
+    });
+    expect(reactor.getJwtResolver()).toBeUndefined();
+  });
+
+  it("wraps a string jwt into a resolver after connect()", async () => {
+    const reactor = new Reactor({
+      apiUrl: "https://api.test.com",
+      modelName: "echo",
+    });
+    // connect() is `async` but the resolver assignment is
+    // synchronous-before-first-await, so kicking off the promise
+    // and ignoring it leaves the resolver observable immediately.
+    const connectPromise = reactor.connect("static-jwt");
+    const resolver = reactor.getJwtResolver();
+    expect(resolver).toBeDefined();
+    expect(await resolver!()).toBe("static-jwt");
+    // Consume the (expected) connect failure so vitest doesn't flag
+    // it as unhandled.
+    await connectPromise.catch(() => {});
+  });
+
+  it("preserves a function resolver verbatim after connect()", async () => {
+    const reactor = new Reactor({
+      apiUrl: "https://api.test.com",
+      modelName: "echo",
+    });
+    let calls = 0;
+    const supplied: JwtResolver = () => `jwt-${++calls}`;
+    const connectPromise = reactor.connect(supplied);
+    // Identity preserved: the stored resolver is the same function
+    // reference that was passed in (no double-wrap).
+    const stored = reactor.getJwtResolver();
+    expect(stored).toBe(supplied);
+    // We don't pin a specific number for `calls` here: the in-flight
+    // connect attempt may have already invoked the resolver once via
+    // CoordinatorClient.getHeaders() (and that's the point — the
+    // resolver gets called *per request*, not once at construction).
+    // Two more direct invocations should produce monotonically
+    // increasing tokens regardless of how many connect spent.
+    const before = calls;
+    expect(await stored!()).toBe(`jwt-${before + 1}`);
+    expect(await stored!()).toBe(`jwt-${before + 2}`);
+    await connectPromise.catch(() => {});
+  });
+
+  it("leaves the resolver unset in local mode (no auth needed)", async () => {
+    const reactor = new Reactor({
+      apiUrl: "http://localhost:8080",
+      modelName: "echo",
+      local: true,
+    });
+    const connectPromise = reactor.connect();
+    // Local mode talks to LocalCoordinatorClient which strips auth
+    // anyway — leaving `jwtResolver` undefined means clip surfaces
+    // correctly drop Authorization on `/clips` fetches too.
+    expect(reactor.getJwtResolver()).toBeUndefined();
+    await connectPromise.catch(() => {});
   });
 });

--- a/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
+++ b/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
@@ -9,15 +9,6 @@ import {
   WEBRTC_VERSION_HEADER,
 } from "../../src/core/types";
 
-// Regression tests for REA-2512: short-lived auth tokens (e.g. Clerk
-// session JWTs, default ~60s) used to be captured once at connect()
-// time and reused indefinitely, so every Coordinator HTTP hop 401'd
-// once the token expired. These tests verify:
-//   - the resolver path is exercised on every fetch (no caching)
-//   - string inputs remain wire-identical to the pre-resolver SDK
-//   - an empty-string token drops the Authorization header
-//   - resolver rejections propagate cleanly to the caller
-
 const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
 
 const MOCK_INITIAL_RESPONSE = {
@@ -45,8 +36,6 @@ describe("normalizeJwtSource", () => {
     let counter = 0;
     const resolver: JwtResolver = () => `jwt-${++counter}`;
     const normalised = normalizeJwtSource(resolver);
-    // Same reference: the resolver IS the source, no wrapper to
-    // hide its stateful increment from the caller.
     expect(normalised).toBe(resolver);
     expect(await normalised()).toBe("jwt-1");
     expect(await normalised()).toBe("jwt-2");
@@ -111,10 +100,7 @@ describe("CoordinatorClient with JWT resolver", () => {
     const client = new CoordinatorClient({
       baseUrl: "https://api.test.com",
       jwtToken: async () => {
-        // microtask hop simulates a Clerk getToken() call landing
-        // after the resolver invocation but before the fetch goes
-        // out — verifies we genuinely await rather than fire-and-
-        // forget.
+        // Microtask hop ensures the fetch waits for resolution.
         await Promise.resolve();
         return "promised-jwt";
       },
@@ -180,8 +166,6 @@ describe("CoordinatorClient with JWT resolver", () => {
     });
 
     await expect(client.createSession()).rejects.toThrow("clerk down");
-    // No fetch should have been issued — we never built the
-    // Authorization header.
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
@@ -206,10 +190,6 @@ describe("WebRTCTransportClient with JWT resolver", () => {
       jwtToken: () => `transport-jwt-${++mintedTokens}`,
     });
 
-    // Two consecutive warmup() calls bypass the in-memory cache by
-    // virtue of going through the same code path; we go via
-    // fetchIceServers directly through warmup() + a second manual
-    // probe to keep the test focused on the auth path.
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -218,10 +198,7 @@ describe("WebRTCTransportClient with JWT resolver", () => {
 
     await transport.warmup();
 
-    // Second call: clear the cache so the resolver fires again.
-    // The transport caches ICE servers internally so we instantiate
-    // a second client to simulate a fresh round-trip — same shape
-    // as ICE refresh during long sessions.
+    // Fresh client to bypass the per-instance ICE cache.
     const transport2 = new WebRTCTransportClient({
       baseUrl: "https://api.test.com",
       sessionId: MOCK_SESSION_ID,
@@ -236,7 +213,6 @@ describe("WebRTCTransportClient with JWT resolver", () => {
     expect(mockFetch.mock.calls[1][1].headers["Authorization"]).toBe(
       "Bearer transport-jwt-2"
     );
-    // WebRTC version header must still be on every request.
     expect(mockFetch.mock.calls[0][1].headers[WEBRTC_VERSION_HEADER]).toBe(
       REACTOR_WEBRTC_VERSION
     );
@@ -283,27 +259,15 @@ describe("WebRTCTransportClient with JWT resolver", () => {
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Reactor.getJwtResolver() exposes the resolver so off-session surfaces
-// (clip-download toast, ClipPlayer / ClipDownloadButton / useClipDownload
-// rendered inside `<ReactorProvider>`) can pick it up without re-threading
-// the prop. The React-side fallback wiring itself isn't exercised by
-// this suite (no @testing-library/react) — these tests cover the
-// underlying Reactor API the fallback relies on.
-// ─────────────────────────────────────────────────────────────────────────────
-
 describe("Reactor.getJwtResolver()", () => {
   const mockFetch = vi.fn();
 
   beforeEach(() => {
     vi.stubGlobal("fetch", mockFetch);
     mockFetch.mockReset();
-    // Reject every fetch with an AbortError so `connect()` exits
-    // cleanly via its `if (isAbortError(error)) return;` path —
-    // no unhandled rejections, no error events, no need for the
-    // test to assert on the connect promise. The resolver
-    // assignment we care about happens synchronously *before*
-    // the first awaited fetch.
+    // Force connect() down its AbortError exit path. The resolver
+    // assignment happens synchronously before the first await, so
+    // it is observable regardless of how the connect promise ends.
     mockFetch.mockImplementation(() =>
       Promise.reject(new AbortError("test: fetch aborted"))
     );
@@ -326,15 +290,10 @@ describe("Reactor.getJwtResolver()", () => {
       apiUrl: "https://api.test.com",
       modelName: "echo",
     });
-    // connect() is `async` but the resolver assignment is
-    // synchronous-before-first-await, so kicking off the promise
-    // and ignoring it leaves the resolver observable immediately.
     const connectPromise = reactor.connect("static-jwt");
     const resolver = reactor.getJwtResolver();
     expect(resolver).toBeDefined();
     expect(await resolver!()).toBe("static-jwt");
-    // Consume the (expected) connect failure so vitest doesn't flag
-    // it as unhandled.
     await connectPromise.catch(() => {});
   });
 
@@ -346,16 +305,10 @@ describe("Reactor.getJwtResolver()", () => {
     let calls = 0;
     const supplied: JwtResolver = () => `jwt-${++calls}`;
     const connectPromise = reactor.connect(supplied);
-    // Identity preserved: the stored resolver is the same function
-    // reference that was passed in (no double-wrap).
     const stored = reactor.getJwtResolver();
     expect(stored).toBe(supplied);
-    // We don't pin a specific number for `calls` here: the in-flight
-    // connect attempt may have already invoked the resolver once via
-    // CoordinatorClient.getHeaders() (and that's the point — the
-    // resolver gets called *per request*, not once at construction).
-    // Two more direct invocations should produce monotonically
-    // increasing tokens regardless of how many connect spent.
+    // connect() may have invoked the resolver once already; rebase
+    // the expectations on the count after that to stay robust.
     const before = calls;
     expect(await stored!()).toBe(`jwt-${before + 1}`);
     expect(await stored!()).toBe(`jwt-${before + 2}`);
@@ -369,9 +322,6 @@ describe("Reactor.getJwtResolver()", () => {
       local: true,
     });
     const connectPromise = reactor.connect();
-    // Local mode talks to LocalCoordinatorClient which strips auth
-    // anyway — leaving `jwtResolver` undefined means clip surfaces
-    // correctly drop Authorization on `/clips` fetches too.
     expect(reactor.getJwtResolver()).toBeUndefined();
     await connectPromise.catch(() => {});
   });

--- a/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
+++ b/packages/js-sdk/__tests__/unit/jwt-resolver.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CoordinatorClient } from "../../src/core/CoordinatorClient";
+import { WebRTCTransportClient } from "../../src/core/WebRTCTransportClient";
+import { normalizeJwtSource, type JwtResolver } from "../../src/core/auth";
+import {
+  REACTOR_WEBRTC_VERSION,
+  WEBRTC_VERSION_HEADER,
+} from "../../src/core/types";
+
+// Regression tests for REA-2512: short-lived auth tokens (e.g. Clerk
+// session JWTs, default ~60s) used to be captured once at connect()
+// time and reused indefinitely, so every Coordinator HTTP hop 401'd
+// once the token expired. These tests verify:
+//   - the resolver path is exercised on every fetch (no caching)
+//   - string inputs remain wire-identical to the pre-resolver SDK
+//   - an empty-string token drops the Authorization header
+//   - resolver rejections propagate cleanly to the caller
+
+const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
+
+const MOCK_INITIAL_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  server_info: { server_version: "1.5.0" },
+  state: "CREATED",
+  cluster: "sup.us-west-2.aws.prod.reactor.inc",
+};
+
+// Wire shape per IceServersResponseSchema: { ice_servers: [{ uris }] }
+const MOCK_ICE_SERVERS = {
+  ice_servers: [{ uris: ["stun:stun.l.google.com:19302"] }],
+};
+
+describe("normalizeJwtSource", () => {
+  it("wraps a string into a constant resolver", async () => {
+    const resolver = normalizeJwtSource("static-jwt");
+    expect(typeof resolver).toBe("function");
+    expect(await resolver()).toBe("static-jwt");
+    expect(await resolver()).toBe("static-jwt");
+  });
+
+  it("returns a function resolver as-is (no double-wrap)", async () => {
+    let counter = 0;
+    const resolver: JwtResolver = () => `jwt-${++counter}`;
+    const normalised = normalizeJwtSource(resolver);
+    // Same reference: the resolver IS the source, no wrapper to
+    // hide its stateful increment from the caller.
+    expect(normalised).toBe(resolver);
+    expect(await normalised()).toBe("jwt-1");
+    expect(await normalised()).toBe("jwt-2");
+  });
+
+  it("supports Promise-returning resolvers", async () => {
+    const resolver = normalizeJwtSource(async () => "async-jwt");
+    expect(await resolver()).toBe("async-jwt");
+  });
+});
+
+describe("CoordinatorClient with JWT resolver", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the resolver before every request (no token caching)", async () => {
+    let mintedTokens = 0;
+    const client = new CoordinatorClient({
+      baseUrl: "https://api.test.com",
+      jwtToken: () => `jwt-${++mintedTokens}`,
+      model: "echo",
+    });
+
+    // createSession → 1st resolver call
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(MOCK_INITIAL_RESPONSE),
+    });
+    await client.createSession();
+    // getSessionInfo → 2nd resolver call
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          session_id: MOCK_SESSION_ID,
+          state: "ACTIVE",
+          cluster: MOCK_INITIAL_RESPONSE.cluster,
+        }),
+    });
+    await client.getSessionInfo();
+
+    expect(mintedTokens).toBe(2);
+    expect(mockFetch.mock.calls[0][1].headers["Authorization"]).toBe(
+      "Bearer jwt-1"
+    );
+    expect(mockFetch.mock.calls[1][1].headers["Authorization"]).toBe(
+      "Bearer jwt-2"
+    );
+  });
+
+  it("awaits Promise-returning resolvers before sending", async () => {
+    const client = new CoordinatorClient({
+      baseUrl: "https://api.test.com",
+      jwtToken: async () => {
+        // microtask hop simulates a Clerk getToken() call landing
+        // after the resolver invocation but before the fetch goes
+        // out — verifies we genuinely await rather than fire-and-
+        // forget.
+        await Promise.resolve();
+        return "promised-jwt";
+      },
+      model: "echo",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(MOCK_INITIAL_RESPONSE),
+    });
+    await client.createSession();
+
+    expect(mockFetch.mock.calls[0][1].headers["Authorization"]).toBe(
+      "Bearer promised-jwt"
+    );
+  });
+
+  it("string input behaves identically to the pre-resolver SDK", async () => {
+    const client = new CoordinatorClient({
+      baseUrl: "https://api.test.com",
+      jwtToken: "static-jwt",
+      model: "echo",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(MOCK_INITIAL_RESPONSE),
+    });
+    await client.createSession();
+
+    expect(mockFetch.mock.calls[0][1].headers["Authorization"]).toBe(
+      "Bearer static-jwt"
+    );
+  });
+
+  it("omits the Authorization header when the resolver returns ''", async () => {
+    const client = new CoordinatorClient({
+      baseUrl: "https://api.test.com",
+      jwtToken: () => "",
+      model: "echo",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(MOCK_INITIAL_RESPONSE),
+    });
+    await client.createSession();
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty("Authorization");
+  });
+
+  it("propagates a rejecting resolver as a thrown error", async () => {
+    const client = new CoordinatorClient({
+      baseUrl: "https://api.test.com",
+      jwtToken: async () => {
+        throw new Error("clerk down");
+      },
+      model: "echo",
+    });
+
+    await expect(client.createSession()).rejects.toThrow("clerk down");
+    // No fetch should have been issued — we never built the
+    // Authorization header.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("WebRTCTransportClient with JWT resolver", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("re-resolves the JWT on each signaling fetch", async () => {
+    let mintedTokens = 0;
+    const transport = new WebRTCTransportClient({
+      baseUrl: "https://api.test.com",
+      sessionId: MOCK_SESSION_ID,
+      jwtToken: () => `transport-jwt-${++mintedTokens}`,
+    });
+
+    // Two consecutive warmup() calls bypass the in-memory cache by
+    // virtue of going through the same code path; we go via
+    // fetchIceServers directly through warmup() + a second manual
+    // probe to keep the test focused on the auth path.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_ICE_SERVERS),
+    });
+
+    await transport.warmup();
+
+    // Second call: clear the cache so the resolver fires again.
+    // The transport caches ICE servers internally so we instantiate
+    // a second client to simulate a fresh round-trip — same shape
+    // as ICE refresh during long sessions.
+    const transport2 = new WebRTCTransportClient({
+      baseUrl: "https://api.test.com",
+      sessionId: MOCK_SESSION_ID,
+      jwtToken: () => `transport-jwt-${++mintedTokens}`,
+    });
+    await transport2.warmup();
+
+    expect(mintedTokens).toBe(2);
+    expect(mockFetch.mock.calls[0][1].headers["Authorization"]).toBe(
+      "Bearer transport-jwt-1"
+    );
+    expect(mockFetch.mock.calls[1][1].headers["Authorization"]).toBe(
+      "Bearer transport-jwt-2"
+    );
+    // WebRTC version header must still be on every request.
+    expect(mockFetch.mock.calls[0][1].headers[WEBRTC_VERSION_HEADER]).toBe(
+      REACTOR_WEBRTC_VERSION
+    );
+  });
+
+  it("string input behaves identically to the pre-resolver SDK", async () => {
+    const transport = new WebRTCTransportClient({
+      baseUrl: "https://api.test.com",
+      sessionId: MOCK_SESSION_ID,
+      jwtToken: "static-transport-jwt",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_ICE_SERVERS),
+    });
+
+    await transport.warmup();
+
+    expect(mockFetch.mock.calls[0][1].headers["Authorization"]).toBe(
+      "Bearer static-transport-jwt"
+    );
+  });
+
+  it("omits Authorization when the resolver returns ''", async () => {
+    const transport = new WebRTCTransportClient({
+      baseUrl: "https://api.test.com",
+      sessionId: MOCK_SESSION_ID,
+      jwtToken: () => "",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(MOCK_ICE_SERVERS),
+    });
+
+    await transport.warmup();
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty("Authorization");
+    expect(headers[WEBRTC_VERSION_HEADER]).toBe(REACTOR_WEBRTC_VERSION);
+  });
+});

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -27,6 +27,7 @@ import {
   VERSION_ERROR_CODES,
 } from "./types";
 import { AbortError } from "../types";
+import { type JwtResolver, type JwtSource, normalizeJwtSource } from "./auth";
 
 const SESSION_POLL_INITIAL_BACKOFF_MS = 200;
 const SESSION_POLL_MAX_BACKOFF_MS = 10_000;
@@ -35,20 +36,30 @@ const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 20;
 
 export interface CoordinatorClientOptions {
   baseUrl: string;
-  jwtToken: string;
+  /**
+   * Either a static JWT string or a {@link JwtResolver} called
+   * immediately before each Coordinator HTTP request. Prefer the
+   * resolver form when the token is short-lived (e.g. Clerk session
+   * JWTs default to ~60s) — see {@link JwtSource} and REA-2512.
+   */
+  jwtToken: JwtSource;
   model: string;
 }
 
 export class CoordinatorClient {
   protected readonly baseUrl: string;
-  private jwtToken: string;
+  // Per-request resolver. String inputs were normalised into a
+  // constant resolver in the constructor so the request path stays
+  // shape-agnostic; the runtime cost vs. the old static field is one
+  // function call + a possible microtask hop.
+  private readonly resolveJwt: JwtResolver;
   protected readonly model: string;
   protected currentSessionId?: string;
   private abortController: AbortController;
 
   constructor(options: CoordinatorClientOptions) {
     this.baseUrl = options.baseUrl;
-    this.jwtToken = options.jwtToken;
+    this.resolveJwt = normalizeJwtSource(options.jwtToken);
     this.model = options.model;
     this.abortController = new AbortController();
   }
@@ -71,14 +82,25 @@ export class CoordinatorClient {
   }
 
   /**
-   * Returns authorization + versioning headers for all coordinator requests.
+   * Returns authorization + versioning headers for all coordinator
+   * requests.
+   *
+   * Async because the JWT resolver may need to round-trip to the
+   * auth provider (Clerk, custom backend, etc.) when its cached
+   * token is near expiry. An empty string suppresses the
+   * `Authorization` header entirely — leave the resolver returning
+   * `""` in local-dev setups where the runtime serves auth-free.
    */
-  protected getHeaders(): HeadersInit {
-    return {
-      Authorization: `Bearer ${this.jwtToken}`,
+  protected async getHeaders(): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {
       [API_VERSION_HEADER]: String(REACTOR_API_VERSION),
       [API_ACCEPT_VERSION_HEADER]: String(REACTOR_API_VERSION),
     };
+    const jwt = await this.resolveJwt();
+    if (jwt) {
+      headers.Authorization = `Bearer ${jwt}`;
+    }
+    return headers;
   }
 
   /**
@@ -150,7 +172,7 @@ export class CoordinatorClient {
     const response = await fetch(`${this.baseUrl}/sessions`, {
       method: "POST",
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
@@ -217,7 +239,7 @@ export class CoordinatorClient {
         `${this.baseUrl}/sessions/${this.currentSessionId}`,
         {
           method: "GET",
-          headers: this.getHeaders(),
+          headers: await this.getHeaders(),
           signal: this.signal,
         }
       );
@@ -280,7 +302,7 @@ export class CoordinatorClient {
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "GET",
-        headers: this.getHeaders(),
+        headers: await this.getHeaders(),
         signal: this.signal,
       }
     );
@@ -308,7 +330,7 @@ export class CoordinatorClient {
       `${this.baseUrl}/sessions/${this.currentSessionId}/info`,
       {
         method: "GET",
-        headers: this.getHeaders(),
+        headers: await this.getHeaders(),
         signal: this.signal,
       }
     );
@@ -344,7 +366,7 @@ export class CoordinatorClient {
       `${this.baseUrl}/sessions/${this.currentSessionId}`,
       {
         method: "PUT",
-        headers: this.getHeaders(),
+        headers: await this.getHeaders(),
         signal: this.signal,
       }
     );
@@ -383,7 +405,7 @@ export class CoordinatorClient {
       {
         method: "DELETE",
         headers: {
-          ...this.getHeaders(),
+          ...(await this.getHeaders()),
           ...(body ? { "Content-Type": "application/json" } : {}),
         },
         ...(body ? { body: JSON.stringify(body) } : {}),
@@ -431,7 +453,7 @@ export class CoordinatorClient {
       {
         method: "POST",
         headers: {
-          ...this.getHeaders(),
+          ...(await this.getHeaders()),
           "Content-Type": "application/json",
         },
         body: JSON.stringify(request),

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -36,22 +36,12 @@ const SESSION_POLL_DEFAULT_MAX_ATTEMPTS = 20;
 
 export interface CoordinatorClientOptions {
   baseUrl: string;
-  /**
-   * Either a static JWT string or a {@link JwtResolver} called
-   * immediately before each Coordinator HTTP request. Prefer the
-   * resolver form when the token is short-lived (e.g. Clerk session
-   * JWTs default to ~60s) — see {@link JwtSource} and REA-2512.
-   */
   jwtToken: JwtSource;
   model: string;
 }
 
 export class CoordinatorClient {
   protected readonly baseUrl: string;
-  // Per-request resolver. String inputs were normalised into a
-  // constant resolver in the constructor so the request path stays
-  // shape-agnostic; the runtime cost vs. the old static field is one
-  // function call + a possible microtask hop.
   private readonly resolveJwt: JwtResolver;
   protected readonly model: string;
   protected currentSessionId?: string;
@@ -83,13 +73,8 @@ export class CoordinatorClient {
 
   /**
    * Returns authorization + versioning headers for all coordinator
-   * requests.
-   *
-   * Async because the JWT resolver may need to round-trip to the
-   * auth provider (Clerk, custom backend, etc.) when its cached
-   * token is near expiry. An empty string suppresses the
-   * `Authorization` header entirely — leave the resolver returning
-   * `""` in local-dev setups where the runtime serves auth-free.
+   * requests. Async so the JWT resolver can fetch a fresh token if
+   * needed; an empty token suppresses the `Authorization` header.
    */
   protected async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -32,7 +32,11 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     });
   }
 
-  protected override getHeaders(): HeadersInit {
+  // The local runtime serves auth-free endpoints, so we override
+  // getHeaders() to strip the Authorization line that the base class
+  // would otherwise emit for the "local" sentinel jwt. Async to match
+  // the base class signature.
+  protected override async getHeaders(): Promise<Record<string, string>> {
     return {
       [API_VERSION_HEADER]: String(REACTOR_API_VERSION),
       [API_ACCEPT_VERSION_HEADER]: String(REACTOR_API_VERSION),
@@ -53,7 +57,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     const response = await fetch(`${this.baseUrl}/start_session`, {
       method: "POST",
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -116,7 +120,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     try {
       await fetch(`${this.baseUrl}/stop_session`, {
         method: "POST",
-        headers: this.getHeaders(),
+        headers: await this.getHeaders(),
         signal: this.signal,
       });
     } catch (error) {

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -32,10 +32,7 @@ export class LocalCoordinatorClient extends CoordinatorClient {
     });
   }
 
-  // The local runtime serves auth-free endpoints, so we override
-  // getHeaders() to strip the Authorization line that the base class
-  // would otherwise emit for the "local" sentinel jwt. Async to match
-  // the base class signature.
+  // Local runtime endpoints are auth-free; skip the Authorization header.
   protected override async getHeaders(): Promise<Record<string, string>> {
     return {
       [API_VERSION_HEADER]: String(REACTOR_API_VERSION),

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -9,7 +9,7 @@ import {
   type ConnectionTimings,
   isAbortError,
 } from "../types";
-import { type JwtSource } from "./auth";
+import { type JwtResolver, type JwtSource, normalizeJwtSource } from "./auth";
 import { CoordinatorClient } from "./CoordinatorClient";
 import { LocalCoordinatorClient } from "./LocalCoordinatorClient";
 import { type TransportClient, type TransportStatus } from "./TransportClient";
@@ -63,6 +63,14 @@ export class Reactor {
   private tracks: TrackCapability[] = [];
   private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
+  // Most recent JWT resolver supplied to `connect()`. We cache it so
+  // off-session surfaces (clip download toast that outlives the
+  // session, `useClipDownload` falling back from a missing `getJwt`
+  // option, etc.) can reach the same token source the
+  // CoordinatorClient/WebRTCTransportClient are using, without
+  // requiring callers to thread `getJwt` through every clip
+  // component. See `getJwtResolver()` and REA-2512.
+  private jwtResolver?: JwtResolver;
 
   /** Per-Reactor recording client. See {@link RecordingClient}. */
   readonly recording: RecordingClient;
@@ -96,6 +104,25 @@ export class Reactor {
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
+
+  /**
+   * Returns the JWT resolver supplied to the most recent
+   * {@link connect} call, or `undefined` if no auth source has been
+   * configured yet (pre-connect, or local mode).
+   *
+   * Surfaces like {@link ClipPlayer}, {@link ClipDownloadButton},
+   * and {@link useClipDownload} use this as a fallback when their
+   * own `getJwt` prop isn't supplied — so a consumer that already
+   * passed `getJwt` to `<ReactorProvider>` doesn't need to re-thread
+   * it through every clip-aware component. The resolver outlives
+   * `disconnect()` on purpose: a captured clip can still be
+   * downloaded after the live session has ended, and refreshing the
+   * JWT against the auth provider (Clerk, etc.) is independent of
+   * session lifecycle.
+   */
+  getJwtResolver(): JwtResolver | undefined {
+    return this.jwtResolver;
+  }
 
   on(event: ReactorEvent, handler: EventHandler) {
     if (!this.eventListeners.has(event)) {
@@ -400,6 +427,16 @@ export class Reactor {
     this.setStatus("connecting");
 
     this.connectStartTime = performance.now();
+
+    // Cache the resolver form before constructing downstream clients
+    // so off-session surfaces (e.g. a clip-download toast that
+    // outlives the session) can reach the same token source via
+    // `getJwtResolver()`. Local mode has no auth — the
+    // LocalCoordinatorClient strips Authorization regardless, so we
+    // leave `jwtResolver` undefined there.
+    if (!this.local && jwtToken !== undefined) {
+      this.jwtResolver = normalizeJwtSource(jwtToken);
+    }
 
     try {
       this.coordinatorClient = this.local

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -9,6 +9,7 @@ import {
   type ConnectionTimings,
   isAbortError,
 } from "../types";
+import { type JwtSource } from "./auth";
 import { CoordinatorClient } from "./CoordinatorClient";
 import { LocalCoordinatorClient } from "./LocalCoordinatorClient";
 import { type TransportClient, type TransportStatus } from "./TransportClient";
@@ -379,8 +380,14 @@ export class Reactor {
   /**
    * Connects to the coordinator, creates a session, then establishes
    * the transport using server-declared capabilities.
+   *
+   * `jwtToken` accepts either a static token string or a
+   * {@link JwtSource} resolver. The resolver form is required when
+   * the token is short-lived (e.g. Clerk session JWTs default to
+   * ~60s) — see REA-2512. A string is wrapped into a constant
+   * resolver and behaves identically to the pre-resolver SDK.
    */
-  async connect(jwtToken?: string, options?: ConnectOptions): Promise<void> {
+  async connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);
 
     if (jwtToken == undefined && !this.local) {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -63,13 +63,10 @@ export class Reactor {
   private tracks: TrackCapability[] = [];
   private presetTracks?: TrackCapability[];
   private sessionResponse?: SessionResponse;
-  // Most recent JWT resolver supplied to `connect()`. We cache it so
-  // off-session surfaces (clip download toast that outlives the
-  // session, `useClipDownload` falling back from a missing `getJwt`
-  // option, etc.) can reach the same token source the
-  // CoordinatorClient/WebRTCTransportClient are using, without
-  // requiring callers to thread `getJwt` through every clip
-  // component. See `getJwtResolver()` and REA-2512.
+  // Cached so clip surfaces (player, download button, hook) can
+  // reach the same token source without re-threading `getJwt`.
+  // Outlives `disconnect()` because captured clips can still be
+  // downloaded after the session has ended.
   private jwtResolver?: JwtResolver;
 
   /** Per-Reactor recording client. See {@link RecordingClient}. */
@@ -107,18 +104,9 @@ export class Reactor {
 
   /**
    * Returns the JWT resolver supplied to the most recent
-   * {@link connect} call, or `undefined` if no auth source has been
-   * configured yet (pre-connect, or local mode).
-   *
-   * Surfaces like {@link ClipPlayer}, {@link ClipDownloadButton},
-   * and {@link useClipDownload} use this as a fallback when their
-   * own `getJwt` prop isn't supplied — so a consumer that already
-   * passed `getJwt` to `<ReactorProvider>` doesn't need to re-thread
-   * it through every clip-aware component. The resolver outlives
-   * `disconnect()` on purpose: a captured clip can still be
-   * downloaded after the live session has ended, and refreshing the
-   * JWT against the auth provider (Clerk, etc.) is independent of
-   * session lifecycle.
+   * {@link connect} call, or `undefined` if none was set (pre-connect
+   * or local mode). Used by clip surfaces as a fallback when their
+   * own `getJwt` prop is omitted.
    */
   getJwtResolver(): JwtResolver | undefined {
     return this.jwtResolver;
@@ -406,13 +394,10 @@ export class Reactor {
 
   /**
    * Connects to the coordinator, creates a session, then establishes
-   * the transport using server-declared capabilities.
-   *
-   * `jwtToken` accepts either a static token string or a
-   * {@link JwtSource} resolver. The resolver form is required when
-   * the token is short-lived (e.g. Clerk session JWTs default to
-   * ~60s) — see REA-2512. A string is wrapped into a constant
-   * resolver and behaves identically to the pre-resolver SDK.
+   * the transport using server-declared capabilities. `jwtToken` may
+   * be a static string or a {@link JwtSource} resolver; pass a
+   * resolver when the token is short-lived so each Coordinator HTTP
+   * hop sees a fresh value.
    */
   async connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);
@@ -428,12 +413,8 @@ export class Reactor {
 
     this.connectStartTime = performance.now();
 
-    // Cache the resolver form before constructing downstream clients
-    // so off-session surfaces (e.g. a clip-download toast that
-    // outlives the session) can reach the same token source via
-    // `getJwtResolver()`. Local mode has no auth — the
-    // LocalCoordinatorClient strips Authorization regardless, so we
-    // leave `jwtResolver` undefined there.
+    // Cache the resolver so clip surfaces can reuse it via
+    // `getJwtResolver()`. Local mode is auth-free, leave it unset.
     if (!this.local && jwtToken !== undefined) {
       this.jwtResolver = normalizeJwtSource(jwtToken);
     }

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -40,13 +40,6 @@ type EventHandler = (...args: any[]) => void;
 export interface TransportClientConfig {
   baseUrl: string;
   sessionId: string;
-  /**
-   * Either a static JWT string or a resolver invoked immediately
-   * before each transport-signaling HTTP request. See
-   * {@link JwtSource} and REA-2512 for why short-lived tokens
-   * (Clerk, custom backends with sub-minute TTLs) need the resolver
-   * form.
-   */
   jwtToken: JwtSource;
 }
 

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -8,6 +8,7 @@
  */
 
 import type { TrackCapability, ConnectionStats, MessageScope } from "../types";
+import type { JwtSource } from "./auth";
 import type { WebRTCTransportTimings } from "./WebRTCTransportClient";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,7 +40,14 @@ type EventHandler = (...args: any[]) => void;
 export interface TransportClientConfig {
   baseUrl: string;
   sessionId: string;
-  jwtToken: string;
+  /**
+   * Either a static JWT string or a resolver invoked immediately
+   * before each transport-signaling HTTP request. See
+   * {@link JwtSource} and REA-2512 for why short-lived tokens
+   * (Clerk, custom backends with sub-minute TTLs) need the resolver
+   * form.
+   */
+  jwtToken: JwtSource;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -15,6 +15,7 @@ import type {
 } from "./TransportClient";
 import type { MessageScope, ConnectionStats } from "../types";
 import { AbortError } from "../types";
+import { type JwtResolver, normalizeJwtSource } from "./auth";
 import {
   type TrackCapability,
   type TrackMappingEntry,
@@ -105,7 +106,11 @@ export class WebRTCTransportClient implements TransportClient {
 
   private readonly baseUrl: string;
   private readonly sessionId: string;
-  private readonly jwtToken: string;
+  // String inputs get wrapped into a constant resolver in the
+  // constructor so the request path is shape-agnostic and short-lived
+  // tokens (Clerk session JWTs, default ~60s lifetime — REA-2512)
+  // can be refreshed lazily before each signaling fetch.
+  private readonly resolveJwt: JwtResolver;
   webrtcVersion: string;
   private readonly maxPollAttempts: number;
   private abortController: AbortController;
@@ -113,7 +118,7 @@ export class WebRTCTransportClient implements TransportClient {
   constructor(config: WebRTCTransportConfig) {
     this.baseUrl = config.baseUrl;
     this.sessionId = config.sessionId;
-    this.jwtToken = config.jwtToken;
+    this.resolveJwt = normalizeJwtSource(config.jwtToken);
     this.webrtcVersion = config.webrtcVersion ?? REACTOR_WEBRTC_VERSION;
     this.maxPollAttempts = config.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
     this.abortController = new AbortController();
@@ -150,11 +155,19 @@ export class WebRTCTransportClient implements TransportClient {
     return `${this.baseUrl}/sessions/${this.sessionId}/transport/webrtc`;
   }
 
-  private getHeaders(): HeadersInit {
-    return {
-      Authorization: `Bearer ${this.jwtToken}`,
+  // Async because the JWT resolver may need a network hop when the
+  // upstream cache is near expiry. Empty resolver returns suppress
+  // the Authorization header entirely (parity with
+  // LocalCoordinatorClient's auth-free signaling path).
+  private async getHeaders(): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {
       [WEBRTC_VERSION_HEADER]: this.webrtcVersion,
     };
+    const jwt = await this.resolveJwt();
+    if (jwt) {
+      headers.Authorization = `Bearer ${jwt}`;
+    }
+    return headers;
   }
 
   private async checkVersionMismatch(response: Response): Promise<void> {
@@ -203,7 +216,7 @@ export class WebRTCTransportClient implements TransportClient {
 
     const response = await fetch(`${this.transportBaseUrl}/ice_servers`, {
       method: "GET",
-      headers: this.getHeaders(),
+      headers: await this.getHeaders(),
       signal: this.signal,
     });
 
@@ -243,7 +256,7 @@ export class WebRTCTransportClient implements TransportClient {
     const response = await fetch(`${this.transportBaseUrl}/sdp_params`, {
       method,
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
@@ -287,7 +300,7 @@ export class WebRTCTransportClient implements TransportClient {
 
       const response = await fetch(`${this.transportBaseUrl}/sdp_params`, {
         method: "GET",
-        headers: this.getHeaders(),
+        headers: await this.getHeaders(),
         signal: this.signal,
       });
 

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -106,10 +106,6 @@ export class WebRTCTransportClient implements TransportClient {
 
   private readonly baseUrl: string;
   private readonly sessionId: string;
-  // String inputs get wrapped into a constant resolver in the
-  // constructor so the request path is shape-agnostic and short-lived
-  // tokens (Clerk session JWTs, default ~60s lifetime — REA-2512)
-  // can be refreshed lazily before each signaling fetch.
   private readonly resolveJwt: JwtResolver;
   webrtcVersion: string;
   private readonly maxPollAttempts: number;
@@ -155,10 +151,8 @@ export class WebRTCTransportClient implements TransportClient {
     return `${this.baseUrl}/sessions/${this.sessionId}/transport/webrtc`;
   }
 
-  // Async because the JWT resolver may need a network hop when the
-  // upstream cache is near expiry. Empty resolver returns suppress
-  // the Authorization header entirely (parity with
-  // LocalCoordinatorClient's auth-free signaling path).
+  // Async so the JWT resolver can fetch a fresh token if needed; an
+  // empty token suppresses the `Authorization` header.
   private async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       [WEBRTC_VERSION_HEADER]: this.webrtcVersion,

--- a/packages/js-sdk/src/core/auth.ts
+++ b/packages/js-sdk/src/core/auth.ts
@@ -1,0 +1,52 @@
+/**
+ * Auth primitives shared by the session-lifecycle clients
+ * (CoordinatorClient, WebRTCTransportClient).
+ *
+ * The SDK historically captured the JWT as a single string at
+ * `connect()` time and reused it on every subsequent HTTP call. That
+ * breaks anyone passing a short-lived token (e.g. a Clerk session
+ * JWT, default lifetime ~60s): once it expires, *all* Coordinator
+ * HTTP hops (`POST /sessions/:id/uploads`, `GET /clips`,
+ * `GET /sessions/:id`, ICE refresh, SDP renegotiation, …) start
+ * 401-ing with `Invalid or expired token`. See REA-2512.
+ *
+ * The fix is to widen every `jwtToken: string` field to accept a
+ * lazy {@link JwtResolver} as well: the SDK calls the resolver
+ * immediately before each fetch, so the token in flight is always
+ * fresh. Consumers that already hold a long-lived SDK JWT can keep
+ * passing a string — it's wrapped into a constant resolver and the
+ * runtime cost is one extra function call per request.
+ */
+
+/**
+ * Lazy resolver for the Coordinator bearer token.
+ *
+ * Called on every Coordinator HTTP request, so token refreshes (e.g.
+ * Clerk's `getToken({ template: "reactor" })`, which the client SDK
+ * caches and only round-trips to the network when the cache is near
+ * expiry) are picked up automatically. Returning `""` produces a
+ * request without an `Authorization` header — useful for local-dev
+ * setups where the runtime serves auth-free endpoints.
+ */
+export type JwtResolver = () => string | Promise<string>;
+
+/**
+ * Accepted shape for any place that historically took a single
+ * `jwtToken: string`. Either a static token, or a {@link JwtResolver}
+ * the SDK invokes per request.
+ */
+export type JwtSource = string | JwtResolver;
+
+/**
+ * Normalize a {@link JwtSource} into a {@link JwtResolver}.
+ *
+ * A bare string is wrapped into a constant function — preserving the
+ * pre-resolver behaviour for callers that pass long-lived SDK JWTs.
+ * A function is returned as-is.
+ */
+export function normalizeJwtSource(source: JwtSource): JwtResolver {
+  if (typeof source === "function") {
+    return source;
+  }
+  return () => source;
+}

--- a/packages/js-sdk/src/core/auth.ts
+++ b/packages/js-sdk/src/core/auth.ts
@@ -1,49 +1,15 @@
 /**
- * Auth primitives shared by the session-lifecycle clients
- * (CoordinatorClient, WebRTCTransportClient).
- *
- * The SDK historically captured the JWT as a single string at
- * `connect()` time and reused it on every subsequent HTTP call. That
- * breaks anyone passing a short-lived token (e.g. a Clerk session
- * JWT, default lifetime ~60s): once it expires, *all* Coordinator
- * HTTP hops (`POST /sessions/:id/uploads`, `GET /clips`,
- * `GET /sessions/:id`, ICE refresh, SDP renegotiation, …) start
- * 401-ing with `Invalid or expired token`. See REA-2512.
- *
- * The fix is to widen every `jwtToken: string` field to accept a
- * lazy {@link JwtResolver} as well: the SDK calls the resolver
- * immediately before each fetch, so the token in flight is always
- * fresh. Consumers that already hold a long-lived SDK JWT can keep
- * passing a string — it's wrapped into a constant resolver and the
- * runtime cost is one extra function call per request.
- */
-
-/**
- * Lazy resolver for the Coordinator bearer token.
- *
- * Called on every Coordinator HTTP request, so token refreshes (e.g.
- * Clerk's `getToken({ template: "reactor" })`, which the client SDK
- * caches and only round-trips to the network when the cache is near
- * expiry) are picked up automatically. Returning `""` produces a
- * request without an `Authorization` header — useful for local-dev
- * setups where the runtime serves auth-free endpoints.
+ * Lazy resolver for the Coordinator bearer token. The SDK calls this
+ * immediately before each authenticated HTTP request, so short-lived
+ * tokens (Clerk session JWTs, etc.) are refreshed transparently.
+ * Returning `""` suppresses the `Authorization` header entirely.
  */
 export type JwtResolver = () => string | Promise<string>;
 
-/**
- * Accepted shape for any place that historically took a single
- * `jwtToken: string`. Either a static token, or a {@link JwtResolver}
- * the SDK invokes per request.
- */
+/** Static token, or a {@link JwtResolver} invoked per request. */
 export type JwtSource = string | JwtResolver;
 
-/**
- * Normalize a {@link JwtSource} into a {@link JwtResolver}.
- *
- * A bare string is wrapped into a constant function — preserving the
- * pre-resolver behaviour for callers that pass long-lived SDK JWTs.
- * A function is returned as-is.
- */
+/** Wrap a {@link JwtSource} into a {@link JwtResolver}. */
 export function normalizeJwtSource(source: JwtSource): JwtResolver {
   if (typeof source === "function") {
     return source;

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -5,6 +5,7 @@ import type {
   MessageScope,
   ConnectOptions,
 } from "../types";
+import { type JwtSource } from "./auth";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
 import { FileRef } from "./FileRef";
 import { create } from "zustand/react";
@@ -24,12 +25,20 @@ export interface ReactorState {
   lastError?: ReactorError;
   sessionId?: string;
   sessionExpiration?: number;
-  jwtToken?: string;
+  /**
+   * Token source for Coordinator HTTP calls. Stored as the union so
+   * callers that pass a resolver via `<ReactorProvider getJwt={…} />`
+   * (the recommended path for short-lived tokens — REA-2512) and
+   * legacy callers that pass a static string both flow through the
+   * same field. Selecting `s.jwtToken` will return whichever shape
+   * the consumer originally supplied.
+   */
+  jwtToken?: JwtSource;
 }
 
 export interface ReactorActions {
   sendCommand(command: string, data: any, scope?: MessageScope): Promise<void>;
-  connect(jwtToken?: string, options?: ConnectOptions): Promise<void>;
+  connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
   publish(name: string, track: MediaStreamTrack): Promise<void>;
   unpublish(name: string): Promise<void>;
@@ -67,7 +76,12 @@ export const defaultInitState: ReactorState = {
 };
 
 export interface ReactorInitializationProps extends ReactorOptions {
-  jwtToken?: string;
+  /**
+   * Token source for the underlying {@link Reactor}. See
+   * {@link ReactorState.jwtToken}: prefer the resolver form when
+   * the token is short-lived (REA-2512).
+   */
+  jwtToken?: JwtSource;
 }
 
 export const initReactorStore = (
@@ -170,7 +184,7 @@ export const createReactorStore = (
           throw error;
         }
       },
-      connect: async (jwtToken?: string, options?: ConnectOptions) => {
+      connect: async (jwtToken?: JwtSource, options?: ConnectOptions) => {
         if (jwtToken === undefined) {
           // If no JWT Token, it might have been passed in the constructor props. So read from it.
           jwtToken = get().jwtToken;

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -25,14 +25,7 @@ export interface ReactorState {
   lastError?: ReactorError;
   sessionId?: string;
   sessionExpiration?: number;
-  /**
-   * Token source for Coordinator HTTP calls. Stored as the union so
-   * callers that pass a resolver via `<ReactorProvider getJwt={…} />`
-   * (the recommended path for short-lived tokens — REA-2512) and
-   * legacy callers that pass a static string both flow through the
-   * same field. Selecting `s.jwtToken` will return whichever shape
-   * the consumer originally supplied.
-   */
+  /** Token source for Coordinator HTTP calls — see {@link JwtSource}. */
   jwtToken?: JwtSource;
 }
 
@@ -76,11 +69,7 @@ export const defaultInitState: ReactorState = {
 };
 
 export interface ReactorInitializationProps extends ReactorOptions {
-  /**
-   * Token source for the underlying {@link Reactor}. See
-   * {@link ReactorState.jwtToken}: prefer the resolver form when
-   * the token is short-lived (REA-2512).
-   */
+  /** Token source for the underlying {@link Reactor} — see {@link JwtSource}. */
   jwtToken?: JwtSource;
 }
 

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -36,8 +36,5 @@ export {
 } from "./core/RecordingClient";
 export type { RecordingClientHost } from "./core/RecordingClient";
 export type { ReactorStore } from "./core/store";
-// JWT resolver types — pass a resolver to ReactorProvider / Reactor.connect()
-// when the token is short-lived (e.g. Clerk session JWTs) so each Coordinator
-// HTTP call picks up a fresh token. See REA-2512.
 export type { JwtResolver, JwtSource } from "./core/auth";
 export { normalizeJwtSource } from "./core/auth";

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -36,3 +36,8 @@ export {
 } from "./core/RecordingClient";
 export type { RecordingClientHost } from "./core/RecordingClient";
 export type { ReactorStore } from "./core/store";
+// JWT resolver types — pass a resolver to ReactorProvider / Reactor.connect()
+// when the token is short-lived (e.g. Clerk session JWTs) so each Coordinator
+// HTTP call picks up a fresh token. See REA-2512.
+export type { JwtResolver, JwtSource } from "./core/auth";
+export { normalizeJwtSource } from "./core/auth";

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -18,14 +18,7 @@ import { useClipDownload, type ClipDownloadState } from "./useClipDownload";
  * render-prop.  No CSS file is shipped — every default style is
  * inline so it loses to anything the consumer provides.
  *
- * @example Inside a `ReactorProvider` (JWT inherited from provider):
- * ```tsx
- * <ReactorProvider getJwt={() => clerk.getToken({ template: "reactor" })}>
- *   <ClipDownloadButton clip={clip} />
- * </ReactorProvider>
- * ```
- *
- * @example Default label, state-aware (explicit getJwt):
+ * @example Default label, state-aware:
  * ```tsx
  * <ClipDownloadButton clip={clip} getJwt={() => jwt} />
  * ```
@@ -46,11 +39,9 @@ export interface ClipDownloadButtonProps {
   /** The clip to download. */
   clip: Clip;
   /**
-   * Lazy JWT resolver. Optional when rendered inside a
-   * ``<ReactorProvider>`` — the button falls back to the
-   * provider's resolver via {@link useClipDownload}'s context
-   * fallback. See {@link ClipPlayerProps.getJwt} for the
-   * production / local-dev distinction. Omit in local-dev mode.
+   * Lazy JWT resolver. Optional inside a ``<ReactorProvider>``
+   * (inherits the provider's resolver) and in local-dev mode. See
+   * {@link ClipPlayerProps.getJwt}.
    */
   getJwt?: () => string | Promise<string>;
   /** Filename for the saved MP4.  Default ``"reactor-clip.mp4"``. */

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -18,7 +18,14 @@ import { useClipDownload, type ClipDownloadState } from "./useClipDownload";
  * render-prop.  No CSS file is shipped — every default style is
  * inline so it loses to anything the consumer provides.
  *
- * @example Default label, state-aware:
+ * @example Inside a `ReactorProvider` (JWT inherited from provider):
+ * ```tsx
+ * <ReactorProvider getJwt={() => clerk.getToken({ template: "reactor" })}>
+ *   <ClipDownloadButton clip={clip} />
+ * </ReactorProvider>
+ * ```
+ *
+ * @example Default label, state-aware (explicit getJwt):
  * ```tsx
  * <ClipDownloadButton clip={clip} getJwt={() => jwt} />
  * ```
@@ -39,8 +46,11 @@ export interface ClipDownloadButtonProps {
   /** The clip to download. */
   clip: Clip;
   /**
-   * Lazy JWT resolver.  See {@link ClipPlayerProps.getJwt} for the
-   * production / local-dev distinction.  Omit in local-dev mode.
+   * Lazy JWT resolver. Optional when rendered inside a
+   * ``<ReactorProvider>`` — the button falls back to the
+   * provider's resolver via {@link useClipDownload}'s context
+   * fallback. See {@link ClipPlayerProps.getJwt} for the
+   * production / local-dev distinction. Omit in local-dev mode.
    */
   getJwt?: () => string | Promise<string>;
   /** Filename for the saved MP4.  Default ``"reactor-clip.mp4"``. */

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -34,18 +34,8 @@ import {
  * operates on the ``Clip`` value alone, so it stays usable after
  * ``reactor.disconnect()`` and works with clips loaded from
  * fixtures, server logs, or any other source. When a
- * ``ReactorProvider`` *is* mounted above, however, an omitted
- * ``getJwt`` falls back to whatever resolver the provider was
- * configured with — saving you from re-threading the token through
- * every clip surface (REA-2512).
- *
- * @example Compose with the download button (provider supplies JWT):
- * ```tsx
- * <ReactorProvider getJwt={() => clerk.getToken({ template: "reactor" })}>
- *   <ClipPlayer clip={clip} />
- *   <ClipDownloadButton clip={clip} />
- * </ReactorProvider>
- * ```
+ * ``ReactorProvider`` is mounted above, an omitted ``getJwt``
+ * inherits the provider's resolver.
  *
  * @example Compose with the download button (explicit `getJwt`):
  * ```tsx
@@ -68,22 +58,16 @@ export interface ClipPlayerProps {
   clip: Clip;
   /**
    * Lazy resolver for the Coordinator JWT used on the ``/clips``
-   * manifest GET.
+   * manifest GET. Called at request time so token refreshes are
+   * picked up automatically.
    *
-   * - **Production / Coordinator:** optional if rendered inside a
-   *   ``<ReactorProvider>`` — the player falls back to whatever
-   *   resolver the provider was configured with via its own
-   *   ``getJwt`` / ``jwtToken`` prop. Pass an explicit `getJwt`
-   *   here to override (e.g. previewing a clip against a different
-   *   tenant). Required when used outside a provider in production.
-   *   Called at request time (not at render time) so token
-   *   refreshes are picked up automatically.
-   * - **Local-dev / HttpRuntime:** omit — the local ``/clips``
-   *   endpoint serves manifests without auth.
+   * - **Production:** required outside a ``<ReactorProvider>``;
+   *   optional inside one (inherits the provider's resolver).
+   * - **Local-dev (HttpRuntime):** omit — ``/clips`` is auth-free.
    *
-   * The chunks referenced *inside* the manifest are S3 presigned
-   * GETs (prod) or unauthenticated runtime URLs (local), and are
-   * fetched without an ``Authorization`` header in either case.
+   * Chunk URLs inside the manifest are presigned (prod) or
+   * unauthenticated (local) and are fetched without
+   * ``Authorization`` in either case.
    */
   getJwt?: () => string | Promise<string>;
   /**
@@ -129,11 +113,8 @@ export function ClipPlayer({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
 
-  // Subscribe to the surrounding `<ReactorProvider>` (if any) so an
-  // omitted `getJwt` prop transparently falls back to the resolver
-  // the provider was configured with. `undefined` outside a
-  // provider, in which case behaviour matches the pre-fallback SDK
-  // (caller must supply `getJwt` for authenticated /clips).
+  // `undefined` outside a `<ReactorProvider>`; used to inherit the
+  // provider's JWT resolver when `getJwt` is omitted.
   const store = useContext(ReactorContext);
 
   // The playback effect intentionally depends only on `clip`.  Callers
@@ -147,12 +128,9 @@ export function ClipPlayer({
   const getJwtRef = useRef(getJwt);
   const autoPlayRef = useRef(autoPlay);
   const slackMsRef = useRef(slackMs);
-  // Captured into a ref for the same reason as `getJwtRef`: the
-  // store identity is stable per-provider but we don't want the
-  // setup effect to re-run on store change either (the resolver
-  // lookup happens at request time, inside `setup`, so a swap on
-  // the provider is picked up on the next attach without needing
-  // to tear down the player).
+  // Same ref pattern: the resolver is looked up inside `setup` at
+  // request time, so a provider swap is picked up on next attach
+  // without tearing the player down.
   const storeRef = useRef(store);
   useEffect(() => {
     getJwtRef.current = getJwt;
@@ -244,11 +222,7 @@ export function ClipPlayer({
     const setup = async () => {
       try {
         setPhase({ kind: "waiting" });
-        // Resolver precedence: explicit `getJwt` prop wins; otherwise
-        // we ask the surrounding `<ReactorProvider>` (if any) for its
-        // resolver. Matches `useClipDownload`'s fallback chain so
-        // composing the two against a single provider gives the same
-        // token without re-threading (REA-2512).
+        // Explicit `getJwt` wins; fall back to the provider's resolver.
         const explicit = getJwtRef.current;
         const fallback = storeRef.current
           ?.getState()

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import React from "react";
+import { ReactorContext } from "../core/store";
 import {
   RecordingError,
   createPlayableManifestUrl,
@@ -32,9 +33,21 @@ import {
  * **does not require a ``ReactorProvider``** in the tree.  It
  * operates on the ``Clip`` value alone, so it stays usable after
  * ``reactor.disconnect()`` and works with clips loaded from
- * fixtures, server logs, or any other source.
+ * fixtures, server logs, or any other source. When a
+ * ``ReactorProvider`` *is* mounted above, however, an omitted
+ * ``getJwt`` falls back to whatever resolver the provider was
+ * configured with — saving you from re-threading the token through
+ * every clip surface (REA-2512).
  *
- * @example Compose with the download button:
+ * @example Compose with the download button (provider supplies JWT):
+ * ```tsx
+ * <ReactorProvider getJwt={() => clerk.getToken({ template: "reactor" })}>
+ *   <ClipPlayer clip={clip} />
+ *   <ClipDownloadButton clip={clip} />
+ * </ReactorProvider>
+ * ```
+ *
+ * @example Compose with the download button (explicit `getJwt`):
  * ```tsx
  * <div>
  *   <ClipPlayer clip={clip} getJwt={() => jwt} />
@@ -57,10 +70,14 @@ export interface ClipPlayerProps {
    * Lazy resolver for the Coordinator JWT used on the ``/clips``
    * manifest GET.
    *
-   * - **Production / Coordinator:** required.  Should return the
-   *   same JWT your app already passes to ``ReactorProvider`` /
-   *   ``reactor.connect()``.  Called at request time (not at render
-   *   time) so token refreshes are picked up automatically.
+   * - **Production / Coordinator:** optional if rendered inside a
+   *   ``<ReactorProvider>`` — the player falls back to whatever
+   *   resolver the provider was configured with via its own
+   *   ``getJwt`` / ``jwtToken`` prop. Pass an explicit `getJwt`
+   *   here to override (e.g. previewing a clip against a different
+   *   tenant). Required when used outside a provider in production.
+   *   Called at request time (not at render time) so token
+   *   refreshes are picked up automatically.
    * - **Local-dev / HttpRuntime:** omit — the local ``/clips``
    *   endpoint serves manifests without auth.
    *
@@ -112,6 +129,13 @@ export function ClipPlayer({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
 
+  // Subscribe to the surrounding `<ReactorProvider>` (if any) so an
+  // omitted `getJwt` prop transparently falls back to the resolver
+  // the provider was configured with. `undefined` outside a
+  // provider, in which case behaviour matches the pre-fallback SDK
+  // (caller must supply `getJwt` for authenticated /clips).
+  const store = useContext(ReactorContext);
+
   // The playback effect intentionally depends only on `clip`.  Callers
   // typically pass an inline `getJwt={() => token}` that changes
   // identity on every render — using it directly in the effect deps
@@ -123,10 +147,18 @@ export function ClipPlayer({
   const getJwtRef = useRef(getJwt);
   const autoPlayRef = useRef(autoPlay);
   const slackMsRef = useRef(slackMs);
+  // Captured into a ref for the same reason as `getJwtRef`: the
+  // store identity is stable per-provider but we don't want the
+  // setup effect to re-run on store change either (the resolver
+  // lookup happens at request time, inside `setup`, so a swap on
+  // the provider is picked up on the next attach without needing
+  // to tear down the player).
+  const storeRef = useRef(store);
   useEffect(() => {
     getJwtRef.current = getJwt;
     autoPlayRef.current = autoPlay;
     slackMsRef.current = slackMs;
+    storeRef.current = store;
   });
 
   // Playback pipeline: fetch manifest (with optional JWT) → wrap in
@@ -212,7 +244,17 @@ export function ClipPlayer({
     const setup = async () => {
       try {
         setPhase({ kind: "waiting" });
-        const jwt = getJwtRef.current ? await getJwtRef.current() : undefined;
+        // Resolver precedence: explicit `getJwt` prop wins; otherwise
+        // we ask the surrounding `<ReactorProvider>` (if any) for its
+        // resolver. Matches `useClipDownload`'s fallback chain so
+        // composing the two against a single provider gives the same
+        // token without re-threading (REA-2512).
+        const explicit = getJwtRef.current;
+        const fallback = storeRef.current
+          ?.getState()
+          .internal.reactor.getJwtResolver();
+        const resolver = explicit ?? fallback;
+        const jwt = resolver ? await resolver() : undefined;
         if (cancelled) return;
         const body = await fetchPlaylist(clip.playlistUrl, {
           predictedReadyAtMs: clip.predictedReadyAtMs,

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -41,20 +41,14 @@ interface ReactorProviderProps extends Omit<
 > {
   connectOptions?: ReactorConnectOptions;
   /**
-   * Static JWT token. Use this when you already hold a long-lived
-   * SDK JWT (e.g. minted via `/tokens`) and don't need refresh.
-   *
-   * For short-lived tokens (Clerk session JWTs default to ~60s,
-   * custom backends with sub-minute TTLs, etc.) use {@link getJwt}
-   * instead — passing a stale string here will make every
-   * Coordinator HTTP hop 401 once the token expires. See REA-2512.
+   * Static JWT token. Use when you hold a long-lived SDK JWT (e.g.
+   * minted via `/tokens`). For short-lived tokens use {@link getJwt}.
    */
   jwtToken?: string;
   /**
-   * Lazy JWT resolver. The SDK calls this immediately before each
-   * Coordinator HTTP request so a fresh token is always on the
-   * wire. Preferred over {@link jwtToken} for short-lived auth
-   * flows. If both are provided, `getJwt` wins.
+   * Lazy JWT resolver invoked immediately before each Coordinator
+   * HTTP request. Preferred for short-lived tokens. Wins over
+   * {@link jwtToken} when both are provided.
    */
   getJwt?: JwtResolver;
   children?: ReactNode;
@@ -68,9 +62,6 @@ export function ReactorProvider({
   getJwt,
   ...props
 }: ReactorProviderProps) {
-  // Reconcile the two token-shape props down to a single
-  // JwtSource for the store. `getJwt` wins when both are supplied
-  // — the resolver subsumes the static form.
   const jwtSource: JwtSource | undefined = getJwt ?? jwtToken;
 
   // Stable Reactor instance
@@ -216,9 +207,6 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-    // The effect intentionally keys on the unified `jwtSource`
-    // identity so a getJwt resolver swap re-runs the provider tear
-    // down/setup path the same way a string change would have.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]);
 

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from "../core/store";
 import { useStore } from "zustand";
 import type { ConnectOptions } from "../types";
+import type { JwtResolver, JwtSource } from "../core/auth";
 
 /**
  * Options for the React provider's connect behavior.
@@ -34,9 +35,28 @@ export interface ReactorConnectOptions extends ConnectOptions {
 // children positionally without falling back to an
 // `eslint-disable-next-line react/no-children-prop` workaround in
 // downstream consumer projects.
-interface ReactorProviderProps extends ReactorInitializationProps {
+interface ReactorProviderProps extends Omit<
+  ReactorInitializationProps,
+  "jwtToken"
+> {
   connectOptions?: ReactorConnectOptions;
+  /**
+   * Static JWT token. Use this when you already hold a long-lived
+   * SDK JWT (e.g. minted via `/tokens`) and don't need refresh.
+   *
+   * For short-lived tokens (Clerk session JWTs default to ~60s,
+   * custom backends with sub-minute TTLs, etc.) use {@link getJwt}
+   * instead — passing a stale string here will make every
+   * Coordinator HTTP hop 401 once the token expires. See REA-2512.
+   */
   jwtToken?: string;
+  /**
+   * Lazy JWT resolver. The SDK calls this immediately before each
+   * Coordinator HTTP request so a fresh token is always on the
+   * wire. Preferred over {@link jwtToken} for short-lived auth
+   * flows. If both are provided, `getJwt` wins.
+   */
+  getJwt?: JwtResolver;
   children?: ReactNode;
 }
 
@@ -45,8 +65,14 @@ export function ReactorProvider({
   children,
   connectOptions,
   jwtToken,
+  getJwt,
   ...props
 }: ReactorProviderProps) {
+  // Reconcile the two token-shape props down to a single
+  // JwtSource for the store. `getJwt` wins when both are supplied
+  // — the resolver subsumes the static form.
+  const jwtSource: JwtSource | undefined = getJwt ?? jwtToken;
+
   // Stable Reactor instance
   const storeRef = useRef<ReactorStoreApi | undefined>(undefined);
   const firstRender = useRef(true);
@@ -60,7 +86,7 @@ export function ReactorProvider({
     storeRef.current = createReactorStore(
       initReactorStore({
         ...props,
-        jwtToken,
+        jwtToken: jwtSource,
       })
     );
     console.debug("[ReactorProvider] Reactor store created successfully");
@@ -99,14 +125,14 @@ export function ReactorProvider({
       if (
         autoConnect &&
         current.getState().status === "disconnected" &&
-        jwtToken
+        jwtSource
       ) {
         console.debug(
           "[ReactorProvider] Starting autoconnect in first render..."
         );
         current
           .getState()
-          .connect(jwtToken, pollingOptions)
+          .connect(jwtSource, pollingOptions)
           .then(() => {
             console.debug(
               "[ReactorProvider] Autoconnect successful in first render"
@@ -146,7 +172,7 @@ export function ReactorProvider({
         apiUrl,
         modelName,
         local,
-        jwtToken,
+        jwtToken: jwtSource,
       } satisfies ReactorInitializationProps)
     );
 
@@ -162,12 +188,12 @@ export function ReactorProvider({
     if (
       autoConnect &&
       current.getState().status === "disconnected" &&
-      jwtToken
+      jwtSource
     ) {
       console.debug("[ReactorProvider] Starting autoconnect...");
       current
         .getState()
-        .connect(jwtToken, pollingOptions)
+        .connect(jwtSource, pollingOptions)
         .then(() => {
           console.debug("[ReactorProvider] Autoconnect successful");
         })
@@ -190,7 +216,11 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-  }, [apiUrl, modelName, autoConnect, local, jwtToken, maxAttempts]);
+    // The effect intentionally keys on the unified `jwtSource`
+    // identity so a getJwt resolver swap re-runs the provider tear
+    // down/setup path the same way a string change would have.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ReactNode, useContext, useEffect, useRef, useState } from "react";
+import {
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   createReactorStore,
   initReactorStore,
@@ -62,7 +69,39 @@ export function ReactorProvider({
   getJwt,
   ...props
 }: ReactorProviderProps) {
-  const jwtSource: JwtSource | undefined = getJwt ?? jwtToken;
+  // Auto-stabilize the `getJwt` resolver via ref. Without this, an
+  // inline `getJwt={async () => …}` on every parent render gives the
+  // provider a new function identity, the effect below treats it
+  // as "auth source changed", tears the store down, and disconnects
+  // the live session — a footgun we'd otherwise be asking every
+  // consumer to defuse with `useCallback`. Same idiom React's
+  // `useEffectEvent` codifies, and what we already use internally
+  // in `useClipDownload` / `ClipPlayer` to absorb resolver identity
+  // churn there. The ref is read at request time so the latest
+  // resolver — and any state it closes over (Clerk session, account
+  // ID, etc.) — is on the wire for every Coordinator HTTP hop.
+  const getJwtRef = useRef<JwtResolver | undefined>(getJwt);
+  useEffect(() => {
+    getJwtRef.current = getJwt;
+  });
+  // Only re-memoize when the resolver transitions between defined
+  // and undefined (sign-in / sign-out). Pure identity changes are
+  // absorbed by `getJwtRef`.
+  const hasGetJwt = getJwt !== undefined;
+  const stableGetJwt = useMemo<JwtResolver | undefined>(() => {
+    if (!hasGetJwt) return undefined;
+    return async () => {
+      const r = getJwtRef.current;
+      return r ? await r() : "";
+    };
+  }, [hasGetJwt]);
+
+  // Static-string `jwtToken` keeps its legacy semantics: changing
+  // the string identity means "different auth source" (e.g. tenant
+  // switch) and intentionally tears the session down. Consumers who
+  // need to rotate a short-lived token should use `getJwt` — which
+  // is now both the recommended path and the foolproof one.
+  const jwtSource: JwtSource | undefined = stableGetJwt ?? jwtToken;
 
   // Stable Reactor instance
   const storeRef = useRef<ReactorStoreApi | undefined>(undefined);

--- a/packages/js-sdk/src/react/useClipDownload.ts
+++ b/packages/js-sdk/src/react/useClipDownload.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { ReactorContext } from "../core/store";
 import {
   RecordingError,
   downloadClipAsFile,
@@ -36,9 +37,17 @@ export interface UseClipDownloadOptions {
   /**
    * Lazy resolver for the Coordinator JWT used on the ``/clips``
    * manifest GET.  Called on every {@link download} invocation, so
-   * token refreshes are picked up automatically.  Omit in local-dev
-   * mode (HttpRuntime has no auth on ``/clips``).  See
-   * {@link ClipPlayerProps.getJwt} for the production / local
+   * token refreshes are picked up automatically.
+   *
+   * **Optional when rendered under a `<ReactorProvider>`** — the
+   * hook falls back to the resolver supplied to
+   * `<ReactorProvider getJwt={…} />` / `Reactor.connect()` when this
+   * prop is omitted. Pass an explicit `getJwt` to override (e.g.
+   * downloading a clip against a different account, or unit-testing
+   * with a fixed token).
+   *
+   * Omit in local-dev mode (HttpRuntime has no auth on ``/clips``).
+   * See {@link ClipPlayerProps.getJwt} for the production / local
    * distinction.
    */
   getJwt?: () => string | Promise<string>;
@@ -103,6 +112,12 @@ export function useClipDownload(
 ): UseClipDownloadResult {
   const [state, setState] = useState<ClipDownloadState>({ kind: "idle" });
 
+  // Subscribe to whatever `<ReactorProvider>` (if any) is mounted
+  // above us. Returns `undefined` outside a provider — in that case
+  // the only token source is whatever the caller passes via
+  // `options.getJwt`, matching the pre-fallback behaviour.
+  const store = useContext(ReactorContext);
+
   // Latest-value refs so `download` can be a stable callback (empty
   // deps) without forcing the caller to memoize `clip` / `options`.
   // This is the same pattern the SDK uses elsewhere (see
@@ -129,7 +144,16 @@ export function useClipDownload(
     inFlightRef.current = true;
     setState({ kind: "downloading", fetched: 0, total: 0 });
     try {
-      const jwt = getJwtRef.current ? await getJwtRef.current() : undefined;
+      // Resolver precedence: explicit `options.getJwt` wins, then we
+      // fall back to whatever resolver the surrounding
+      // `<ReactorProvider>` configured via its own `getJwt` prop
+      // (REA-2512). Reading the resolver from the store at click
+      // time (not at render time) means a token-source swap on the
+      // provider is picked up immediately by the next download.
+      const explicit = getJwtRef.current;
+      const fallback = store?.getState().internal.reactor.getJwtResolver();
+      const resolver = explicit ?? fallback;
+      const jwt = resolver ? await resolver() : undefined;
       const blob = await downloadClipAsFile(
         clipRef.current,
         filenameRef.current,
@@ -153,7 +177,10 @@ export function useClipDownload(
     } finally {
       inFlightRef.current = false;
     }
-  }, []);
+    // `store` is stable for the lifetime of its `<ReactorProvider>` —
+    // including it in deps keeps the closure correct without
+    // forcing the caller to re-memoize their click handler.
+  }, [store]);
 
   const reset = useCallback(() => setState({ kind: "idle" }), []);
 

--- a/packages/js-sdk/src/react/useClipDownload.ts
+++ b/packages/js-sdk/src/react/useClipDownload.ts
@@ -39,16 +39,9 @@ export interface UseClipDownloadOptions {
    * manifest GET.  Called on every {@link download} invocation, so
    * token refreshes are picked up automatically.
    *
-   * **Optional when rendered under a `<ReactorProvider>`** — the
-   * hook falls back to the resolver supplied to
-   * `<ReactorProvider getJwt={…} />` / `Reactor.connect()` when this
-   * prop is omitted. Pass an explicit `getJwt` to override (e.g.
-   * downloading a clip against a different account, or unit-testing
-   * with a fixed token).
-   *
-   * Omit in local-dev mode (HttpRuntime has no auth on ``/clips``).
-   * See {@link ClipPlayerProps.getJwt} for the production / local
-   * distinction.
+   * Optional inside a ``<ReactorProvider>`` (inherits the provider's
+   * resolver) and in local-dev mode. See
+   * {@link ClipPlayerProps.getJwt}.
    */
   getJwt?: () => string | Promise<string>;
 }
@@ -112,10 +105,8 @@ export function useClipDownload(
 ): UseClipDownloadResult {
   const [state, setState] = useState<ClipDownloadState>({ kind: "idle" });
 
-  // Subscribe to whatever `<ReactorProvider>` (if any) is mounted
-  // above us. Returns `undefined` outside a provider — in that case
-  // the only token source is whatever the caller passes via
-  // `options.getJwt`, matching the pre-fallback behaviour.
+  // `undefined` outside a `<ReactorProvider>`; used to inherit the
+  // provider's JWT resolver when `options.getJwt` is omitted.
   const store = useContext(ReactorContext);
 
   // Latest-value refs so `download` can be a stable callback (empty
@@ -144,12 +135,9 @@ export function useClipDownload(
     inFlightRef.current = true;
     setState({ kind: "downloading", fetched: 0, total: 0 });
     try {
-      // Resolver precedence: explicit `options.getJwt` wins, then we
-      // fall back to whatever resolver the surrounding
-      // `<ReactorProvider>` configured via its own `getJwt` prop
-      // (REA-2512). Reading the resolver from the store at click
-      // time (not at render time) means a token-source swap on the
-      // provider is picked up immediately by the next download.
+      // Explicit `options.getJwt` wins; fall back to the provider's
+      // resolver. Reading at click time picks up provider swaps
+      // without re-running this callback.
       const explicit = getJwtRef.current;
       const fallback = store?.getState().internal.reactor.getJwtResolver();
       const resolver = explicit ?? fallback;
@@ -177,9 +165,6 @@ export function useClipDownload(
     } finally {
       inFlightRef.current = false;
     }
-    // `store` is stable for the lifetime of its `<ReactorProvider>` —
-    // including it in deps keeps the closure correct without
-    // forcing the caller to re-memoize their click handler.
   }, [store]);
 
   const reset = useCallback(() => setState({ kind: "idle" }), []);


### PR DESCRIPTION
> Closes [REA-2512](https://linear.app/reactor-team/issue/REA-2512/js-sdk-refresh-jwt-on-every-coordinator-http-call-short-lived-clerk)

## The symptom

In the production webapp playground, anything that round-trips through the Coordinator over HTTP starts 401-ing roughly 60 seconds into any session:

- `POST /sessions/:id/uploads` — reference-image upload, 401 `Invalid or expired token`
- `GET /clips` — clip download manifest, same 401
- `GET /sessions/:id`, `PUT /sessions/:id`, `DELETE /sessions/:id` — same
- `GET /sessions/:id/transport/webrtc/ice_servers`, `POST/PUT/GET .../sdp_params` — same when exercised (ICE refresh, SDP renegotiation)

The steady-state WebRTC media path stays alive (no auth on the data channel), so to the user it looks like _“everything works for the first minute, then uploads and clips break”_. Reconnecting fixes it for another minute. Repeat.

## What's actually happening

The SDK was built around the assumption that a JWT is a long-lived secret you mint once and keep. `CoordinatorClient` and `WebRTCTransportClient` each took a `jwtToken: string` at construction, stashed it in a private field, and pasted it into the `Authorization: Bearer …` header on every subsequent fetch — for the entire lifetime of the session.

That works fine for a long-lived SDK JWT minted via `/tokens`. It breaks for short-lived auth flows. The most common one in our stack today: the webapp feeding the SDK a Clerk session JWT obtained via `getToken({ template: "reactor" })`, which Clerk hands out with a **default 60-second TTL**. The cached string ages out 60s after `connect()`, and from then on every Coordinator HTTP call hits `UnifiedAuth → Clerk validator → expired` → 401.

Interesting wrinkle: we already solved this problem _once_ for the recording surface. `useClipDownload`, `ClipPlayer`, and `ClipDownloadButton` accept a `getJwt: () => string | Promise<string>` resolver and call it immediately before each fetch. That pattern just never made it into the session-lifecycle clients.

This PR extends the existing `getJwt` idiom to those clients, lets the clip surfaces inherit the same resolver from the surrounding `<ReactorProvider>`, and makes the provider's `getJwt` prop self-stabilizing so consumers can pass an inline arrow without footguns.

## The fix, in one diagram

**Before** — token captured once at construction, reused forever:

```
ReactorProvider(jwtToken="ey…")
  └─> store.connect(jwtToken)
        └─> new CoordinatorClient({ jwtToken: "ey…" })   ← cached as string
              └─> getHeaders() → Authorization: Bearer ey…   ← every request
```

**After** — token resolved per request, single source of truth, identity-stable in React:

```
ReactorProvider(getJwt=() => clerk.getToken(…))   ← inline arrow OK
  │   (auto-stabilized via ref+memo inside the provider)
  ├─> store.connect(jwtSource)
  │     └─> new CoordinatorClient({ jwtToken: jwtSource })   ← normalized to resolver
  │           └─> await getHeaders() → Authorization: Bearer <fresh>   ← per request
  │
  └─> Reactor.getJwtResolver()   ← cached resolver, also exposed for…
        ├─> useClipDownload()  ← falls back here when no `getJwt` prop
        ├─> <ClipPlayer />     ← falls back here when no `getJwt` prop
        └─> <ClipDownloadButton />   ← inherited via useClipDownload
```

Strings still work; they're wrapped into a constant resolver internally so the request path stays shape-agnostic.

## Commit-by-commit narrative

The PR is structured as four reviewable commits so you can read it as a story:

1. **`thread JWT resolver through Coordinator + WebRTC clients`** — the systemic plumbing. `CoordinatorClient`, `WebRTCTransportClient`, `Reactor.connect()`, and the store all accept a `JwtSource = string | (() => string | Promise<string>)`. `getHeaders()` becomes `async` and resolves the token per request.
2. **`clip surfaces auto-inherit JWT resolver from ReactorProvider`** — `useClipDownload`, `ClipPlayer`, `ClipDownloadButton` stop demanding their own `getJwt` prop when rendered under a `<ReactorProvider>`. Adds `Reactor.getJwtResolver()` so off-session surfaces (a clip-download toast that outlives the session, custom clip UIs) can grab the same token source.
3. **`trim narrative comments in JWT resolver wiring`** — pure prose tidy-up.
4. **`auto-stabilize ReactorProvider's getJwt prop`** — closes the last sharp edge. Captures the resolver in a ref + memo so an inline `getJwt={async () => …}` doesn't tear down the session on every parent re-render. Same idiom React's `useEffectEvent` codifies, and that `useClipDownload` / `ClipPlayer` already use internally for their own `getJwt` props.

## Public API changes

### New surface

```ts
import {
  type JwtResolver,
  type JwtSource,
  normalizeJwtSource,
} from "@reactor-team/js-sdk";

// Resolver invoked per Coordinator HTTP request.
type JwtResolver = () => string | Promise<string>;

// Accepted wherever a static `jwtToken: string` used to live.
type JwtSource = string | JwtResolver;
```

### React provider — new `getJwt` prop, identity-safe

```tsx
// Long-lived SDK JWT (unchanged, still supported):
<ReactorProvider jwtToken={sdkJwt}>…</ReactorProvider>

// Short-lived Clerk token. Inline arrow is fine — the provider auto-
// stabilizes the resolver internally, so identity churn on parent
// re-render does NOT tear down the session.
<ReactorProvider getJwt={async () => (await clerk.getToken({ template: "reactor" })) ?? ""}>
  …
</ReactorProvider>
```

If both `jwtToken` and `getJwt` are provided, `getJwt` wins.

The auto-stabilization only treats the **defined ↔ undefined** transition as a real auth boundary (sign-in / sign-out, which we want to honour with a session reset). Any identity change while the resolver stays defined is absorbed via a ref, and the latest resolver is invoked on the next Coordinator request.

### Clip surfaces — `getJwt` is now optional

Anything rendered under a `<ReactorProvider>` inherits the provider's resolver. No more triple-passing the same callback:

```tsx
// Before — same resolver threaded three times:
<ReactorProvider getJwt={getFreshToken}>
  <ClipPlayer clip={clip} getJwt={getFreshToken} />
  <ClipDownloadButton clip={clip} getJwt={getFreshToken} />
</ReactorProvider>

// After — clip surfaces auto-inherit:
<ReactorProvider getJwt={getFreshToken}>
  <ClipPlayer clip={clip} />
  <ClipDownloadButton clip={clip} />
</ReactorProvider>
```

Explicit `getJwt` props still take precedence — useful for previewing a clip against a different tenant, fixture playback, or unit-testing with a fixed token.

### Core `Reactor` — new accessor + widened `connect()`

```ts
// New
reactor.getJwtResolver(): JwtResolver | undefined

// Widened (was `jwtToken?: string`)
reactor.connect(jwtToken?: JwtSource, options?)
```

Same widening applies to `ReactorActions.connect` on the store. `getJwtResolver()` is what `useClipDownload` / `ClipPlayer` consult for their context fallback; consumers can read it directly when building their own clip-aware surfaces (post-session "download the clip you snapped earlier" toast, batch clip exporters, etc.).

## What I touched

| File | Change |
|---|---|
| `src/core/auth.ts` *(new)* | `JwtResolver` / `JwtSource` types + `normalizeJwtSource(source)` helper. |
| `src/core/CoordinatorClient.ts` | Accepts `JwtSource`. `getHeaders()` is now `async` and resolves the token per request; empty string drops the `Authorization` header. |
| `src/core/WebRTCTransportClient.ts` | Same widening + `async getHeaders()`. Awaits at all three signaling fetch sites (`ice_servers`, `POST/PUT sdp_params`, `GET sdp_params`). |
| `src/core/TransportClient.ts` | `TransportClientConfig.jwtToken` widened to `JwtSource`. |
| `src/core/LocalCoordinatorClient.ts` | Overrides `async getHeaders()` to match the new base-class signature (still auth-free). |
| `src/core/Reactor.ts` | `connect()` accepts `JwtSource`; caches the resolver and exposes it via `getJwtResolver()`. |
| `src/core/store.ts` | `ReactorState.jwtToken` + `ReactorActions.connect` widened. The union-typed field means `s.jwtToken` still returns whatever shape the consumer originally supplied. |
| `src/react/ReactorProvider.tsx` | New `getJwt?: JwtResolver` prop alongside `jwtToken?: string`; both feed into the same internal `JwtSource`. Resolver auto-stabilized via `useRef` + `useMemo` so inline-arrow `getJwt` doesn't tear down the session on every parent re-render. |
| `src/react/useClipDownload.ts` | `getJwt` option now optional under a `<ReactorProvider>`; falls back to `Reactor.getJwtResolver()` via `useContext(ReactorContext)`. |
| `src/react/ClipPlayer.tsx` | Same fallback as `useClipDownload`. |
| `src/react/ClipDownloadButton.tsx` | Inherits the fallback for free (just JSDoc changes). |
| `src/index.ts` | Re-exports `JwtResolver`, `JwtSource`, `normalizeJwtSource`. |
| `__tests__/unit/jwt-resolver.test.ts` *(new)* | 15 cases — see below. |

## Backward compatibility

Strict. Nothing was removed, nothing was renamed, and everything that used to accept a `string` still does:

- `<ReactorProvider jwtToken="ey…">` — same as before; wrapped into a constant resolver internally. String-identity changes still tear the session down (a genuine "different tenant" signal we don't want to silently leak across).
- `reactor.connect("ey…")` — same.
- `store.connect("ey…")` — same.
- `<ClipPlayer clip={c} getJwt={() => jwt} />` — explicit prop still wins over the provider fallback.
- `s.jwtToken` selectors — return whatever the caller originally passed (string or resolver).
- The on-the-wire `Authorization: Bearer ey…` header is byte-identical for string inputs.

The one user-visible behaviour change: clip surfaces rendered under a `<ReactorProvider>` *without* an explicit `getJwt` used to silently send no `Authorization` header (and 401 in prod). They now correctly inherit the provider's resolver. If you were relying on that prior unauthenticated path, pass `getJwt={() => ""}` explicitly to suppress.

Runtime cost vs. the previous implementation: one extra function call and one microtask hop per Coordinator HTTP request. Nothing that hits a hot path — the data channel is unaffected.

External `TransportClient` implementers (none in-tree besides `WebRTCTransportClient`) would need to widen their config type, but no third party should be implementing this interface today.

## Tests

`__tests__/unit/jwt-resolver.test.ts` (15 new cases) covers:

**`normalizeJwtSource`**
- wraps a string into a constant resolver
- returns a function resolver as-is (no double-wrap, so stateful resolvers stay stateful)
- supports `Promise<string>`-returning resolvers

**`CoordinatorClient` with a resolver**
- calls the resolver before every request (no token caching across calls)
- awaits `Promise<string>` resolvers before issuing the fetch
- string input is wire-identical to the pre-resolver SDK
- empty-string resolver output drops the `Authorization` header entirely
- a rejecting resolver throws cleanly and **does not fire fetch** (no half-built request leaks out)

**`WebRTCTransportClient` with a resolver**
- re-resolves on each signaling fetch (modelled via ICE-server refresh)
- string parity
- empty-string suppression
- `Reactor-WebRTC-Version` header preserved across all paths

**`Reactor.getJwtResolver()`**
- returns `undefined` before `connect()`
- wraps a string JWT into a resolver, observable immediately after `connect()` returns the promise
- preserves function resolvers by reference (no double-wrap) — call counter advances per invocation
- stays `undefined` in local mode (LocalCoordinatorClient strips auth anyway)

The provider's auto-stabilization isn't covered by unit tests in this PR — there's no `@testing-library/react` setup today and installing JSDOM + RTL for two `useRef`/`useMemo` lines isn't worth the install weight. The behaviour is verifiable end-to-end against the locally-linked webapp (manual confirmation: inline-arrow `getJwt` no longer disconnects mid-session), and the underlying `Reactor.getJwtResolver()` it rides on _is_ covered.

The existing **346-case** suite passes unchanged — no behavioural regressions in the string path. **Total: 361 tests passing**.

Local CI parity:

- `pnpm --filter @reactor-team/js-sdk test:unit` — green
- `pnpm --filter @reactor-team/js-sdk build` — green (CJS + ESM + DTS)
- `pnpm run format:check` — green
- `pnpm run lint:license` — green
- `pnpm run lint:secrets` — green
- DCO trailer present on every commit

## Follow-up (separate PR, in `reactor-webapp`)

With auto-stabilization landed, the webapp diff is minimal:

- `PlaygroundWithProvider.tsx` — `jwtToken=` → `getJwt={async () => (await getFreshToken()) ?? ""}` (inline arrow, no `useCallback` required).
- `PlaygroundContent`/`PlaygroundLingbotBody` — `connect(token)` → `connect()` (the provider's resolver flows through automatically).
- `PlaygroundClipSnap` — **drop** the `getJwt` prop threading entirely. The toast inherits from the provider.

Verified locally against this branch via a `pnpm.overrides` link to `../js-sdk/packages/js-sdk` — uploads, clip snap, and clip download all work past the 60-second cliff, and the session no longer disconnects on parent re-renders.

## How to review

1. **`src/core/auth.ts`** — small, frames the whole change.
2. **`CoordinatorClient.ts`** — confirm `getHeaders` is the only behavioural change and every `getHeaders()` call site got an `await`.
3. **`WebRTCTransportClient.ts`** — same drill (three fetch sites: `ice_servers`, `sdp_params` POST/PUT, `sdp_params` GET).
4. **`Reactor.ts`** — new resolver cache + `getJwtResolver()` accessor. Note the resolver survives `disconnect()` on purpose so off-session toasts still work.
5. **`ReactorProvider.tsx`** — `jwtToken`/`getJwt` reconciliation (getJwt wins), and the auto-stabilization (ref + memo gated on defined↔undefined). The legacy `jwtToken: string` path still re-creates on identity change, by design.
6. **`useClipDownload.ts`** + **`ClipPlayer.tsx`** — `useContext(ReactorContext)` fallback. Both follow the same explicit-wins-then-provider-fallback chain.
7. **`__tests__/unit/jwt-resolver.test.ts`** — the contract spelled out.

Reading commit-by-commit (1 → 4 in chronological order) gives the cleanest narrative; the diff stat is small per commit and each builds on the last.