### PR TITLE
Bump js-sdk to 2.11.0

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Trickle ICE support landed on `main` in [#110](https://github.com/reactor-team/js-sdk/pull/110) and the follow-up 401 fix in [#179](https://github.com/reactor-team/js-sdk/pull/179) — both released to consumers as a versioned `@reactor-team/js-sdk` package. The behavior change is observable and worth flagging in the version: the handshake no longer blocks on full ICE gathering before sending the SDP offer, so connect latency drops noticeably on networks where gathering host/srflx/relay candidates serially takes hundreds of ms.

That's a minor bump territory — new wire behavior, no breaking surface change — so this moves the package from `2.10.1` to `2.11.0`.

## What this changes

Single edit: `packages/js-sdk/package.json` `version: 2.10.1` → `2.11.0`. Nothing else in the package needs to move. `create-reactor-app` continues to declare `^2.2.2` so it picks up the new release automatically.

For context on what consumers get with the bump:

- `WebRTCTransportClient` now sends the SDP offer immediately and streams local candidates to `POST /sessions/:id/transport/webrtc/candidates` as they arrive, debounced into batches via `ICE_CANDIDATE_BATCH_WINDOW_MS = 25ms`. The end-of-gathering event flushes immediately with `is_final: true`.
- Wire format aligned with the Coordinator REST API: `sdp_mid` / `sdp_mline_index` fields, `client_info` parity with the offer call, and a `202 Accepted` response check.
- ICE candidate POSTs are scheduled with `priority: "high"` (best-effort hint to Chromium/Safari).
- Buffer + debounce timer are reset on `prepare()` / `disconnect()` so a stale batch from an aborted connection can't leak.

## API surface

No public API change. `Reactor`, `ReactorProvider`, the transport types, and every hook are unchanged. Existing consumers pick up the latency improvement transparently on upgrade.

## Verification

- `pnpm --filter @reactor-team/js-sdk build` — clean ESM + CJS + d.ts output.
- `pnpm --filter @reactor-team/js-sdk test:unit` — 363/363 passing.
- `git diff origin/main -- packages/js-sdk/src/index.ts` — empty (no surface change).
- DCO sign-off present on the single commit.

Integration tests run in CI against a Coordinator and are not exercised locally here.

Made with [Cursor](https://cursor.com)