### PR TITLE
Lift recording API onto the React store surface

### DIFF
--- a/packages/js-sdk/__tests__/unit/store-recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/store-recording.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Verifies that `requestClip` / `requestRecording` / `downloadClipAsFile`
+ * are exposed as top-level actions on the React store and delegate to
+ * the underlying {@link Reactor} instance, so consumers don't have to
+ * reach through `state.internal.reactor`.
+ *
+ * The wire-level behaviour of the underlying methods is covered by
+ * `reactor-recording.test.ts`; this file only checks the store-layer
+ * passthrough.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createReactorStore } from "../../src/core/store";
+import type { Clip } from "../../src/utils/recording";
+
+// Same minimal mocks as the reactor unit suites: the store constructs
+// a Reactor in its initialiser which in turn constructs these clients
+// lazily on `connect()`, but the constructor itself doesn't touch the
+// network — we still mock them so a future change can't accidentally
+// trip an outbound request from the test.
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn(function (this: unknown) {
+    return {};
+  }),
+}));
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn(function (this: unknown) {
+    return {};
+  }),
+}));
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn(function (this: unknown) {
+    return { on: vi.fn(), off: vi.fn() };
+  }),
+}));
+
+const FAKE_CLIP: Clip = {
+  sessionId: "rec-1",
+  kind: "snap",
+  startMarker: 120,
+  endMarker: 150,
+  nowMarker: 150,
+  predictedReadyAtMs: 9_999_999_999_999,
+  playlistUrl: "https://api.reactor.inc/clips?session_id=rec-1",
+};
+
+function makeStore() {
+  return createReactorStore({ modelName: "echo", local: true });
+}
+
+describe("ReactorStore recording actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes requestClip / requestRecording / downloadClipAsFile on the public surface", () => {
+    const state = makeStore().getState();
+    expect(typeof state.requestClip).toBe("function");
+    expect(typeof state.requestRecording).toBe("function");
+    expect(typeof state.downloadClipAsFile).toBe("function");
+  });
+
+  it("requestClip delegates to internal.reactor.requestClip with the same arg", async () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    const spy = vi.spyOn(reactor, "requestClip").mockResolvedValue(FAKE_CLIP);
+
+    const result = await store.getState().requestClip(45);
+
+    expect(spy).toHaveBeenCalledWith(45);
+    expect(result).toBe(FAKE_CLIP);
+  });
+
+  it("requestRecording delegates to internal.reactor.requestRecording", async () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    const spy = vi
+      .spyOn(reactor, "requestRecording")
+      .mockResolvedValue(FAKE_CLIP);
+
+    const result = await store.getState().requestRecording();
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(result).toBe(FAKE_CLIP);
+  });
+
+  it("downloadClipAsFile forwards clip, filename and options unchanged", async () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    const fakeBlob = new Blob(["x"], { type: "video/mp4" });
+    const spy = vi
+      .spyOn(reactor, "downloadClipAsFile")
+      .mockResolvedValue(fakeBlob);
+
+    const onProgress = vi.fn();
+    const result = await store
+      .getState()
+      .downloadClipAsFile(FAKE_CLIP, "out.mp4", { onProgress });
+
+    expect(spy).toHaveBeenCalledWith(FAKE_CLIP, "out.mp4", { onProgress });
+    expect(result).toBe(fakeBlob);
+  });
+
+  it("downloadClipAsFile propagates errors from the underlying reactor", async () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    vi.spyOn(reactor, "downloadClipAsFile").mockRejectedValue(
+      new Error("nope")
+    );
+
+    await expect(
+      store.getState().downloadClipAsFile(FAKE_CLIP)
+    ).rejects.toThrow("nope");
+  });
+});

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -8,6 +8,7 @@ import type {
 import { type JwtSource } from "./auth";
 import { Reactor, type Options as ReactorOptions } from "./Reactor";
 import { FileRef } from "./FileRef";
+import type { Clip, DownloadClipOptions } from "../utils/recording";
 import { create } from "zustand/react";
 import { createContext } from "react";
 
@@ -37,6 +38,31 @@ export interface ReactorActions {
   unpublish(name: string): Promise<void>;
   reconnect(options?: ConnectOptions): Promise<void>;
   uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef>;
+  /**
+   * Capture the trailing `durationSeconds` of the live session as a
+   * clip.  Top-level alias for `internal.reactor.requestClip(…)` —
+   * lifted onto the store so consumers don't have to reach through
+   * `internal.reactor` for the common case.  See
+   * {@link Reactor.requestClip}.
+   */
+  requestClip(durationSeconds: number): Promise<Clip>;
+  /**
+   * Capture the entire session up to "now" as a clip.  Top-level
+   * alias for `internal.reactor.requestRecording()`.  See
+   * {@link Reactor.requestRecording}.
+   */
+  requestRecording(): Promise<Clip>;
+  /**
+   * Stream the chunks referenced by `clip.playlistUrl` and trigger a
+   * native browser download of the assembled MP4.  Top-level alias
+   * for `internal.reactor.downloadClipAsFile(…)`.  See
+   * {@link Reactor.downloadClipAsFile}.
+   */
+  downloadClipAsFile(
+    clip: Clip,
+    filename?: string | null,
+    options?: DownloadClipOptions
+  ): Promise<Blob>;
 }
 
 // Internal state not exposed to components
@@ -255,6 +281,14 @@ export const createReactorStore = (
           throw error;
         }
       },
