### PR TITLE
Fix 401 on trickle ICE candidate POST (missing await)

### DIFF
--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -306,7 +306,7 @@ export class WebRTCTransportClient implements TransportClient {
     const response = await fetch(`${this.transportBaseUrl}/ice_candidates`, {
       method: "POST",
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),


### PR DESCRIPTION
Follow-up to #110 (Support Trickle ICE in JS-SDK).

## Why

#110 introduced `POST /sessions/:id/transport/webrtc/ice_candidates` as the new trickle ICE candidate channel. End-to-end against a coordinator with non-empty JWT auth (i.e. everything outside `local: true`), every trickle POST returns `401 Unauthorized` and the candidates silently never reach the supervisor. WebRTC still comes up — host candidates already inside the SDP offer are enough for a same-LAN connect — so a casual smoke test wouldn't catch this. But on any real network where the supervisor's reflexive/relay candidates matter, the trickle path is effectively off.

The cause is a one-character miss in `sendIceCandidates`. `WebRTCTransportClient.getHeaders()` is `async` — the JWT is resolved via `await this.resolveJwt()` so the method can fetch a fresh token when needed. Every other transport call site (`sendSdpOffer`, `fetchIceServers`, `pollSdpAnswer`) does:

```ts
headers: {
  ...(await this.getHeaders()),
  "Content-Type": "application/json",
}
```

The new `sendIceCandidates` site shipped without the `await`:

```ts
headers: {
  ...this.getHeaders(),          // ← spread of a Promise = {}
  "Content-Type": "application/json",
}
```

Spreading a `Promise` produces no own enumerable properties, so the outgoing request has no `Authorization` header and no `Reactor-WebRTC-Version` header. The coordinator's auth middleware rejects with `401`. The flush helper catches and logs at `debug` level — trickle is fire-and-forget by design — so the failure is invisible unless you have devtools open and verbose logs on.

## What this changes

`...this.getHeaders()` → `...(await this.getHeaders())` at the only remaining un-awaited call site in `WebRTCTransportClient.ts`. No behavior changes anywhere else.

Confirmed locally end-to-end against `api.rea.live`:

- Before: every `POST .../ice_candidates` returns 401. Browser network panel shows no `Authorization` header on those requests.
- After: each batch returns `202 Accepted`. The SDP offer carries `a=ice-options:trickle` and zero `a=candidate:` lines, candidates trickle separately via `POST /ice_candidates`, and `is_final: true` flushes on `iceGatheringState === "complete"` as designed.

## Verification

- `pnpm test:unit` — 363/363 passing.
- Manual repro on dev before the fix: 401 on every trickle POST, no candidates reach the supervisor.
- Manual repro on dev after the fix: 202 on every trickle POST, full waterfall (offer with no candidates, host → srflx → relay batches, final flush at gathering complete).

The bug went undetected because none of the unit tests assert on the headers of the trickle path. A small follow-up that mocks `fetch` and verifies each of the four transport endpoints (`/ice_servers`, `/sdp_params` POST/GET, `/ice_candidates`) sends `Authorization: Bearer <jwt>` would have caught this. Deliberately kept out of this PR to ship the fix tight; happy to add it as a follow-up.

Made with [Cursor](https://cursor.com)