### PR TITLE
Fix integration tests to use POST /tokens

### DIFF
--- a/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/integration/coordinator-client.test.ts
@@ -7,7 +7,7 @@ const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 
 async function fetchTestToken(apiKey: string, apiUrl: string): Promise<string> {
   const response = await fetch(`${apiUrl}/tokens`, {
-    method: "GET",
+    method: "POST",
     headers: { "Reactor-API-Key": apiKey },
   });
   if (!response.ok) {

--- a/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
+++ b/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
@@ -7,7 +7,7 @@ const COORDINATOR_URL = process.env.REACTOR_COORDINATOR_URL ?? DEFAULT_BASE_URL;
 
 async function fetchTestToken(apiKey: string, apiUrl: string): Promise<string> {
   const response = await fetch(`${apiUrl}/tokens`, {
-    method: "GET",
+    method: "POST",
     headers: { "Reactor-API-Key": apiKey },
   });
   if (!response.ok) {


### PR DESCRIPTION
## Why

The integration test suite under `packages/js-sdk/__tests__/integration/` has been failing in CI on the token-fetch step before any SDK code under test gets exercised:

```
Error: Failed to create token: 404 404 page not found
 ❯ fetchTestToken __tests__/integration/reactor-e2e.test.ts:15:11
```

The cause is a contract drift on the Coordinator. The legacy `GET /tokens` form of the API-key → JWT exchange was removed in REA-1190; only `POST /tokens` is mounted now (see `services/pkg/http/routes.go` and `services/pkg/handlers/token_handler.go` in `reactor-team/reactor`). Both `reactor-e2e.test.ts` and `coordinator-client.test.ts` still had their `fetchTestToken` helper bouncing off the old `GET` route, so all 12 tests in the suite 404'd before doing anything useful.

## What this changes

Flip the HTTP method on the test helper from `GET` to `POST` in the two integration test files that have a copy of `fetchTestToken`:

- `packages/js-sdk/__tests__/integration/reactor-e2e.test.ts`
- `packages/js-sdk/__tests__/integration/coordinator-client.test.ts`

The `Reactor-API-Key` header is kept exactly as is — that is the canonical header name on the Coordinator (`APIKeyHeader = "Reactor-API-Key"` in `services/pkg/handlers/middleware/middleware.go`); no `X-Reactor-*` legacy prefix is used anywhere in the codebase, and we are not introducing one.

Nothing in `packages/js-sdk/src/` is touched — this is purely a test-harness contract fix.

## Verification

- `pnpm -F @reactor-team/js-sdk test:unit` → 363/363 pass.
- `pnpm -F @reactor-team/js-sdk test:integration` without `REACTOR_API_KEY` → 12 skipped (suite is gated on `describe.skipIf(!API_KEY)`), as before.
- Direct probe against the production Coordinator confirms the route shape:
  - `POST https://api.reactor.inc/tokens` → `HTTP/2 401` (endpoint exists, auth missing — expected without a key).
  - `GET  https://api.reactor.inc/tokens` → `HTTP/2 404 page not found` (matches the failure we were seeing).
- `prettier --check` on both touched files is clean.
- Full integration run with a real key is left for the CI step that sets `REACTOR_API_KEY`.
