### PR TITLE
[REA-2577] types: add ModerationEvent for content moderation runtimeMessages

### DIFF
--- a/packages/js-sdk/__tests__/unit/reactor-moderation.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-moderation.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+import type { ModerationEvent } from "../../src/types";
+
+// Moderation events arrive as the inner payload of an existing
+// `runtimeMessage` envelope — no dedicated `'moderation'` event.
+// Callers discriminate on `m.type === "moderation"` and cast the
+// payload to `ModerationEvent`.
+
+const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
+
+const MOCK_INITIAL_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "CREATED",
+};
+
+const MOCK_FULL_SESSION_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "ACTIVE",
+  selected_transport: { protocol: "webrtc", version: "1.0" },
+  capabilities: {
+    protocol_version: "1.0",
+    tracks: [],
+  },
+};
+
+let transportHandlers: Record<string, (...args: any[]) => void> = {};
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn(function (this: any) {
+    return {
+      createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+      pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+      getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+      terminateSession: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue(MOCK_SESSION_ID),
+    };
+  }),
+}));
+
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn(function (this: any) {
+    transportHandlers = {};
+    return {
+      warmup: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        transportHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue(undefined),
+      getTransportTimings: vi.fn().mockReturnValue(undefined),
+      abort: vi.fn(),
+    };
+  }),
+}));
+
+async function newConnectedReactor(): Promise<Reactor> {
+  const r = new Reactor({ modelName: "echo" });
+  await r.connect("jwt-token");
+  transportHandlers["statusChanged"]?.("connected");
+  return r;
+}
+
+/**
+ * Mirrors WebRTCTransportClient.onmessage: emits `("message", inner, scope)`
+ * with `scope = "runtime"` for platform-control payloads.
+ */
+function emitRuntimeMessage(message: unknown): void {
+  transportHandlers["message"]?.(message, "runtime");
+}
+
+describe("Reactor moderation events on runtimeMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transportHandlers = {};
+  });
+
+  it("delivers a moderation terminate via runtimeMessage", async () => {
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    const payload: ModerationEvent = {
+      action: "terminate",
+      input_kind: "text",
+      command: "set_prompt",
+      categories: ["violence", "violence/graphic"],
+      message: "Session terminated due to policy violation.",
+    };
+    emitRuntimeMessage({ type: "moderation", data: payload });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      type: "moderation",
+      data: payload,
+    });
+  });
+
+  it("delivers a moderation warn via runtimeMessage", async () => {
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    emitRuntimeMessage({
+      type: "moderation",
+      data: {
+        action: "warn",
+        input_kind: "text",
+        command: "set_prompt",
+        categories: ["harassment"],
+        message: "Content was flagged for potential policy violations.",
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].type).toBe("moderation");
+    expect(handler.mock.calls[0][0].data.action).toBe("warn");
+  });
+
+  it("non-moderation runtimeMessages also pass through unchanged", async () => {
+    // Existing consumers (e.g. RecordingClient) keep working — there is
+    // no SDK-level filtering of which runtime types reach the listener.
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    emitRuntimeMessage({
+      type: "modelCapabilities",
+      data: { protocol_version: "1.0", tracks: [], commands: [] },
+    });
+    emitRuntimeMessage({ type: "ping", data: {} });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0][0].type).toBe("modelCapabilities");
+    expect(handler.mock.calls[1][0].type).toBe("ping");
+  });
+
+  it("does not emit a dedicated 'moderation' event", async () => {
+    // Design check: the SDK deliberately doesn't expose a separate
+    // `'moderation'` event surface — consumers filter `runtimeMessage`
+    // by `type`, so the SDK doesn't need a parallel event per type.
+    const r = await newConnectedReactor();
+    const moderationHandler = vi.fn();
+    // Subscribe to the event name we do NOT have; should never fire.
+    (r as any).on("moderation", moderationHandler);
+
+    emitRuntimeMessage({
+      type: "moderation",
+      data: {
+        action: "terminate",
+        input_kind: "text",
+        command: "set_prompt",
+        categories: ["sexual"],
+        message: "Session terminated due to policy violation.",
+      },
+    });
+
+    expect(moderationHandler).not.toHaveBeenCalled();
+  });
+
+  it("typed filter idiom: caller checks `type === 'moderation'`", async () => {
+    // The recommended pattern: subscribe to runtimeMessage, narrow on
+    // the `type` discriminant, then treat `data` as ModerationEvent.
+    const r = await newConnectedReactor();
+    const moderationCallbacks: ModerationEvent[] = [];
+    r.on("runtimeMessage", (m: any) => {
+      if (m?.type === "moderation") {
+        moderationCallbacks.push(m.data as ModerationEvent);
+      }
+    });
+
+    emitRuntimeMessage({ type: "ping", data: {} });
+    emitRuntimeMessage({
+      type: "moderation",
+      data: {
+        action: "terminate",
+        input_kind: "image",
+        command: "set_image",
+        categories: ["sexual"],
+        message: "Session terminated due to policy violation.",
+      },
+    });
+    emitRuntimeMessage({
+      type: "modelCapabilities",
+      data: { protocol_version: "1.0" },
+    });
+
+    expect(moderationCallbacks).toHaveLength(1);
+    expect(moderationCallbacks[0].action).toBe("terminate");
+    expect(moderationCallbacks[0].input_kind).toBe("image");
+  });
+});

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -549,6 +549,9 @@ export class Reactor {
       } else if (scope === "runtime") {
         // Just emit — `RecordingClient` and any app-level
         // `runtimeMessage` listeners are subscribers via `on()`.
+        // Content moderation events arrive as `{ type: "moderation",
+        // data: ModerationEvent }`; apps filter on `type` rather than
+        // subscribing to a dedicated SDK event.
         this.emit("runtimeMessage", message);
       }
     });

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -108,9 +108,55 @@ export type ReactorEvent =
   | "statusChanged" //updates on the reactor status
   | "sessionIdChanged" //updates on the session ID.
   | "message" //application-scoped messages from the model
