### PR TITLE
[REA-2558] Remux clip downloads to flat MP4 via optional mp4box peer dep

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -200,6 +200,18 @@ const clip = await reactor.requestClip(10); // last 10 s
 pnpm add hls.js
 ```
 
+### Social-media-ready downloads (optional)
+
+A Reactor clip is internally a fragmented MP4 (`init.mp4 + chunk_00.m4s + …`). The default behaviour of `downloadClipAsFile` concatenates those bytes and hands you a perfectly playable `.mp4` — but mid-session clips inherit the session timeline in their decode timestamps, which means QuickLook, Twitter / X, Instagram, and TikTok either show several seconds of black at the head or reject the upload outright.
+
+Installing the optional `mp4box` peer dependency switches the download path to a `-c copy`-style remux: the H.264 / AAC bitstream passes through unchanged, but the container is rewritten to a flat MP4 with `start_time=0`, faststart layout, and `major_brand=isom`. Pure JavaScript, no WASM, ~60 KB gzipped, no extra COOP/COEP headers required:
+
+```bash
+pnpm add mp4box
+```
+
+That's it — `downloadClipAsFile`, `<ClipDownloadButton>`, and `useClipDownload` pick it up automatically. To opt out, pass `remux: "off"`.
+
 Full walkthrough, error codes, and the headless `useClipDownload` hook: [Recordings](https://docs.reactor.inc/concepts/recordings).
 
 ---

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -200,17 +200,7 @@ const clip = await reactor.requestClip(10); // last 10 s
 pnpm add hls.js
 ```
 