+      requestClip: (durationSeconds: number) =>
+        get().internal.reactor.requestClip(durationSeconds),
+      requestRecording: () => get().internal.reactor.requestRecording(),
+      downloadClipAsFile: (
+        clip: Clip,
+        filename?: string | null,
+        options?: DownloadClipOptions
+      ) => get().internal.reactor.downloadClipAsFile(clip, filename, options),
     };
   });
 };


### PR DESCRIPTION
## Why

Today, the React store exposes the imperative `Reactor` methods that
matter for connection lifecycle — `connect`, `disconnect`,
`publish`, `unpublish`, `reconnect`, `uploadFile`, `sendCommand` — as
top-level actions on `ReactorActions`, so consumers write:

```ts
const connect = useReactor((s) => s.connect);
await connect();
```

But the recording API (`requestClip`, `requestRecording`,
`downloadClipAsFile`) was conspicuously missing from this list. It
lived only on the underlying `Reactor` instance, which the store
keeps under `internal.reactor` as an escape hatch for advanced
consumers. The result was a two-class API: lifecycle is first-class
on React, but recording forces you to reach across the boundary:

```ts
const reactor = useReactor((s) => s.internal.reactor);
const clip = await reactor.requestClip(30);
```

Every consumer in the monorepo has independently been writing the
same boilerplate:

- `test-frontend/lib/useClips.ts` — `useReactor((s) => ({ reactor: s.internal.reactor, status: s.status }))`, then `reactor.requestClip` / `reactor.requestRecording`.
- `reactor-webapp/components/design-system/sandbox/_hooks/use-clip-snap.tsx` — `useReactor((s) => s.internal.reactor)`, then `reactor.requestClip` / `reactor.downloadClipAsFile`.
- `public-demos/components/session-recorder/SessionRecorderProvider.tsx` — same pattern.

`internal.reactor` is a real escape hatch (it covers
`reactor.getJwtResolver()`, direct `reactor.on("runtimeMessage", …)`
subscriptions, etc.) and isn't going away. But the three recording
*actions* fit the exact mold of the other store actions and deserve
to sit alongside them.

## What this changes

The `ReactorActions` interface in `packages/js-sdk/src/core/store.ts`
gains three new entries — `requestClip`, `requestRecording`,
`downloadClipAsFile` — and the store implementation adds matching
thin passthroughs that defer to `get().internal.reactor.<method>`.
This mirrors the existing pattern used by every other action in the
file (`connect`, `disconnect`, `publish`, `uploadFile`, …): the
store doesn't reimplement behaviour, it just lifts the entrypoint
onto the React-visible surface.

No change to the underlying `Reactor` class, the `RecordingClient`,
the FIFO correlator, the JWT-resolver caching, the local-mode URL
rewrite, or any wire-level behaviour. `internal.reactor` keeps
working unchanged — consumers that still need `getJwtResolver()` or
direct event subscriptions reach for it the same way they do today.

A focused `__tests__/unit/store-recording.test.ts` covers the new
store-layer passthrough: it mocks the underlying `Reactor` methods
and verifies that the store-level methods (a) exist on the public
surface, (b) forward their arguments unchanged, and (c) propagate
errors. Wire-level coverage already in `reactor-recording.test.ts`
and `recording-client.test.ts` is untouched and still owns the
behaviour under those passthroughs.

## API surface

```ts
interface ReactorActions {
  // …existing actions unchanged…

  requestClip(durationSeconds: number): Promise<Clip>;
  requestRecording(): Promise<Clip>;
  downloadClipAsFile(
    clip: Clip,
    filename?: string | null,
    options?: DownloadClipOptions
  ): Promise<Blob>;
}
```

How it feels on the consumer side — capture-then-download in one
component, no `internal.reactor`:

```tsx
function ClipButtons() {
  const { requestClip, downloadClipAsFile, status } = useReactor((s) => ({
    requestClip: s.requestClip,
    downloadClipAsFile: s.downloadClipAsFile,
    status: s.status,
  }));

  const snap = useCallback(async () => {
    const clip = await requestClip(30);
    await downloadClipAsFile(clip, `snap-${Date.now()}.mp4`);
  }, [requestClip, downloadClipAsFile]);

  return (
    <button onClick={snap} disabled={status !== "ready"}>
      Snap last 30s
    </button>
  );
}
```

A `useClips()` hook drops from "destructure reactor out of the store
then call on it" to "destructure the actions":

```tsx
const { requestClip, requestRecording, status } = useReactor((s) => ({
  requestClip: s.requestClip,
  requestRecording: s.requestRecording,
  status: s.status,
}));
```

`internal.reactor` is still there for everything else — advanced
consumers that subscribe to `runtimeMessage`, read
`getJwtResolver()` to thread JWTs through `<ClipPlayer>` /
`<ClipDownloadButton>`, or otherwise want the raw event surface.
This PR doesn't deprecate any of that.

## Verification

- `pnpm -F @reactor-team/js-sdk test` — 368 tests pass (5 new in
  `__tests__/unit/store-recording.test.ts`, the rest unchanged).
- `pnpm -F @reactor-team/js-sdk build` — clean, `dist/index.d.ts`
  shows the three new methods on `ReactorActions`.
- `pnpm format:check` — clean.
- Patch version bump to `2.11.1` lives in a separate commit on top
  of the feature commit so the release commit is reviewable in
  isolation.