-  | "runtimeMessage" //internal platform-level control messages (e.g. capabilities)
+  | "runtimeMessage" //internal platform-level control messages (e.g. capabilities, moderation)
   | "trackReceived" // (name: string, track: MediaStreamTrack, stream: MediaStream)
   | "error" //error events with ReactorError details
   | "sessionExpirationChanged" //session expiration has changed
   | "capabilitiesReceived" //server capabilities received after session creation
   | "statsUpdate"; //WebRTC stats update (RTT, etc.)
+
+/**
+ * Severity tier of a content moderation event delivered as the inner
+ * payload of a `runtimeMessage` with `type === "moderation"`.
+ *
+ * - `"warn"`: the input scored above the warn threshold but below the
+ *   terminate threshold. The session continues; this is informational
+ *   only.
+ * - `"terminate"`: the input crossed the terminate threshold. The
+ *   session will be ended shortly after this message is dispatched.
+ */
+export type ModerationAction = "warn" | "terminate";
+
+/**
+ * Inner payload of a `runtimeMessage` with `type === "moderation"`.
+ *
+ * Surfaces a content-moderation outcome to the client app. Fires on
+ * any moderatable input (free-text fields, file uploads) that the
+ * configured moderation policy flags. Apps receive it by subscribing
+ * to the existing `runtimeMessage` event and filtering on `type`:
+ *
+ *     reactor.on("runtimeMessage", (m) => {
+ *       if (m?.type === "moderation") {
+ *         const payload = m.data as ModerationEvent;
+ *         // ...render banner, log, etc.
+ *       }
+ *     });
+ */
+export interface ModerationEvent {
+  /** Severity tier — `"warn"` continues the session, `"terminate"` ends it. */
+  action: ModerationAction;
+  /**
+   * Modality of the flagged input. `"text"` for string fields,
+   * `"image"` for `UploadedFile` payloads with an image MIME type.
+   */
+  input_kind: "text" | "image";
+  /**
+   * Name of the inbound command/event whose payload was flagged
+   * (e.g. `"set_prompt"`, `"set_image"`, `"fileUploaded"`).
+   */
+  command: string;
+  /** Category labels that flagged (e.g. `["sexual"]`, `["violence/graphic"]`). */
+  categories: string[];
+  /** Short human-readable summary suitable for UI rendering. */
+  message: string;
+}


### PR DESCRIPTION
## Summary

Pure types-only additions for content moderation. No runtime behavior change.

- `ModerationEvent` interface — typed payload shape (`action`, `input_kind`, `command`, `categories`, `message`) for the inner payload of `runtimeMessage` events with `type === "moderation"`.
- `ModerationAction` literal type (`"warn" | "terminate"`).

## Why no dedicated event

Content moderation events arrive on the **existing** `runtimeMessage` event with `type === "moderation"`. The SDK does not introduce a parallel `moderation` event surface. Recommended caller pattern:

```ts
reactor.on("runtimeMessage", (m) => {
  if (m?.type === "moderation") {
    const payload = m.data as ModerationEvent;
    // render banner, log, etc.
  }
});
```

Keeps the public event surface stable; opt-in for callers that care about moderation.

## Test plan

- [x] 5 unit tests added: terminate via `runtimeMessage`, warn via `runtimeMessage`, non-moderation runtime types still pass through, no dedicated `moderation` event is emitted, typed-filter idiom compiles + runs.
- [ ] `pnpm typecheck` + `pnpm test` pass in CI.