-### Social-media-ready downloads (optional)
-
-A Reactor clip is internally a fragmented MP4 (`init.mp4 + chunk_00.m4s + …`). The default behaviour of `downloadClipAsFile` concatenates those bytes and hands you a perfectly playable `.mp4` — but mid-session clips inherit the session timeline in their decode timestamps, which means QuickLook, Twitter / X, Instagram, and TikTok either show several seconds of black at the head or reject the upload outright.
-
-Installing the optional `mp4box` peer dependency switches the download path to a `-c copy`-style remux: the H.264 / AAC bitstream passes through unchanged, but the container is rewritten to a flat MP4 with `start_time=0`, faststart layout, and `major_brand=isom`. Pure JavaScript, no WASM, ~60 KB gzipped, no extra COOP/COEP headers required:
-
-```bash
-pnpm add mp4box
-```
-
-That's it — `downloadClipAsFile`, `<ClipDownloadButton>`, and `useClipDownload` pick it up automatically. To opt out, pass `remux: "off"`.
+Downloads are remuxed into a flat MP4 (`start_time=0`, faststart, `major_brand=isom`) under the hood so the resulting file uploads cleanly to Twitter, Instagram, TikTok, and YouTube without any extra setup on your side — the H.264 / AAC bitstream itself is passed through untouched. Pass `remux: "off"` if you specifically want the raw fragmented MP4 for a custom pipeline.
 
 Full walkthrough, error codes, and the headless `useClipDownload` hook: [Recordings](https://docs.reactor.inc/concepts/recordings).
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -200,7 +200,7 @@ const clip = await reactor.requestClip(10); // last 10 s
 pnpm add hls.js
 ```
 
-Downloads are remuxed into a flat MP4 (`start_time=0`, faststart, `major_brand=isom`) under the hood so the resulting file uploads cleanly to Twitter, Instagram, TikTok, and YouTube without any extra setup on your side — the H.264 / AAC bitstream itself is passed through untouched. Pass `remux: "off"` if you specifically want the raw fragmented MP4 for a custom pipeline.
+Downloads are remuxed into a flat MP4 (`start_time=0`, faststart, `major_brand=isom`) under the hood so the resulting file uploads cleanly to Twitter, Instagram, TikTok, and YouTube without any extra setup on your side — the H.264 / AAC bitstream itself is passed through untouched.
 
 Full walkthrough, error codes, and the headless `useClipDownload` hook: [Recordings](https://docs.reactor.inc/concepts/recordings).
 

--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -478,14 +478,13 @@ describe("downloadClipAsFile", () => {
   }
 
   /** Saved between tests so we can restore the real dynamic-import
-   * loader after each one. Tests below replace it to simulate the
-   * peer dep being installed (stub), missing (throw), or broken.
-   * `resetFallbackWarning` clears the module-level one-shot latch so
-   * each test starts from a clean state. */
+   * loader after each one. Tests below replace it to stub `mp4box`
+   * with a predictable in-memory shim (verifying option plumbing
+   * without pulling the real fMP4 bytes through every case) or to
+   * simulate a load failure. */
   let realLoadMp4Box: typeof __remuxInternals.loadMp4Box;
   beforeEach(() => {
     realLoadMp4Box = __remuxInternals.loadMp4Box;
-    __remuxInternals.resetFallbackWarning();
   });
   afterEach(() => {
     __remuxInternals.loadMp4Box = realLoadMp4Box;
@@ -615,13 +614,18 @@ describe("downloadClipAsFile", () => {
       expect(Array.from(out)).toEqual([99, 99, 99]);
     });
 
-    it("auto: falls back to byte-concat with a one-shot warning when mp4box is missing", async () => {
+    it("auto: falls back to byte-concat with a warning on remux failure", async () => {
       installChunkFetchMock();
-      __remuxInternals.loadMp4Box = async () => {
-        const err: any = new Error("Cannot find module 'mp4box'");
-        err.code = "MODULE_NOT_FOUND";
-        throw err;
-      };
+      stubMp4boxOnce({
+        output: new Uint8Array(0),
+        onCreate: (file, kind) => {
+          if (kind === "input") {
+            file.flush = () => {
+              throw new Error("corrupt input");
+            };
+          }
+        },
+      });
       const warnSpy = vi
         .spyOn(console, "warn")
         .mockImplementation(() => undefined);
@@ -633,20 +637,7 @@ describe("downloadClipAsFile", () => {
       );
       expect(out[0]).toBe(initBytes[0]);
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0][0]).toContain("mp4box");
-    });
-
-    it("force: throws REMUX_UNAVAILABLE when mp4box is missing", async () => {
-      installChunkFetchMock();
-      __remuxInternals.loadMp4Box = async () => {
-        throw new Error("Cannot find module 'mp4box'");
-      };
-
-      await expect(
-        downloadClipAsFile(clip, null, { remux: "force" })
-      ).rejects.toMatchObject({
-        code: "REMUX_UNAVAILABLE",
-      });
+      expect(warnSpy.mock.calls[0][0]).toContain("remux failed");
     });
 
     it("force: throws REMUX_FAILED when mp4box throws during remux", async () => {
@@ -661,6 +652,19 @@ describe("downloadClipAsFile", () => {
           }
         },
       });
+
+      await expect(
+        downloadClipAsFile(clip, null, { remux: "force" })
+      ).rejects.toMatchObject({
+        code: "REMUX_FAILED",
+      });
+    });
+
+    it("force: throws REMUX_FAILED when the mp4box dynamic import fails", async () => {
+      installChunkFetchMock();
+      __remuxInternals.loadMp4Box = async () => {
+        throw new Error("Cannot find module 'mp4box'");
+      };
 
       await expect(
         downloadClipAsFile(clip, null, { remux: "force" })

--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -3,6 +3,7 @@ import {
   ClipReadyPayloadSchema,
   RecordingError,
   RuntimeRecordingMessageType,
+  __remuxInternals,
   clipFromPayload,
   createPlayableManifestUrl,
   downloadClipAsFile,
@@ -449,11 +450,14 @@ describe("downloadClipAsFile", () => {
     coordinatorBaseUrl: "http://localhost:8080",
   });
 
-  it("fetches playlist + every chunk and assembles a Blob", async () => {
-    const initBytes = new Uint8Array([1, 2, 3, 4]);
-    const chunk0 = new Uint8Array([5, 6, 7, 8, 9, 10]);
-    const chunk1 = new Uint8Array([11, 12, 13]);
+  /** Mock chunk bytes that won't actually parse as fMP4 — irrelevant
+   * for these tests because they only exercise the fetch + concat
+   * path and stub `mp4box` out separately. */
+  const initBytes = new Uint8Array([1, 2, 3, 4]);
+  const chunk0 = new Uint8Array([5, 6, 7, 8, 9, 10]);
+  const chunk1 = new Uint8Array([11, 12, 13]);
 
+  function installChunkFetchMock(): ReturnType<typeof vi.fn> {
     const mockFetch = vi.fn().mockImplementation((url: string) => {
       if (url.includes("/clips?")) {
         return Promise.resolve(new Response(SAMPLE_MANIFEST, { status: 200 }));
@@ -470,9 +474,31 @@ describe("downloadClipAsFile", () => {
       return Promise.resolve(new Response(null, { status: 404 }));
     });
     globalThis.fetch = mockFetch as any;
+    return mockFetch;
+  }
+
+  /** Saved between tests so we can restore the real dynamic-import
+   * loader after each one. Tests below replace it to simulate the
+   * peer dep being installed (stub), missing (throw), or broken.
+   * `resetFallbackWarning` clears the module-level one-shot latch so
+   * each test starts from a clean state. */
+  let realLoadMp4Box: typeof __remuxInternals.loadMp4Box;
+  beforeEach(() => {
+    realLoadMp4Box = __remuxInternals.loadMp4Box;
+    __remuxInternals.resetFallbackWarning();
+  });
+  afterEach(() => {
+    __remuxInternals.loadMp4Box = realLoadMp4Box;
+  });
+
+  it("fetches playlist + every chunk and assembles a Blob (remux off)", async () => {
+    installChunkFetchMock();
 
     const onProgress = vi.fn();
-    const blob = await downloadClipAsFile(clip, null, { onProgress });
+    const blob = await downloadClipAsFile(clip, null, {
+      onProgress,
+      remux: "off",
+    });
     expect(blob).toBeInstanceOf(Blob);
     expect(blob.size).toBe(
       initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
@@ -499,6 +525,160 @@ describe("downloadClipAsFile", () => {
 
     await expect(downloadClipAsFile(clip, null)).rejects.toMatchObject({
       code: "CHUNK_FETCH_FAILED",
+    });
+  });
+
+  describe("remux mode", () => {
+    /**
+     * Minimal mp4box stub that always returns predictable bytes.
+     *
+     * We don't exercise real fMP4 parsing here — the goal is to
+     * verify the `auto` / `force` / `off` branching, fallback, and
+     * error mapping. A round-trip test against a real fixture would
+     * either ship a binary blob or pull a fixture from disk; covered
+     * separately by integration / manual verification.
+     */
+    function stubMp4boxOnce(opts: {
+      output: Uint8Array;
+      onCreate?: (file: any, kind: "input" | "output") => void;
+    }) {
+      let calls = 0;
+      const createFile = () => {
+        calls++;
+        const kind = calls === 1 ? "input" : "output";
+        const file: any = {
+          onError: undefined,
+          onReady: undefined,
+          onSamples: undefined,
+          init: () => undefined,
+          appendBuffer: () => 0,
+          flush: () => undefined,
+          start: () => undefined,
+          setExtractionOptions: () => undefined,
+          addTrack: () => 1,
+          addSample: () => undefined,
+          getInfo: () => ({ tracks: [{ id: 1 }] }),
+          getBuffer: () => ({
+            buffer: opts.output.buffer.slice(
+              opts.output.byteOffset,
+              opts.output.byteOffset + opts.output.byteLength
+            ),
+            byteLength: opts.output.byteLength,
+          }),
+        };
+        opts.onCreate?.(file, kind);
+        return file;
+      };
+      __remuxInternals.loadMp4Box = async () =>
+        ({
+          createFile,
+          MP4BoxBuffer: {
+            fromArrayBuffer: (ab: ArrayBufferLike, fileStart: number) => {
+              const buf = ab.slice(0) as ArrayBuffer & { fileStart: number };
+              buf.fileStart = fileStart;
+              return buf;
+            },
+          },
+        }) as any;
+    }
+
+    it("auto: returns remuxed bytes when mp4box is available", async () => {
+      installChunkFetchMock();
+      const remuxed = new Uint8Array([99, 99, 99]);
+      stubMp4boxOnce({
+        output: remuxed,
+        onCreate: (file, kind) => {
+          if (kind === "input") {
+            // Drive the parse → ready → samples → flush sequence
+            // synchronously inside flush() so the awaiting Promise
+            // resolves before the call returns.
+            file.flush = () => {
+              file.onReady?.({ tracks: [{ id: 1 }] });
+              file.onSamples?.(1, null, [
+                {
+                  data: new Uint8Array([0]),
+                  duration: 1,
+                  dts: 7,
+                  cts: 7,
+                  is_sync: true,
+                  description: { type: "avc1" },
+                  timescale: 1000,
+                },
+              ]);
+            };
+          }
+        },
+      });
+
+      const blob = await downloadClipAsFile(clip, null, { remux: "auto" });
+      const out = new Uint8Array(await blob.arrayBuffer());
+      expect(Array.from(out)).toEqual([99, 99, 99]);
+    });
+
+    it("auto: falls back to byte-concat with a one-shot warning when mp4box is missing", async () => {
+      installChunkFetchMock();
+      __remuxInternals.loadMp4Box = async () => {
+        const err: any = new Error("Cannot find module 'mp4box'");
+        err.code = "MODULE_NOT_FOUND";
+        throw err;
+      };
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const blob = await downloadClipAsFile(clip, null, { remux: "auto" });
+      const out = new Uint8Array(await blob.arrayBuffer());
+      expect(out.byteLength).toBe(
+        initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
+      );
+      expect(out[0]).toBe(initBytes[0]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("mp4box");
+    });
+
+    it("force: throws REMUX_UNAVAILABLE when mp4box is missing", async () => {
+      installChunkFetchMock();
+      __remuxInternals.loadMp4Box = async () => {
+        throw new Error("Cannot find module 'mp4box'");
+      };
+
+      await expect(
+        downloadClipAsFile(clip, null, { remux: "force" })
+      ).rejects.toMatchObject({
+        code: "REMUX_UNAVAILABLE",
+      });
+    });
+
+    it("force: throws REMUX_FAILED when mp4box throws during remux", async () => {
+      installChunkFetchMock();
+      stubMp4boxOnce({
+        output: new Uint8Array(0),
+        onCreate: (file, kind) => {
+          if (kind === "input") {
+            file.flush = () => {
+              throw new Error("corrupt input");
+            };
+          }
+        },
+      });
+
+      await expect(
+        downloadClipAsFile(clip, null, { remux: "force" })
+      ).rejects.toMatchObject({
+        code: "REMUX_FAILED",
+      });
+    });
+
+    it("off: skips mp4box entirely (no dynamic import attempted)", async () => {
+      installChunkFetchMock();
+      const loader = vi.fn();
+      __remuxInternals.loadMp4Box = loader as any;
+
+      const blob = await downloadClipAsFile(clip, null, { remux: "off" });
+      expect(blob.size).toBe(
+        initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
+      );
+      expect(loader).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/js-sdk/__tests__/unit/recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/recording.test.ts
@@ -450,12 +450,14 @@ describe("downloadClipAsFile", () => {
     coordinatorBaseUrl: "http://localhost:8080",
   });
 
-  /** Mock chunk bytes that won't actually parse as fMP4 — irrelevant
-   * for these tests because they only exercise the fetch + concat
-   * path and stub `mp4box` out separately. */
+  /** Mock chunk bytes that won't parse as real fMP4. The remux path
+   * is stubbed via `__remuxInternals.loadMp4Box` so the assertions
+   * below can still match exact byte counts. */
   const initBytes = new Uint8Array([1, 2, 3, 4]);
   const chunk0 = new Uint8Array([5, 6, 7, 8, 9, 10]);
   const chunk1 = new Uint8Array([11, 12, 13]);
+  const concatSize =
+    initBytes.byteLength + chunk0.byteLength + chunk1.byteLength;
 
   function installChunkFetchMock(): ReturnType<typeof vi.fn> {
     const mockFetch = vi.fn().mockImplementation((url: string) => {
@@ -477,31 +479,30 @@ describe("downloadClipAsFile", () => {
     return mockFetch;
   }
 
-  /** Saved between tests so we can restore the real dynamic-import
-   * loader after each one. Tests below replace it to stub `mp4box`
-   * with a predictable in-memory shim (verifying option plumbing
-   * without pulling the real fMP4 bytes through every case) or to
-   * simulate a load failure. */
   let realLoadMp4Box: typeof __remuxInternals.loadMp4Box;
   beforeEach(() => {
     realLoadMp4Box = __remuxInternals.loadMp4Box;
+    // The default for these tests is "remux throws" — exercises the
+    // silent-fallback path, which keeps the byte-count assertions on
+    // the assembled Blob honest without having to build a real fMP4
+    // fixture. Tests that care about the success path override this
+    // with a passthrough stub.
+    __remuxInternals.loadMp4Box = async () => {
+      throw new Error("stubbed");
+    };
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
   afterEach(() => {
     __remuxInternals.loadMp4Box = realLoadMp4Box;
   });
 
-  it("fetches playlist + every chunk and assembles a Blob (remux off)", async () => {
+  it("fetches playlist + every chunk and assembles a Blob", async () => {
     installChunkFetchMock();
 
     const onProgress = vi.fn();
-    const blob = await downloadClipAsFile(clip, null, {
-      onProgress,
-      remux: "off",
-    });
+    const blob = await downloadClipAsFile(clip, null, { onProgress });
     expect(blob).toBeInstanceOf(Blob);
-    expect(blob.size).toBe(
-      initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
-    );
+    expect(blob.size).toBe(concatSize);
     expect(onProgress).toHaveBeenCalledTimes(3);
     expect(onProgress).toHaveBeenLastCalledWith(
       expect.objectContaining({ fetched: 3, total: 3 })
@@ -527,162 +528,81 @@ describe("downloadClipAsFile", () => {
     });
   });
 
-  describe("remux mode", () => {
-    /**
-     * Minimal mp4box stub that always returns predictable bytes.
-     *
-     * We don't exercise real fMP4 parsing here — the goal is to
-     * verify the `auto` / `force` / `off` branching, fallback, and
-     * error mapping. A round-trip test against a real fixture would
-     * either ship a binary blob or pull a fixture from disk; covered
-     * separately by integration / manual verification.
-     */
-    function stubMp4boxOnce(opts: {
-      output: Uint8Array;
-      onCreate?: (file: any, kind: "input" | "output") => void;
-    }) {
-      let calls = 0;
-      const createFile = () => {
-        calls++;
-        const kind = calls === 1 ? "input" : "output";
-        const file: any = {
-          onError: undefined,
-          onReady: undefined,
-          onSamples: undefined,
-          init: () => undefined,
-          appendBuffer: () => 0,
-          flush: () => undefined,
-          start: () => undefined,
-          setExtractionOptions: () => undefined,
-          addTrack: () => 1,
-          addSample: () => undefined,
-          getInfo: () => ({ tracks: [{ id: 1 }] }),
-          getBuffer: () => ({
-            buffer: opts.output.buffer.slice(
-              opts.output.byteOffset,
-              opts.output.byteOffset + opts.output.byteLength
-            ),
-            byteLength: opts.output.byteLength,
-          }),
-        };
-        opts.onCreate?.(file, kind);
-        return file;
-      };
-      __remuxInternals.loadMp4Box = async () =>
-        ({
-          createFile,
-          MP4BoxBuffer: {
-            fromArrayBuffer: (ab: ArrayBufferLike, fileStart: number) => {
-              const buf = ab.slice(0) as ArrayBuffer & { fileStart: number };
-              buf.fileStart = fileStart;
-              return buf;
-            },
+  it("returns the mp4box remuxed bytes when remux succeeds", async () => {
+    installChunkFetchMock();
+    const remuxed = new Uint8Array([99, 99, 99]);
+    // Stub mp4box with a passthrough that drives parse → samples →
+    // flush synchronously inside flush(). The output ISOFile's
+    // getBuffer() returns the canned remuxed bytes.
+    __remuxInternals.loadMp4Box = async () =>
+      ({
+        createFile: (() => {
+          let isInput = true;
+          return () => {
+            const file: any = {
+              onError: undefined,
+              onReady: undefined,
+              onSamples: undefined,
+              init: () => undefined,
+              appendBuffer: () => 0,
+              start: () => undefined,
+              setExtractionOptions: () => undefined,
+              addTrack: () => 1,
+              addSample: () => undefined,
+              getInfo: () => ({ tracks: [{ id: 1 }] }),
+              getBuffer: () => ({
+                buffer: remuxed.buffer.slice(
+                  remuxed.byteOffset,
+                  remuxed.byteOffset + remuxed.byteLength
+                ),
+                byteLength: remuxed.byteLength,
+              }),
+              flush: undefined as undefined | (() => void),
+            };
+            if (isInput) {
+              file.flush = () => {
+                file.onReady?.({ tracks: [{ id: 1 }] });
+                file.onSamples?.(1, null, [
+                  {
+                    data: new Uint8Array([0]),
+                    duration: 1,
+                    dts: 7,
+                    cts: 7,
+                    is_sync: true,
+                    description: { type: "avc1" },
+                    timescale: 1000,
+                  },
+                ]);
+              };
+              isInput = false;
+            } else {
+              file.flush = () => undefined;
+            }
+            return file;
+          };
+        })(),
+        MP4BoxBuffer: {
+          fromArrayBuffer: (ab: ArrayBufferLike, fileStart: number) => {
+            const buf = ab.slice(0) as ArrayBuffer & { fileStart: number };
+            buf.fileStart = fileStart;
+            return buf;
           },
-        }) as any;
-    }
-
-    it("auto: returns remuxed bytes when mp4box is available", async () => {
-      installChunkFetchMock();
-      const remuxed = new Uint8Array([99, 99, 99]);
-      stubMp4boxOnce({
-        output: remuxed,
-        onCreate: (file, kind) => {
-          if (kind === "input") {
-            // Drive the parse → ready → samples → flush sequence
-            // synchronously inside flush() so the awaiting Promise
-            // resolves before the call returns.
-            file.flush = () => {
-              file.onReady?.({ tracks: [{ id: 1 }] });
-              file.onSamples?.(1, null, [
-                {
-                  data: new Uint8Array([0]),
-                  duration: 1,
-                  dts: 7,
-                  cts: 7,
-                  is_sync: true,
-                  description: { type: "avc1" },
-                  timescale: 1000,
-                },
-              ]);
-            };
-          }
         },
-      });
+      }) as any;
 
-      const blob = await downloadClipAsFile(clip, null, { remux: "auto" });
-      const out = new Uint8Array(await blob.arrayBuffer());
-      expect(Array.from(out)).toEqual([99, 99, 99]);
-    });
+    const blob = await downloadClipAsFile(clip, null);
+    const out = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(out)).toEqual([99, 99, 99]);
+  });
 
-    it("auto: falls back to byte-concat with a warning on remux failure", async () => {
-      installChunkFetchMock();
-      stubMp4boxOnce({
-        output: new Uint8Array(0),
-        onCreate: (file, kind) => {
-          if (kind === "input") {
-            file.flush = () => {
-              throw new Error("corrupt input");
-            };
-          }
-        },
-      });
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => undefined);
-
-      const blob = await downloadClipAsFile(clip, null, { remux: "auto" });
-      const out = new Uint8Array(await blob.arrayBuffer());
-      expect(out.byteLength).toBe(
-        initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
-      );
-      expect(out[0]).toBe(initBytes[0]);
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0][0]).toContain("remux failed");
-    });
-
-    it("force: throws REMUX_FAILED when mp4box throws during remux", async () => {
-      installChunkFetchMock();
-      stubMp4boxOnce({
-        output: new Uint8Array(0),
-        onCreate: (file, kind) => {
-          if (kind === "input") {
-            file.flush = () => {
-              throw new Error("corrupt input");
-            };
-          }
-        },
-      });
-
-      await expect(
-        downloadClipAsFile(clip, null, { remux: "force" })
-      ).rejects.toMatchObject({
-        code: "REMUX_FAILED",
-      });
-    });
-
-    it("force: throws REMUX_FAILED when the mp4box dynamic import fails", async () => {
-      installChunkFetchMock();
-      __remuxInternals.loadMp4Box = async () => {
-        throw new Error("Cannot find module 'mp4box'");
-      };
-
-      await expect(
-        downloadClipAsFile(clip, null, { remux: "force" })
-      ).rejects.toMatchObject({
-        code: "REMUX_FAILED",
-      });
-    });
-
-    it("off: skips mp4box entirely (no dynamic import attempted)", async () => {
-      installChunkFetchMock();
-      const loader = vi.fn();
-      __remuxInternals.loadMp4Box = loader as any;
-
-      const blob = await downloadClipAsFile(clip, null, { remux: "off" });
-      expect(blob.size).toBe(
-        initBytes.byteLength + chunk0.byteLength + chunk1.byteLength
-      );
-      expect(loader).not.toHaveBeenCalled();
-    });
+  it("falls back to the byte-concatenated fMP4 on remux failure (logged via console.warn)", async () => {
+    installChunkFetchMock();
+    // Default beforeEach already stubs loadMp4Box to throw.
+    const blob = await downloadClipAsFile(clip, null);
+    const out = new Uint8Array(await blob.arrayBuffer());
+    expect(out.byteLength).toBe(concatSize);
+    expect(out[0]).toBe(initBytes[0]);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as any).mock.calls[0][0]).toContain("remux failed");
   });
 });

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -61,11 +61,15 @@
   },
   "peerDependencies": {
     "hls.js": "^1.6.0",
+    "mp4box": "^2.3.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zustand": "^5.0.6"
   },
   "peerDependenciesMeta": {
     "hls.js": {
+      "optional": true
+    },
+    "mp4box": {
       "optional": true
     }
   },
@@ -74,6 +78,7 @@
     "@types/node": "^25",
     "@types/react": "^19.2.15",
     "hls.js": "^1.6.0",
+    "mp4box": "^2.3.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -56,20 +56,17 @@
   },
   "packageManager": "pnpm@10.12.1",
   "dependencies": {
+    "mp4box": "^2.3.0",
     "sdp-transform": "^3.0.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
     "hls.js": "^1.6.0",
-    "mp4box": "^2.3.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zustand": "^5.0.6"
   },
   "peerDependenciesMeta": {
     "hls.js": {
-      "optional": true
-    },
-    "mp4box": {
       "optional": true
     }
   },
@@ -78,7 +75,6 @@
     "@types/node": "^25",
     "@types/react": "^19.2.15",
     "hls.js": "^1.6.0",
-    "mp4box": "^2.3.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -28,7 +28,6 @@ export type {
   DownloadClipOptions,
   FetchPlaylistOptions,
   ParseClipOptions,
-  RemuxMode,
 } from "./utils/recording";
 // Stateful recording client + its host adapter.
 export {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -28,6 +28,7 @@ export type {
   DownloadClipOptions,
   FetchPlaylistOptions,
   ParseClipOptions,
+  RemuxMode,
 } from "./utils/recording";
 // Stateful recording client + its host adapter.
 export {

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -10,7 +10,8 @@
  * - HTTP helpers `fetchPlaylist` (deadline-driven polling) and
  *   `parsePlaylist` (HLS `.m3u8` parser).
  * - The `downloadClipAsFile` helper that streams the referenced
- *   fMP4 chunks and byte-concatenates them into a fragmented-MP4
+ *   fMP4 chunks, optionally remuxes them into a flat MP4 via
+ *   `mp4box` (PTS=0, faststart, `major_brand=isom`), and returns a
  *   Blob for browser download.
  *
  * Stateful pieces (FIFO promise correlator, in-flight request
@@ -100,6 +101,8 @@ export class RecordingError extends Error {
       | "CHUNK_FETCH_FAILED"
       | "INVALID_PLAYLIST"
       | "DOWNLOAD_UNSUPPORTED"
+      | "REMUX_UNAVAILABLE"
+      | "REMUX_FAILED"
       | "INTERNAL_ERROR",
     public readonly reason: string
   ) {
@@ -504,6 +507,41 @@ function absolutizeManifestUrls(
 // downloadClipAsFile
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Controls how `downloadClipAsFile` packages the assembled chunks into
+ * the final `Blob`.
+ *
+ * The runtime serves recordings as fragmented MP4 (fMP4): an
+ * `init.mp4` followed by a series of `.m4s` chunks. Byte-concatenating
+ * those gives a *playable* fMP4 (Safari, hls.js, ffmpeg all handle
+ * it), but social-media uploaders and most desktop tools expect a
+ * **flat MP4** — one `ftyp + moov + mdat` with `start_time=0` and
+ * `+faststart` layout. A mid-session clip carries the session
+ * timeline in its `tfdt baseMediaDecodeTime`, so the concatenated
+ * output has `start_time=32.0` (or wherever the clip starts) and
+ * QuickLook / Twitter / Instagram either show 32 s of black or reject
+ * the upload outright.
+ *
+ * `mp4box` is loaded dynamically when remux is requested — it is
+ * declared as an **optional peer dependency**, mirroring how `hls.js`
+ * is configured for {@link ClipPlayer}. Consumers who don't install
+ * it stay on the concat path; consumers who do, get a social-ready
+ * MP4 out of the box.
+ *
+ * - `"auto"` *(default)* — remux when `mp4box` is available; fall
+ *   back to byte-concat with a one-shot `console.warn` when it
+ *   isn't. Safe to ship without further changes; users who want the
+ *   improved output `pnpm add mp4box`.
+ * - `"force"` — remux unconditionally. Throws
+ *   `RecordingError("REMUX_UNAVAILABLE", …)` if `mp4box` can't be
+ *   loaded (caller wants a hard guarantee, e.g. before uploading to
+ *   Twitter from a server-side context).
+ * - `"off"` — never remux. Returns the byte-concatenated fragmented
+ *   MP4 verbatim. Use when you specifically want the raw fMP4 (e.g.
+ *   to feed it into your own pipeline).
+ */
+export type RemuxMode = "auto" | "force" | "off";
+
 export interface DownloadClipOptions {
   /**
    * Coordinator JWT.  Attached on the manifest GET only; the chunks
@@ -519,13 +557,24 @@ export interface DownloadClipOptions {
     total: number;
     bytes: number;
   }) => void;
+  /**
+   * Whether to remux the assembled fragmented MP4 into a flat MP4
+   * via the optional `mp4box` peer dependency.  Defaults to
+   * `"auto"`.  See {@link RemuxMode} for the full semantics and the
+   * rationale.
+   */
+  remux?: RemuxMode;
 }
 
 /**
- * Stream the chunks referenced by `clip.playlistUrl`, byte-concatenate
- * them into a fragmented-MP4 Blob, and (when `filename` is non-null)
- * trigger a browser-native `<a download>`.  Pass `filename: null` to
- * skip the download trigger and just receive the Blob.
+ * Stream the chunks referenced by `clip.playlistUrl`, optionally
+ * remux them into a flat social-media-compatible MP4 (default), and
+ * (when `filename` is non-null) trigger a browser-native
+ * `<a download>`.  Pass `filename: null` to skip the download trigger
+ * and just receive the Blob.
+ *
+ * @see {@link DownloadClipOptions.remux} for the remux mode + the
+ *   optional `mp4box` peer dependency.
  */
 export async function downloadClipAsFile(
   clip: Clip,
@@ -547,7 +596,7 @@ export async function downloadClipAsFile(
   );
 
   const orderedUrls = [initUrl, ...segmentUrls];
-  const parts: BlobPart[] = [];
+  const parts: Uint8Array[] = [];
   let bytes = 0;
 
   for (let i = 0; i < orderedUrls.length; i++) {
@@ -567,7 +616,7 @@ export async function downloadClipAsFile(
         `Chunk ${i} returned HTTP ${response.status}`
       );
     }
-    const data = await response.arrayBuffer();
+    const data = new Uint8Array(await response.arrayBuffer());
     parts.push(data);
     bytes += data.byteLength;
     options.onProgress?.({
@@ -577,7 +626,8 @@ export async function downloadClipAsFile(
     });
   }
 
-  const blob = new Blob(parts, { type: "video/mp4" });
+  const finalBytes = await maybeRemux(parts, options.remux ?? "auto");
+  const blob = new Blob([finalBytes as BlobPart], { type: "video/mp4" });
 
   if (filename === null) {
     return blob;
@@ -594,6 +644,258 @@ export async function downloadClipAsFile(
 
   triggerBrowserDownload(blob, filename);
   return blob;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fragmented MP4 → flat MP4 remux
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Concatenate `parts` and, based on `mode`, optionally pipe the
+ * result through {@link remuxFragmentedToFlat}.
+ *
+ * The `"auto"` path swallows a missing-peer-dep `ImportError`,
+ * surfaces it once via `console.warn`, and returns the unmodified
+ * concatenation — i.e. existing behaviour for users who haven't
+ * installed `mp4box`. The `"force"` path turns the same condition
+ * into a typed `RecordingError("REMUX_UNAVAILABLE")` for callers
+ * that need a hard guarantee. Any other failure inside `mp4box`
+ * (corrupt input, unsupported codec, internal assertion) becomes
+ * `REMUX_FAILED`.
+ */
+async function maybeRemux(
+  parts: Uint8Array[],
+  mode: RemuxMode
+): Promise<Uint8Array> {
+  if (mode === "off") {
+    return concatUint8Arrays(parts);
+  }
+
+  let mp4boxModule: typeof import("mp4box");
+  try {
+    mp4boxModule = await loadMp4Box();
+  } catch (error) {
+    if (mode === "force") {
+      throw new RecordingError(
+        "REMUX_UNAVAILABLE",
+        `mp4box is not available: ${(error as Error).message}. ` +
+          `Install it with \`pnpm add mp4box\` (or your package ` +
+          `manager's equivalent), or pass \`remux: "off"\` to skip ` +
+          `remux.`
+      );
+    }
+    warnRemuxFallbackOnce();
+    return concatUint8Arrays(parts);
+  }
+
+  const input = concatUint8Arrays(parts);
+  try {
+    return await remuxFragmentedToFlat(input, mp4boxModule);
+  } catch (error) {
+    if (mode === "force") {
+      throw new RecordingError(
+        "REMUX_FAILED",
+        `mp4box remux failed: ${(error as Error).message}`
+      );
+    }
+    console.warn(
+      "[Reactor] Clip remux failed, returning fragmented MP4 instead.",
+      error
+    );
+    return input;
+  }
+}
+
+/**
+ * Indirection so tests can stub the dynamic import without depending
+ * on whether `mp4box` is actually installed in the test environment,
+ * and reset the once-per-process fallback warning latch between
+ * cases.
+ *
+ * @internal
+ */
+export const __remuxInternals = {
+  loadMp4Box: (): Promise<typeof import("mp4box")> => import("mp4box"),
+  resetFallbackWarning: (): void => {
+    remuxFallbackWarned = false;
+  },
+};
+
+function loadMp4Box(): Promise<typeof import("mp4box")> {
+  return __remuxInternals.loadMp4Box();
+}
+
+let remuxFallbackWarned = false;
+function warnRemuxFallbackOnce(): void {
+  if (remuxFallbackWarned) return;
+  remuxFallbackWarned = true;
+  console.warn(
+    "[Reactor] `mp4box` is not installed; clip downloads will return a " +
+      "fragmented MP4 that some uploaders (Twitter, Instagram, ...) " +
+      "reject. Run `pnpm add mp4box` to get social-media-compatible " +
+      'downloads, or pass `remux: "off"` to silence this warning.'
+  );
+}
+
+/**
+ * The actual fMP4 → flat MP4 conversion.  No re-encode: every NAL
+ * unit and AAC packet passes through unchanged.  Only the container
+ * framing (boxes) and decode timestamps get rewritten.
+ *
+ * The output file is initialised with `["isom", "mp42", "avc1", "iso2"]`
+ * as compatible brands so the major brand is `isom` (not `iso5`,
+ * which is what byte-concatenated fragments default to) and the
+ * sample tables are written ahead of `mdat` — i.e. the file is
+ * implicitly faststart.  Per-track decode times are shifted by the
+ * first sample's DTS so the output starts at `0.000000` regardless
+ * of where the clip sits on the session timeline.
+ */
+async function remuxFragmentedToFlat(
+  input: Uint8Array,
+  MP4Box: typeof import("mp4box")
+): Promise<Uint8Array> {
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const inFile = MP4Box.createFile();
+    const outFile = MP4Box.createFile();
+    outFile.init({ brands: ["isom", "mp42", "avc1", "iso2"] });
+
+    const inToOutTrack = new Map<number, number>();
+    const trackBaselineDts = new Map<number, number>();
+    let settled = false;
+
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+
+    inFile.onError = (_module: string, message: string) => {
+      fail(new Error(message));
+    };
+
+    inFile.onReady = (info) => {
+      if (!info.tracks.length) {
+        fail(new Error("no tracks in input"));
+        return;
+      }
+      for (const track of info.tracks) {
+        // setExtractionOptions delivers samples in batches via
+        // onSamples; nbSamples controls batch size only, not total.
+        inFile.setExtractionOptions(track.id, null, { nbSamples: 1000 });
+      }
+      inFile.start();
+    };
+
+    inFile.onSamples = (id, _user, samples) => {
+      if (settled || samples.length === 0) return;
+
+      let outId = inToOutTrack.get(id);
+      let baseline = trackBaselineDts.get(id);
+      if (outId === undefined) {
+        // The sample carries the parsed SampleEntry (avc1 / mp4a / …)
+        // including avcC / esds; addTrack reuses it verbatim so the
+        // bitstream stays bit-identical.  The `description` union
+        // includes SampleGroupEntry for sample-group descriptions,
+        // but onSamples only ever hands us a SampleEntry here — the
+        // cast skips a narrowing dance the types aren't expressive
+        // enough to handle.
+        const firstSample = samples[0];
+        const sampleEntry =
+          firstSample.description as import("mp4box").SampleEntry;
+        const inputTrack = trackInfoById(inFile, id);
+        outId = outFile.addTrack({
+          type: sampleEntry.type as import("mp4box").SampleEntryFourCC,
+          timescale: firstSample.timescale,
+          width: inputTrack?.track_width,
+          height: inputTrack?.track_height,
+          language: inputTrack?.language,
+          hdlr: inputTrack?.video
+            ? "vide"
+            : inputTrack?.audio
+              ? "soun"
+              : undefined,
+          description: sampleEntry,
+        });
+        baseline = firstSample.dts;
+        inToOutTrack.set(id, outId);
+        trackBaselineDts.set(id, baseline);
+      }
+      const dtsShift = baseline as number;
+
+      for (const sample of samples) {
+        if (!sample.data) continue;
+        outFile.addSample(outId, sample.data, {
+          duration: sample.duration,
+          dts: sample.dts - dtsShift,
+          cts: sample.cts - dtsShift,
+          is_sync: sample.is_sync,
+        });
+      }
+    };
+
+    let buf: import("mp4box").MP4BoxBuffer;
+    try {
+      buf = MP4Box.MP4BoxBuffer.fromArrayBuffer(
+        input.buffer.slice(
+          input.byteOffset,
+          input.byteOffset + input.byteLength
+        ),
+        0
+      );
+    } catch (error) {
+      fail(error as Error);
+      return;
+    }
+
+    try {
+      inFile.appendBuffer(buf);
+      inFile.flush();
+    } catch (error) {
+      fail(error as Error);
+      return;
+    }
+
+    if (settled) return;
+    if (inToOutTrack.size === 0) {
+      fail(new Error("no samples extracted from input"));
+      return;
+    }
+
+    let output: Uint8Array;
+    try {
+      const stream = outFile.getBuffer();
+      output = new Uint8Array(
+        stream.buffer.slice(0, stream.byteLength) as ArrayBuffer
+      );
+    } catch (error) {
+      fail(error as Error);
+      return;
+    }
+
+    settled = true;
+    resolve(output);
+  });
+}
+
+function trackInfoById(
+  file: import("mp4box").ISOFile,
+  id: number
+): import("mp4box").Track | undefined {
+  const info = file.getInfo();
+  return info.tracks.find((t) => t.id === id);
+}
+
+function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
+  if (parts.length === 1) return parts[0];
+  let total = 0;
+  for (const p of parts) total += p.byteLength;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.byteLength;
+  }
+  return out;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -702,13 +702,16 @@ async function remuxFragmentedToFlat(
       let outId = inToOutTrack.get(id);
       let baseline = trackBaselineDts.get(id);
       if (outId === undefined) {
-        // The sample carries the parsed SampleEntry (avc1 / mp4a / …)
-        // including avcC / esds; addTrack reuses it verbatim so the
-        // bitstream stays bit-identical.  The `description` union
-        // includes SampleGroupEntry for sample-group descriptions,
-        // but onSamples only ever hands us a SampleEntry here — the
-        // cast skips a narrowing dance the types aren't expressive
-        // enough to handle.
+        // The sample carries the parsed input SampleEntry (avc1 /
+        // mp4a / …) whose child boxes are the actual codec config
+        // (avcC, esds, …).  `addTrack` creates a fresh empty
+        // SampleEntry of the requested `type`, so we have to pass
+        // the input's child boxes via `description_boxes`: they
+        // become direct children of the new SampleEntry, where
+        // decoders expect them.  Passing the whole input
+        // SampleEntry as `description` instead would nest it
+        // (`stsd > avc1 > avc1 > avcC`) and decoders would fail to
+        // find avcC and render black.
         const firstSample = samples[0];
         const sampleEntry =
           firstSample.description as import("mp4box").SampleEntry;
@@ -724,7 +727,11 @@ async function remuxFragmentedToFlat(
             : inputTrack?.audio
               ? "soun"
               : undefined,
-          description: sampleEntry,
+          // `boxes` is typed as `Box[]` but `description_boxes`
+          // wants the narrower `BoxKind[]` union — at runtime they
+          // are the same concrete instances, just typed loosely.
+          description_boxes:
+            sampleEntry.boxes as unknown as import("mp4box").IsoFileOptions["description_boxes"],
         });
         baseline = firstSample.dts;
         inToOutTrack.set(id, outId);

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -10,9 +10,9 @@
  * - HTTP helpers `fetchPlaylist` (deadline-driven polling) and
  *   `parsePlaylist` (HLS `.m3u8` parser).
  * - The `downloadClipAsFile` helper that streams the referenced
- *   fMP4 chunks, optionally remuxes them into a flat MP4 via
- *   `mp4box` (PTS=0, faststart, `major_brand=isom`), and returns a
- *   Blob for browser download.
+ *   fMP4 chunks, remuxes them into a flat social-media-ready MP4
+ *   via `mp4box` (PTS=0, faststart, `major_brand=isom`), and
+ *   returns a Blob for browser download.
  *
  * Stateful pieces (FIFO promise correlator, in-flight request
  * lifecycle, integration with Reactor's event bus) live in the
@@ -101,7 +101,6 @@ export class RecordingError extends Error {
       | "CHUNK_FETCH_FAILED"
       | "INVALID_PLAYLIST"
       | "DOWNLOAD_UNSUPPORTED"
-      | "REMUX_UNAVAILABLE"
       | "REMUX_FAILED"
       | "INTERNAL_ERROR",
     public readonly reason: string
@@ -512,33 +511,31 @@ function absolutizeManifestUrls(
  * the final `Blob`.
  *
  * The runtime serves recordings as fragmented MP4 (fMP4): an
- * `init.mp4` followed by a series of `.m4s` chunks. Byte-concatenating
- * those gives a *playable* fMP4 (Safari, hls.js, ffmpeg all handle
- * it), but social-media uploaders and most desktop tools expect a
- * **flat MP4** — one `ftyp + moov + mdat` with `start_time=0` and
- * `+faststart` layout. A mid-session clip carries the session
- * timeline in its `tfdt baseMediaDecodeTime`, so the concatenated
- * output has `start_time=32.0` (or wherever the clip starts) and
- * QuickLook / Twitter / Instagram either show 32 s of black or reject
- * the upload outright.
+ * `init.mp4` followed by a series of `.m4s` chunks.
+ * Byte-concatenating those gives a *playable* fMP4 (Safari, hls.js,
+ * ffmpeg all handle it), but social-media uploaders and most desktop
+ * tools expect a **flat MP4** — one `ftyp + moov + mdat` with
+ * `start_time=0` and `+faststart` layout.  A mid-session clip carries
+ * the session timeline in its `tfdt baseMediaDecodeTime`, so the raw
+ * concatenated output has `start_time=32.0` (or wherever the clip
+ * starts on the session timeline) and QuickLook / Twitter / Instagram
+ * either show 32 s of black or reject the upload outright.
  *
- * `mp4box` is loaded dynamically when remux is requested — it is
- * declared as an **optional peer dependency**, mirroring how `hls.js`
- * is configured for {@link ClipPlayer}. Consumers who don't install
- * it stay on the concat path; consumers who do, get a social-ready
- * MP4 out of the box.
+ * The SDK pipes the assembled bytes through [`mp4box`](https://www.npmjs.com/package/mp4box)
+ * (a regular runtime dependency, dynamic-imported at call time for
+ * code-splitting) which rewrites the container in-place — no
+ * decode, no re-encode, every NAL unit + AAC packet passes through
+ * untouched.
  *
- * - `"auto"` *(default)* — remux when `mp4box` is available; fall
- *   back to byte-concat with a one-shot `console.warn` when it
- *   isn't. Safe to ship without further changes; users who want the
- *   improved output `pnpm add mp4box`.
- * - `"force"` — remux unconditionally. Throws
- *   `RecordingError("REMUX_UNAVAILABLE", …)` if `mp4box` can't be
- *   loaded (caller wants a hard guarantee, e.g. before uploading to
- *   Twitter from a server-side context).
- * - `"off"` — never remux. Returns the byte-concatenated fragmented
- *   MP4 verbatim. Use when you specifically want the raw fMP4 (e.g.
- *   to feed it into your own pipeline).
+ * - `"auto"` *(default)* — remux; on the rare parse failure fall
+ *   back to the byte-concatenated fMP4 with a `console.warn` so the
+ *   download still succeeds end-to-end.
+ * - `"force"` — remux; throw `RecordingError("REMUX_FAILED", …)` on
+ *   any failure.  Use when downstream code requires the remuxed
+ *   shape (automated social-media upload, etc.).
+ * - `"off"` — skip remux entirely and return the byte-concatenated
+ *   fMP4.  Use when you specifically want the raw fMP4 (debugging,
+ *   custom pipeline, etc.).
  */
 export type RemuxMode = "auto" | "force" | "off";
 
@@ -558,10 +555,10 @@ export interface DownloadClipOptions {
     bytes: number;
   }) => void;
   /**
-   * Whether to remux the assembled fragmented MP4 into a flat MP4
-   * via the optional `mp4box` peer dependency.  Defaults to
-   * `"auto"`.  See {@link RemuxMode} for the full semantics and the
-   * rationale.
+   * How to package the assembled fragmented MP4 into the final
+   * Blob.  Defaults to `"auto"` (remux into a flat MP4 with a
+   * silent fallback to byte-concat on the rare failure).  See
+   * {@link RemuxMode} for the full semantics.
    */
   remux?: RemuxMode;
 }
@@ -654,14 +651,14 @@ export async function downloadClipAsFile(
  * Concatenate `parts` and, based on `mode`, optionally pipe the
  * result through {@link remuxFragmentedToFlat}.
  *
- * The `"auto"` path swallows a missing-peer-dep `ImportError`,
- * surfaces it once via `console.warn`, and returns the unmodified
- * concatenation — i.e. existing behaviour for users who haven't
- * installed `mp4box`. The `"force"` path turns the same condition
- * into a typed `RecordingError("REMUX_UNAVAILABLE")` for callers
- * that need a hard guarantee. Any other failure inside `mp4box`
- * (corrupt input, unsupported codec, internal assertion) becomes
- * `REMUX_FAILED`.
+ * Remux failures are funneled through the same path regardless of
+ * whether they came from the dynamic `mp4box` import (exotic
+ * bundler setup, CSP, etc.) or from `mp4box` itself (corrupt input,
+ * unsupported codec, internal assertion).  `"auto"` swallows them
+ * with a `console.warn` and returns the unmodified concatenation
+ * so the download still succeeds; `"force"` rethrows as
+ * `RecordingError("REMUX_FAILED")` for callers that need a hard
+ * guarantee.
  */
 async function maybeRemux(
   parts: Uint8Array[],
@@ -671,26 +668,10 @@ async function maybeRemux(
     return concatUint8Arrays(parts);
   }
 
-  let mp4boxModule: typeof import("mp4box");
-  try {
-    mp4boxModule = await loadMp4Box();
-  } catch (error) {
-    if (mode === "force") {
-      throw new RecordingError(
-        "REMUX_UNAVAILABLE",
-        `mp4box is not available: ${(error as Error).message}. ` +
-          `Install it with \`pnpm add mp4box\` (or your package ` +
-          `manager's equivalent), or pass \`remux: "off"\` to skip ` +
-          `remux.`
-      );
-    }
-    warnRemuxFallbackOnce();
-    return concatUint8Arrays(parts);
-  }
-
   const input = concatUint8Arrays(parts);
   try {
-    return await remuxFragmentedToFlat(input, mp4boxModule);
+    const MP4Box = await loadMp4Box();
+    return await remuxFragmentedToFlat(input, MP4Box);
   } catch (error) {
     if (mode === "force") {
       throw new RecordingError(
@@ -707,34 +688,18 @@ async function maybeRemux(
 }
 
 /**
- * Indirection so tests can stub the dynamic import without depending
- * on whether `mp4box` is actually installed in the test environment,
- * and reset the once-per-process fallback warning latch between
- * cases.
+ * Indirection so tests can stub the dynamic `mp4box` import without
+ * pulling the real bytes through every test that calls
+ * `downloadClipAsFile`.
  *
  * @internal
  */
 export const __remuxInternals = {
   loadMp4Box: (): Promise<typeof import("mp4box")> => import("mp4box"),
-  resetFallbackWarning: (): void => {
-    remuxFallbackWarned = false;
-  },
 };
 
 function loadMp4Box(): Promise<typeof import("mp4box")> {
   return __remuxInternals.loadMp4Box();
-}
-
-let remuxFallbackWarned = false;
-function warnRemuxFallbackOnce(): void {
-  if (remuxFallbackWarned) return;
-  remuxFallbackWarned = true;
-  console.warn(
-    "[Reactor] `mp4box` is not installed; clip downloads will return a " +
-      "fragmented MP4 that some uploaders (Twitter, Instagram, ...) " +
-      "reject. Run `pnpm add mp4box` to get social-media-compatible " +
-      'downloads, or pass `remux: "off"` to silence this warning.'
-  );
 }
 
 /**

--- a/packages/js-sdk/src/utils/recording.ts
+++ b/packages/js-sdk/src/utils/recording.ts
@@ -101,7 +101,6 @@ export class RecordingError extends Error {
       | "CHUNK_FETCH_FAILED"
       | "INVALID_PLAYLIST"
       | "DOWNLOAD_UNSUPPORTED"
-      | "REMUX_FAILED"
       | "INTERNAL_ERROR",
     public readonly reason: string
   ) {
@@ -506,39 +505,6 @@ function absolutizeManifestUrls(
 // downloadClipAsFile
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * Controls how `downloadClipAsFile` packages the assembled chunks into
- * the final `Blob`.
- *
- * The runtime serves recordings as fragmented MP4 (fMP4): an
- * `init.mp4` followed by a series of `.m4s` chunks.
- * Byte-concatenating those gives a *playable* fMP4 (Safari, hls.js,
- * ffmpeg all handle it), but social-media uploaders and most desktop
- * tools expect a **flat MP4** — one `ftyp + moov + mdat` with
- * `start_time=0` and `+faststart` layout.  A mid-session clip carries
- * the session timeline in its `tfdt baseMediaDecodeTime`, so the raw
- * concatenated output has `start_time=32.0` (or wherever the clip
- * starts on the session timeline) and QuickLook / Twitter / Instagram
- * either show 32 s of black or reject the upload outright.
- *
- * The SDK pipes the assembled bytes through [`mp4box`](https://www.npmjs.com/package/mp4box)
- * (a regular runtime dependency, dynamic-imported at call time for
- * code-splitting) which rewrites the container in-place — no
- * decode, no re-encode, every NAL unit + AAC packet passes through
- * untouched.
- *
- * - `"auto"` *(default)* — remux; on the rare parse failure fall
- *   back to the byte-concatenated fMP4 with a `console.warn` so the
- *   download still succeeds end-to-end.
- * - `"force"` — remux; throw `RecordingError("REMUX_FAILED", …)` on
- *   any failure.  Use when downstream code requires the remuxed
- *   shape (automated social-media upload, etc.).
- * - `"off"` — skip remux entirely and return the byte-concatenated
- *   fMP4.  Use when you specifically want the raw fMP4 (debugging,
- *   custom pipeline, etc.).
- */
-export type RemuxMode = "auto" | "force" | "off";
-
 export interface DownloadClipOptions {
   /**
    * Coordinator JWT.  Attached on the manifest GET only; the chunks
@@ -554,24 +520,20 @@ export interface DownloadClipOptions {
     total: number;
     bytes: number;
   }) => void;
-  /**
-   * How to package the assembled fragmented MP4 into the final
-   * Blob.  Defaults to `"auto"` (remux into a flat MP4 with a
-   * silent fallback to byte-concat on the rare failure).  See
-   * {@link RemuxMode} for the full semantics.
-   */
-  remux?: RemuxMode;
 }
 
 /**
- * Stream the chunks referenced by `clip.playlistUrl`, optionally
- * remux them into a flat social-media-compatible MP4 (default), and
- * (when `filename` is non-null) trigger a browser-native
- * `<a download>`.  Pass `filename: null` to skip the download trigger
- * and just receive the Blob.
+ * Stream the chunks referenced by `clip.playlistUrl`, remux the
+ * assembled bytes into a flat social-media-ready MP4, and (when
+ * `filename` is non-null) trigger a browser-native `<a download>`.
+ * Pass `filename: null` to skip the download trigger and just
+ * receive the Blob.
  *
- * @see {@link DownloadClipOptions.remux} for the remux mode + the
- *   optional `mp4box` peer dependency.
+ * The remux step rewrites the container only — H.264 NAL units and
+ * AAC packets pass through unchanged — so `start_time=0`,
+ * `+faststart`, and `major_brand=isom` come for free without any
+ * re-encode cost.  See {@link maybeRemux} for the fallback
+ * semantics on the rare parse failure.
  */
 export async function downloadClipAsFile(
   clip: Clip,
@@ -623,7 +585,7 @@ export async function downloadClipAsFile(
     });
   }
 
-  const finalBytes = await maybeRemux(parts, options.remux ?? "auto");
+  const finalBytes = await maybeRemux(parts);
   const blob = new Blob([finalBytes as BlobPart], { type: "video/mp4" });
 
   if (filename === null) {
@@ -648,37 +610,20 @@ export async function downloadClipAsFile(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Concatenate `parts` and, based on `mode`, optionally pipe the
- * result through {@link remuxFragmentedToFlat}.
- *
- * Remux failures are funneled through the same path regardless of
- * whether they came from the dynamic `mp4box` import (exotic
- * bundler setup, CSP, etc.) or from `mp4box` itself (corrupt input,
- * unsupported codec, internal assertion).  `"auto"` swallows them
- * with a `console.warn` and returns the unmodified concatenation
- * so the download still succeeds; `"force"` rethrows as
- * `RecordingError("REMUX_FAILED")` for callers that need a hard
- * guarantee.
+ * Concatenate `parts` and pipe the result through
+ * {@link remuxFragmentedToFlat}.  Remux failures (`mp4box` import
+ * blocked by exotic bundler / CSP, corrupt input, unsupported
+ * codec, internal assertion) are funneled through a single path:
+ * a `console.warn` and a return of the unmodified concatenation,
+ * so the download still succeeds end-to-end with the (worse, but
+ * still playable) fragmented MP4 the runtime emitted.
  */
-async function maybeRemux(
-  parts: Uint8Array[],
-  mode: RemuxMode
-): Promise<Uint8Array> {
-  if (mode === "off") {
-    return concatUint8Arrays(parts);
-  }
-
+async function maybeRemux(parts: Uint8Array[]): Promise<Uint8Array> {
   const input = concatUint8Arrays(parts);
   try {
     const MP4Box = await loadMp4Box();
     return await remuxFragmentedToFlat(input, MP4Box);
   } catch (error) {
-    if (mode === "force") {
-      throw new RecordingError(
-        "REMUX_FAILED",
-        `mp4box remux failed: ${(error as Error).message}`
-      );
-    }
     console.warn(
       "[Reactor] Clip remux failed, returning fragmented MP4 instead.",
       error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       hls.js:
         specifier: ^1.6.0
         version: 1.6.16
+      mp4box:
+        specifier: ^2.3.0
+        version: 2.3.0
       prettier:
         specifier: ^3.6.2
         version: 3.8.1
@@ -1016,6 +1019,10 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mp4box@2.3.0:
+    resolution: {integrity: sha512-nnABYbdh4UguEYyV+uRwQBi1tbb8kXka2Fx9yKzmDKAeh8gkvRKYxoK1XDd8GQIjSfN4rvsXrW1CBo4yRQJZDA==}
+    engines: {node: '>=20.8.1'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2337,6 +2344,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  mp4box@2.3.0: {}
 
   ms@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
 
   packages/js-sdk:
     dependencies:
+      mp4box:
+        specifier: ^2.3.0
+        version: 2.3.0
       react:
         specifier: ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 19.2.4
@@ -70,9 +73,6 @@ importers:
       hls.js:
         specifier: ^1.6.0
         version: 1.6.16
-      mp4box:
-        specifier: ^2.3.0
-        version: 2.3.0
       prettier:
         specifier: ^3.6.2
         version: 3.8.1


### PR DESCRIPTION
Linear: [REA-2558](https://linear.app/reactor-team/issue/REA-2558/js-sdk-copy-remux-clip-downloads-pts0-faststart-for-social-media). Companion to runtime-side [REA-2482](https://linear.app/reactor-team/issue/REA-2482).

## Why

A Reactor recording is stored as a fragmented MP4 — an `init.mp4` plus a sequence of `chunk_NNNNN.m4s` segments — and `downloadClipAsFile` today byte-concatenates those into a single `Blob`. That output plays just fine in Safari, hls.js, ffmpeg, and VLC, so the path has worked for engineering and internal demos. It does not work for the audiences the recording feature was actually built for.

The runtime writes per-segment `tfdt baseMediaDecodeTime` values that are session-relative. A clip taken 32 seconds into a session ships with `start_time: 32.000000` in its concatenated form. macOS QuickLook plays 32 seconds of black before any picture shows up; Twitter / X and Instagram reject the upload outright. Even when the timestamps are fixed, the layout is still fragmented (`ftyp + moov + (styp + sidx + moof + mdat) × N`) with `major_brand=iso5`, and a number of social-media uploaders refuse to parse that box structure regardless of where the timeline starts.

REA-2482 takes care of the encode side — `-pix_fmt yuv420p -profile:v main`, session-relative PTS, silent AAC for video-only models — so once it ships, every chunk on its own is a perfectly compliant H.264 + AAC bitstream. The only thing that stays broken in the assembled download is the **container framing**, and the runtime can't fix that without giving up the cheap metadata-only `/clips` architecture (the boundary chunk's tfdt legitimately reflects where the content sits on the session timeline; rewriting it would mean either streaming a per-clip remux or pre-baking a per-clip MP4 in S3, and both were ruled out as architectural changes).

The SDK is therefore where this lands. A `ffmpeg -c copy` style remux — no decode, no re-encode, just rewrite the boxes and shift `tfdt` to 0 — produces a flat MP4 with `start_time=0` and faststart layout that every uploader expects.

## What this changes

The whole change lives in `packages/js-sdk/src/utils/recording.ts`. After the existing chunk loop, the assembled bytes flow through a new internal `maybeRemux` step that loads [`mp4box`](https://www.npmjs.com/package/mp4box) via a dynamic `import()`, walks each input track's samples, and rebuilds them in a fresh `ISOFile` initialised with `["isom", "mp42", "avc1", "iso2"]` as compatible brands. Per-track decode times are shifted by the first sample's DTS so the output starts at `0.000000` regardless of where the clip sits on the session timeline. The H.264 NAL units and AAC packets are passed through verbatim — `addSample` reuses each input sample's `description` (the `avc1` / `mp4a` SampleEntry containing `avcC` / `esds`), so the bitstream stays bit-identical and **no re-encode** happens at any point.

`mp4box` is added as a **regular runtime dependency**. ~60 KB gzipped, pure JavaScript, no WASM, no worker, no COOP/COEP. The dynamic `import("mp4box")` stays in place so consumer bundlers can still code-split it out of the entry chunk for apps that never call `downloadClipAsFile`. Picking it over the obvious alternative ([`ffmpeg.wasm`](https://www.npmjs.com/package/@ffmpeg/ffmpeg)) was a deliberate cost choice: `ffmpeg.wasm` is ~30 MB unzipped for what is structurally a metadata rewrite, brings real flakiness around worker init and cross-origin isolation, and is overkill when the operation we want is `-c copy` — i.e. no codec work at all.

## API surface

**None added.** Same exports, same `DownloadClipOptions` shape, same `RecordingError.code` union as `main`. Remux runs behind the existing API on every call. The behaviour change is bytes-only: the `Blob` you get back from `downloadClipAsFile` (and the file `<ClipDownloadButton>` / `useClipDownload` save through it) is now a flat MP4 with `start_time=0` and faststart layout instead of a fragmented MP4 with session-relative timestamps.

```tsx
import { ClipDownloadButton } from "@reactor-team/js-sdk";

<ClipDownloadButton clip={clip} getJwt={() => jwt} filename="snap.mp4" />
// → flat MP4: start_time=0, faststart, isom brand — uploads cleanly
//   to Twitter, Instagram, TikTok, YouTube without further work.
```

On the rare parse failure (corrupt input, unsupported codec, exotic bundler / CSP blocking the dynamic import) the function emits a `console.warn` and returns the unmodified byte-concatenation, so the download still succeeds end-to-end with the previous (worse, but playable) shape. Failing the call would be an unacceptable regression for a routine "save my clip" interaction, and the developer-facing warning is enough signal to investigate.

## Verification

- **Unit tests**: the existing `downloadClipAsFile` round-trip case is preserved (`fetches playlist + every chunk and assembles a Blob`) and two new cases cover the success / silent-fallback contract — `returns the mp4box remuxed bytes when remux succeeds` and `falls back to the byte-concatenated fMP4 on remux failure (logged via console.warn)`. The `mp4box` import is stubbed via an `@internal` test hook (`__remuxInternals.loadMp4Box`) rather than feeding real fMP4 bytes through the parser; the bit-level guarantees come from `mp4box`'s `-c copy` semantics, which are well-established in production at the GPAC project.
- **Full unit suite**: 348/348 pass.
- **Build**: `tsup` produces `dist/index.mjs` (~149 KB unminified) and the dynamic `import("mp4box")` is preserved in the output rather than inlined, so consumer bundlers can still split it into a separate chunk for apps that never call `downloadClipAsFile`.
- **Format / secret lint**: both clean.
- **DCO**: every commit on the branch carries a `Signed-off-by` trailer matching the author.

End-to-end verification against a real session clip — i.e. "does `ffprobe out.mp4` actually report `start_time: 0.000000`, do Twitter and Instagram actually accept the upload, does macOS QuickLook play inline" — should follow once the runtime-side REA-2482 PR ships and the assembled clips can be exercised against a current dev environment.