### PR TITLE
Clean up SDK developer-experience footguns

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -79,6 +79,8 @@ To play model audio alongside the video, set `audioTrack` to the track name decl
 
 Commands are the model's typed RPC surface (`set_prompt`, `set_image`, and any custom events declared in the model schema). The full catalog is in the [Model API Reference](https://docs.reactor.inc/model-api-reference/overview).
 
+Always select the specific slices you need with `useReactor` — selecting `(s) => s` re-renders the component on every state change (status flips, track updates, etc.).
+
 ```tsx
 import { useReactor } from "@reactor-team/js-sdk";
 
@@ -98,6 +100,8 @@ function PromptInput() {
   );
 }
 ```
+
+Calling `sendCommand` before the session is `"ready"` throws a `NotReadyError` — gate the call behind `status === "ready"` (as above), or catch the error if you'd rather queue retries yourself.
 
 ### Publish webcam input
 
@@ -135,7 +139,10 @@ function FrameCounter() {
 Bind an `<input type="file">` to the model with `uploadFile` and then pass the returned [`FileRef`](https://docs.reactor.inc/api-reference/types#fileref) into any command:
 
 ```tsx
-const { uploadFile, sendCommand } = useReactor((s) => s);
+const { uploadFile, sendCommand } = useReactor((s) => ({
+  uploadFile: s.uploadFile,
+  sendCommand: s.sendCommand,
+}));
 
 const ref = await uploadFile(file);
 await sendCommand("set_image", { image: ref });
@@ -153,18 +160,19 @@ import { Reactor } from "@reactor-team/js-sdk";
 const reactor = new Reactor({
   apiUrl: "https://api.reactor.inc",
   modelName: "your-model-name",
-  jwtToken: await fetchJwt(),
 });
 
-reactor.on("statusChange", (status) => console.log("status:", status));
+reactor.on("statusChanged", (status) => console.log("status:", status));
 reactor.on("message", (msg) => console.log("model:", msg));
+reactor.on("trackReceived", (name, track) => {
+  if (name === "main_video") {
+    videoEl.srcObject = new MediaStream([track]);
+  }
+});
 
-await reactor.connect();
+await reactor.connect(await fetchJwt());
 
 await reactor.sendCommand("set_prompt", { prompt: "a forest at dawn" });
-
-const stream = reactor.getMediaStream("main_video");
-videoEl.srcObject = stream;
 ```
 
 ---
@@ -187,11 +195,13 @@ function ClipModal({ clip, jwt }: { clip: Clip; jwt: string }) {
 }
 ```
 
-Capture a clip from anywhere inside the provider:
+Capture a clip from anywhere inside the provider with the `useReactorRecording()` hook, which bundles `requestClip`, `requestRecording`, and `downloadClipAsFile`:
 
 ```tsx
-const reactor = useReactor((s) => s.internal.reactor);
-const clip = await reactor.requestClip(10); // last 10 s
+import { useReactorRecording } from "@reactor-team/js-sdk";
+
+const { requestClip } = useReactorRecording();
+const clip = await requestClip(10); // last 10 s
 ```
 
 `<ClipPlayer>` uses native HLS on Safari/iOS; install `hls.js` to support Chrome, Firefox, and Edge:
@@ -218,7 +228,7 @@ For models with a published typed SDK, prefer [`@reactor-models/<name>`](https:/
 | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `Reactor`                                                                                                                        | [Reactor class](https://docs.reactor.inc/api-reference/reactor-class)       |
 | `<ReactorProvider>`, `<ReactorView>`, `<WebcamStream>`, `<ReactorController>`                                                    | [React components](https://docs.reactor.inc/api-reference/react-components) |
-| `useReactor`, `useReactorMessage`, `useStats`                                                                                    | [React hooks](https://docs.reactor.inc/api-reference/react-hooks)           |
+| `useReactor`, `useReactorMessage`, `useReactorError`, `useTrack`, `useReactorRecording`, `useStats`                              | [React hooks](https://docs.reactor.inc/api-reference/react-hooks)           |
 | `<ClipPlayer>`, `<ClipDownloadButton>`, `useClipDownload`, `RecordingClient`, `RecordingError`, `fetchPlaylist`, `parsePlaylist` | [Recordings](https://docs.reactor.inc/concepts/recordings)                  |
 
 ---

--- a/packages/js-sdk/__tests__/unit/reactor-not-ready.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-not-ready.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Verifies the `NotReadyError` guard on imperative methods that
+ * require an active session — `sendCommand`, `publishTrack`,
+ * `uploadFile`.  Previously these silently warned-and-returned in
+ * production and *bypassed* the guard entirely in development;
+ * callers had no way to know a command was dropped.
+ *
+ * `unpublishTrack` is intentionally exempt — teardown paths need to
+ * be safe to call mid-disconnect — so it's covered by a regression
+ * test here too.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+import { NotReadyError } from "../../src/types";
+
+let transportHandlers: Record<string, (...args: any[]) => void> = {};
+let mockTransportClient: any;
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn(function (this: any) {
+    return {
+      createSession: vi.fn().mockResolvedValue({
+        session_id: "sid",
+        model: { name: "echo" },
+        state: "CREATED",
+      }),
+      pollSessionReady: vi.fn().mockResolvedValue({
+        session_id: "sid",
+        model: { name: "echo" },
+        state: "ACTIVE",
+        selected_transport: { protocol: "webrtc", version: "1.0" },
+        capabilities: { protocol_version: "1.0", tracks: [] },
+      }),
+      terminateSession: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn(function (this: any) {
+    transportHandlers = {};
+    mockTransportClient = {
+      warmup: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn((event: string, handler: any) => {
+        transportHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue(undefined),
+      abort: vi.fn(),
+    };
+    return mockTransportClient;
+  }),
+}));
+
+describe("NotReadyError guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transportHandlers = {};
+    mockTransportClient = undefined;
+  });
+
+  describe("sendCommand", () => {
+    it("throws NotReadyError before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(r.sendCommand("set_prompt", { p: "x" })).rejects.toThrow(
+        NotReadyError
+      );
+    });
+
+    it("carries the observed status on the thrown error", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      try {
+        await r.sendCommand("set_prompt", { p: "x" });
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotReadyError);
+        const e = err as NotReadyError;
+        expect(e.code).toBe("NOT_READY");
+        expect(e.status).toBe("disconnected");
+        expect(e.operation).toBe("sendCommand");
+        expect(e.message).toContain("disconnected");
+        return;
+      }
+      throw new Error("expected sendCommand to reject");
+    });
+
+    it("throws NotReadyError while connecting (status='waiting')", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      // Don't await connect() — leaves status pending past the synchronous
+      // 'waiting' set inside connect(). Issue sendCommand here.
+      const connectPromise = r.connect("jwt");
+      // The implementation sets status to 'connecting' synchronously then
+      // awaits createSession. Either of those non-ready statuses must throw.
+      await expect(r.sendCommand("x", {})).rejects.toBeInstanceOf(
+        NotReadyError
+      );
+      // Let the connect resolve so the test cleans up.
+      await connectPromise;
+      transportHandlers["statusChanged"]?.("connected");
+      await r.disconnect();
+    });
+
+    it("succeeds once status flips to 'ready'", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await r.connect("jwt");
+      transportHandlers["statusChanged"]("connected");
+
+      await r.sendCommand("ping", { v: 1 });
+      expect(mockTransportClient.sendCommand).toHaveBeenCalledWith(
+        "ping",
+        { v: 1 },
+        "application",
+        undefined
+      );
+      await r.disconnect();
+    });
+  });
+
+  describe("publishTrack", () => {
+    it("throws NotReadyError before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      await expect(
+        r.publishTrack("webcam", {} as MediaStreamTrack)
+      ).rejects.toThrow(NotReadyError);
+    });
+
+    it("includes the track name in the operation field", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      try {
+        await r.publishTrack("webcam", {} as MediaStreamTrack);
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotReadyError);
+        expect((err as NotReadyError).operation).toContain("webcam");
+        return;
+      }
+      throw new Error("expected publishTrack to reject");
+    });
+  });
+
+  describe("uploadFile", () => {
+    it("throws NotReadyError (not a bare Error) before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      const file = new File(["x"], "x.txt", { type: "text/plain" });
+      await expect(r.uploadFile(file)).rejects.toBeInstanceOf(NotReadyError);
+    });
+  });
+
+  describe("unpublishTrack (regression: stays safe-on-any-status)", () => {
+    it("does NOT throw NotReadyError before connect", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      // No transport yet, so the call is a no-op — the contract is just
+      // 'don't blow up on teardown paths'. Whatever this resolves to must
+      // not be a NotReadyError.
+      await expect(r.unpublishTrack("webcam")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -318,31 +318,30 @@ describe("Reactor", () => {
   // ── sendCommand() guard ───────────────────────────────────────────────
 
   describe("sendCommand()", () => {
-    it("warns and returns when not ready", async () => {
+    it("throws NotReadyError when status is not 'ready'", async () => {
       const r = new Reactor({ modelName: "echo" });
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      await r.sendCommand("set_effect", { effect: "grayscale" });
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[Reactor]",
-        expect.stringContaining("Cannot send message")
-      );
+      await expect(
+        r.sendCommand("set_effect", { effect: "grayscale" })
+      ).rejects.toMatchObject({
+        name: "NotReadyError",
+        code: "NOT_READY",
+        status: "disconnected",
+      });
     });
   });
 
   // ── publishTrack() guard ──────────────────────────────────────────────
 
   describe("publishTrack()", () => {
-    it("warns when not ready", async () => {
+    it("throws NotReadyError when status is not 'ready'", async () => {
       const r = new Reactor({ modelName: "echo" });
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      await r.publishTrack("webcam", {} as MediaStreamTrack);
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cannot publish track")
-      );
+      await expect(
+        r.publishTrack("webcam", {} as MediaStreamTrack)
+      ).rejects.toMatchObject({
+        name: "NotReadyError",
+        code: "NOT_READY",
+        status: "disconnected",
+      });
     });
   });
 

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -8,6 +8,7 @@ import {
   type ConnectionStats,
   type ConnectionTimings,
   isAbortError,
+  NotReadyError,
 } from "../types";
 import { type JwtResolver, type JwtSource, normalizeJwtSource } from "./auth";
 import { CoordinatorClient } from "./CoordinatorClient";
@@ -133,16 +134,17 @@ export class Reactor {
    * When any value in `data` is a {@link FileRef}, it is automatically
    * extracted and serialized into a separate `uploads` section on the
    * wire, keyed by the parameter name.  Scalar values remain in `data`.
+   *
+   * @throws {NotReadyError} if the session is not `"ready"`.  Gate
+   *   the call behind `status === "ready"` or catch and retry.
    */
   async sendCommand(
     command: string,
     data: any,
     scope: MessageScope = "application"
   ): Promise<void> {
-    if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
-      const errorMessage = `Cannot send message, status is ${this.status}`;
-      console.warn("[Reactor]", errorMessage);
-      return;
+    if (this.status !== "ready") {
+      throw new NotReadyError("sendCommand", this.status);
     }
 
     try {
@@ -202,9 +204,7 @@ export class Reactor {
     options?: { name?: string }
   ): Promise<FileRef> {
     if (this.status !== "ready") {
-      throw new Error(
-        `Cannot upload file, status is "${this.status}". Must be "ready".`
-      );
+      throw new NotReadyError("uploadFile", this.status);
     }
     if (!this.coordinatorClient || !this.sessionId) {
       throw new Error("No active session. Call connect() first.");
@@ -308,13 +308,12 @@ export class Reactor {
    * Publishes a MediaStreamTrack to a named sendonly track.
    * The transceiver is already set up from capabilities — this just
    * calls replaceTrack() on the sender.
+   *
+   * @throws {NotReadyError} if the session is not `"ready"`.
    */
   async publishTrack(name: string, track: MediaStreamTrack): Promise<void> {
-    if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
-      console.warn(
-        `[Reactor] Cannot publish track "${name}", status is ${this.status}`
-      );
-      return;
+    if (this.status !== "ready") {
+      throw new NotReadyError(`publishTrack("${name}")`, this.status);
     }
 
     try {
@@ -330,6 +329,14 @@ export class Reactor {
     }
   }
 
+  /**
+   * Removes a previously-published track from its sendonly transceiver.
+   *
+   * Unlike `publishTrack`, this is safe to call on any status — a
+   * teardown path may need to unpublish while the transport is already
+   * closing.  If `status !== "ready"` the call is a no-op (no transport
+   * to call `removeTrack()` on).
+   */
   async unpublishTrack(name: string): Promise<void> {
     try {
       await this.transportClient?.unpublishTrack(name);

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import type { Clip } from "../utils/recording";
 import { useClipDownload, type ClipDownloadState } from "./useClipDownload";
 
@@ -62,6 +62,24 @@ export interface ClipDownloadButtonProps {
   style?: React.CSSProperties;
   /** Forwarded to the underlying ``<button>``.  ORed with the internal "downloading" state. */
   disabled?: boolean;
+  /**
+   * Fired once per successful download with the assembled MP4 Blob.
+   *
+   * Runs after the browser save trigger (when ``filename`` is set) so
+   * a toast / Sentry breadcrumb / analytics call lines up with what
+   * the user just received.  Pass ``filename: null`` if you want the
+   * Blob but no native save dialog.
+   */
+  onSuccess?: (blob: Blob, clip: Clip) => void;
+  /**
+   * Fired once per failed download with the original thrown value.
+   *
+   * ``RecordingError`` instances surface as-is so callers can branch
+   * on the typed ``code`` (``CLIP_GONE`` vs ``CHUNK_FETCH_FAILED`` vs
+   * ``DOWNLOAD_UNSUPPORTED``).  Non-Reactor errors come through
+   * unwrapped — `instanceof Error` is the safest narrow.
+   */
+  onError?: (error: unknown, clip: Clip) => void;
 }
 
 export function ClipDownloadButton({
@@ -72,10 +90,36 @@ export function ClipDownloadButton({
   className,
   style,
   disabled,
+  onSuccess,
+  onError,
 }: ClipDownloadButtonProps) {
   const { state, download } = useClipDownload(clip, { filename, getJwt });
   const downloading = state.kind === "downloading";
   const isDisabled = downloading || !!disabled;
+
+  // Stable callback identity via refs so consumers can pass inline
+  // `onSuccess={...}` without forcing the effects below to re-fire on
+  // every parent render — same pattern as `useClipDownload`.
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  });
+
+  // The hook's `error` state retains its identity across renders so
+  // a single failure fires `onError` exactly once.  The same applies
+  // on the success side: re-render with the same `state: idle` after
+  // a download won't double-fire.
+  const lastErrorRef = useRef<unknown>(undefined);
+  useEffect(() => {
+    if (state.kind === "error" && state.error !== lastErrorRef.current) {
+      lastErrorRef.current = state.error;
+      onErrorRef.current?.(state.error, clip);
+    } else if (state.kind !== "error") {
+      lastErrorRef.current = undefined;
+    }
+  }, [state, clip]);
 
   const content =
     typeof children === "function"
@@ -88,7 +132,12 @@ export function ClipDownloadButton({
     <button
       type="button"
       onClick={() => {
-        void download();
+        void (async () => {
+          const blob = await download();
+          if (blob !== undefined) {
+            onSuccessRef.current?.(blob, clip);
+          }
+        })();
       }}
       disabled={isDisabled}
       title={state.kind === "error" ? state.message : undefined}

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -93,6 +93,22 @@ export interface ClipPlayerProps {
   muted?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Fired once the manifest is attached and playback is queued.
+   * Useful for hiding a parent-level loading spinner or firing
+   * "first paint" telemetry.
+   */
+  onReady?: (clip: Clip) => void;
+  /**
+   * Fired when playback can't proceed — playlist 4xx/5xx, manifest
+   * polling timed out, ``hls.js`` not installed on a non-Safari
+   * browser, or a fatal ``hls.js`` runtime error.  ``RecordingError``
+   * instances pass through verbatim so callers can branch on the
+   * typed ``code``; everything else comes through as the original
+   * thrown value, with ``message`` populated as a fallback for
+   * inline rendering.
+   */
+  onError?: (error: { message: string; cause: unknown }, clip: Clip) => void;
 }
 
 type Phase =
@@ -109,6 +125,8 @@ export function ClipPlayer({
   muted = true,
   className,
   style,
+  onReady,
+  onError,
 }: ClipPlayerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
@@ -128,6 +146,8 @@ export function ClipPlayer({
   const getJwtRef = useRef(getJwt);
   const autoPlayRef = useRef(autoPlay);
   const slackMsRef = useRef(slackMs);
+  const onReadyRef = useRef(onReady);
+  const onErrorRef = useRef(onError);
   // Same ref pattern: the resolver is looked up inside `setup` at
   // request time, so a provider swap is picked up on next attach
   // without tearing the player down.
@@ -136,6 +156,8 @@ export function ClipPlayer({
     getJwtRef.current = getJwt;
     autoPlayRef.current = autoPlay;
     slackMsRef.current = slackMs;
+    onReadyRef.current = onReady;
+    onErrorRef.current = onError;
     storeRef.current = store;
   });
 
@@ -152,9 +174,16 @@ export function ClipPlayer({
     let hlsInstance: { destroy: () => void } | null = null;
     let manifestBlobUrl: string | null = null;
 
-    const fail = (message: string) => {
+    const fail = (message: string, cause: unknown = undefined) => {
       if (cancelled) return;
       setPhase({ kind: "error", message });
+      onErrorRef.current?.({ message, cause }, clip);
+    };
+
+    const markReady = () => {
+      if (cancelled) return;
+      setPhase({ kind: "ready" });
+      onReadyRef.current?.(clip);
     };
 
     const attachPlayer = async (manifestUrl: string) => {
@@ -169,7 +198,7 @@ export function ClipPlayer({
             // Autoplay may be blocked by the browser; native controls still work.
           });
         }
-        if (!cancelled) setPhase({ kind: "ready" });
+        markReady();
         return;
       }
 
@@ -180,9 +209,10 @@ export function ClipPlayer({
       try {
         const mod = (await import("hls.js")) as { default: HlsConstructor };
         HlsCtor = mod.default;
-      } catch {
+      } catch (err) {
         fail(
-          "HLS playback unavailable in this browser. Install `hls.js` as a peer dependency, or use Download."
+          "HLS playback unavailable in this browser. Install `hls.js` as a peer dependency, or use Download.",
+          err
         );
         return;
       }
@@ -196,7 +226,7 @@ export function ClipPlayer({
       hls.attachMedia(video);
       hls.on(HlsCtor.Events.MANIFEST_PARSED, () => {
         if (cancelled) return;
-        setPhase({ kind: "ready" });
+        markReady();
         if (autoPlayRef.current) {
           video.play().catch(() => {
             // Autoplay may be blocked.
@@ -211,7 +241,7 @@ export function ClipPlayer({
         // `levelLoadError`) that the user-facing overlay would
         // otherwise hide.  Fatal errors still hard-fail the player.
         if (data.fatal) {
-          fail(`Playback error: ${data.details ?? "unknown"}`);
+          fail(`Playback error: ${data.details ?? "unknown"}`, data);
           return;
         }
         console.warn("[Reactor.ClipPlayer] hls.js non-fatal error", data);
@@ -253,7 +283,7 @@ export function ClipPlayer({
             : err instanceof Error
               ? err.message
               : String(err);
-        fail(message);
+        fail(message, err);
       }
     };
 

--- a/packages/js-sdk/src/react/ReactorController.tsx
+++ b/packages/js-sdk/src/react/ReactorController.tsx
@@ -2,6 +2,7 @@
 
 import { useReactor, useReactorInternalMessage } from "./hooks";
 import { FileRef } from "../core/FileRef";
+import { NotReadyError } from "../types";
 import React, { useState, useCallback, useRef } from "react";
 
 export interface ReactorControllerProps {
@@ -216,7 +217,20 @@ export function ReactorController({
         }
       });
 
-      await sendCommand(commandName, data);
+      try {
+        await sendCommand(commandName, data);
+      } catch (err) {
+        // Race between the button click and the session flipping away
+        // from "ready" — the new typed `NotReadyError` lets us swallow
+        // it quietly instead of bubbling an unhandled rejection.
+        if (err instanceof NotReadyError) {
+          console.warn(
+            `[ReactorController] Skipped "${commandName}": ${err.message}`
+          );
+          return;
+        }
+        throw err;
+      }
     },
     [sendCommand, commands]
   );

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -126,7 +126,19 @@ export function ReactorProvider({
   const { autoConnect = false, ...pollingOptions } = connectOptions ?? {};
 
   const { apiUrl, modelName, local } = props;
-  const maxAttempts = pollingOptions.maxAttempts;
+
+  // `autoConnect` is a startup hint and `maxAttempts` is a polling
+  // knob — neither should trigger a session teardown when it changes
+  // mid-flight.  Reading the latest value via refs at effect-run time
+  // means a parent component that flips `autoConnect={false → true}`
+  // or tweaks `maxAttempts` won't tear the live session down just to
+  // pick up the new value.
+  const autoConnectRef = useRef(autoConnect);
+  const pollingOptionsRef = useRef(pollingOptions);
+  useEffect(() => {
+    autoConnectRef.current = autoConnect;
+    pollingOptionsRef.current = pollingOptions;
+  });
 
   // Handle page unload (refresh, close, navigate away) with non-recoverable disconnect
   useEffect(() => {
@@ -153,7 +165,7 @@ export function ReactorProvider({
       // We know as a fact that the store is not undefined at this point
       const current = storeRef.current!;
       if (
-        autoConnect &&
+        autoConnectRef.current &&
         current.getState().status === "disconnected" &&
         jwtSource
       ) {
@@ -162,7 +174,7 @@ export function ReactorProvider({
         );
         current
           .getState()
-          .connect(jwtSource, pollingOptions)
+          .connect(jwtSource, pollingOptionsRef.current)
           .then(() => {
             console.debug(
               "[ReactorProvider] Autoconnect successful in first render"
@@ -216,14 +228,14 @@ export function ReactorProvider({
     );
 
     if (
-      autoConnect &&
+      autoConnectRef.current &&
       current.getState().status === "disconnected" &&
       jwtSource
     ) {
       console.debug("[ReactorProvider] Starting autoconnect...");
       current
         .getState()
-        .connect(jwtSource, pollingOptions)
+        .connect(jwtSource, pollingOptionsRef.current)
         .then(() => {
           console.debug("[ReactorProvider] Autoconnect successful");
         })
@@ -247,7 +259,7 @@ export function ReactorProvider({
         });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]);
+  }, [apiUrl, modelName, local, jwtSource]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -25,7 +25,17 @@ export interface ReactorViewProps {
   videoObjectFit?: NonNullable<
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
-  /** Controls whether inbound audio plays. Default true (muted) to satisfy browser autoplay policies. */
+  /**
+   * Controls whether inbound audio plays.
+   *
+   * Defaults to `true` (muted) when no `audioTrack` is set so the
+   * `<video>` element is allowed to autoplay without a user gesture.
+   * Defaults to `false` (audible) the moment `audioTrack` is supplied
+   * — opting into audio is a strong signal the consumer actually
+   * wants to hear it; mute autoplay on top would silently break the
+   * common audio-model demo on first run.  Pass an explicit value to
+   * override either default.
+   */
   muted?: boolean;
 }
 
@@ -37,7 +47,7 @@ export function ReactorView({
   className,
   style,
   videoObjectFit = "contain",
-  muted = true,
+  muted = audioTrack === undefined,
 }: ReactorViewProps) {
   const { videoMediaTrack, audioMediaTrack } = useReactor((state) => ({
     videoMediaTrack: state.tracks[track] ?? null,

--- a/packages/js-sdk/src/react/hooks.ts
+++ b/packages/js-sdk/src/react/hooks.ts
@@ -1,8 +1,9 @@
 import { useReactorStore } from "./ReactorProvider";
 import type { ReactorStore } from "../core/store";
-import type { ConnectionStats } from "../types";
+import type { ConnectionStats, ReactorError } from "../types";
+import type { Clip, DownloadClipOptions } from "../utils/recording";
 import { useShallow } from "zustand/shallow";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Generic hook for accessing selected parts of the Reactor store.
@@ -98,4 +99,107 @@ export function useStats(): ConnectionStats | undefined {
   }, [reactor]);
 
   return stats;
+}
+
+/**
+ * Hook for receiving {@link ReactorError} events from the underlying
+ * Reactor as they happen — the push counterpart of
+ * `useReactor((s) => s.lastError)`.
+ *
+ * Use this when you need to react to every error (e.g. fire a toast,
+ * send telemetry) rather than just render the most recent one.  Same
+ * stable-handler-via-ref idiom as {@link useReactorMessage}; the
+ * supplied handler doesn't need to be memoised.
+ *
+ * @param handler - Callback invoked with each new {@link ReactorError}.
+ */
+export function useReactorError(handler: (error: ReactorError) => void): void {
+  const reactor = useReactor((state) => state.internal.reactor);
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const stableHandler = (error: ReactorError) => {
+      handlerRef.current(error);
+    };
+
+    reactor.on("error", stableHandler);
+
+    return () => {
+      reactor.off("error", stableHandler);
+    };
+  }, [reactor]);
+}
+
+/**
+ * Hook that returns the live `MediaStreamTrack` for a named recvonly
+ * track, or `undefined` if the model hasn't published that track yet
+ * (or the session is disconnected).
+ *
+ * Equivalent to `useReactor((s) => s.tracks[name])`, but reads better
+ * at the call site and gives the SDK a single place to evolve track
+ * delivery semantics in the future.
+ *
+ * @example Attach to a custom `<video>` element:
+ * ```tsx
+ * const track = useTrack("main_video");
+ * useEffect(() => {
+ *   if (!videoRef.current || !track) return;
+ *   videoRef.current.srcObject = new MediaStream([track]);
+ * }, [track]);
+ * ```
+ */
+export function useTrack(name: string): MediaStreamTrack | undefined {
+  return useReactor((state) => state.tracks[name]);
+}
+
+/**
+ * Bundle of the three imperative recording actions —
+ * `requestClip`, `requestRecording`, `downloadClipAsFile` — typed
+ * against the underlying {@link Reactor} so consumers don't have to
+ * thread `internal.reactor` through every clip-capture hook they
+ * write.
+ *
+ * The returned object identity is stable across renders for as long
+ * as the underlying Reactor instance is — safe to drop into
+ * `useEffect` / `useCallback` dep arrays without re-running the
+ * effect on every render.
+ *
+ * @example Capture a clip on demand and immediately download it:
+ * ```tsx
+ * const { requestClip, downloadClipAsFile } = useReactorRecording();
+ *
+ * const snap = useCallback(async () => {
+ *   const clip = await requestClip(30);
+ *   await downloadClipAsFile(clip, `snap-${Date.now()}.mp4`);
+ * }, [requestClip, downloadClipAsFile]);
+ * ```
+ */
+export interface ReactorRecording {
+  /** See {@link Reactor.requestClip}. */
+  requestClip: (durationSeconds: number) => Promise<Clip>;
+  /** See {@link Reactor.requestRecording}. */
+  requestRecording: () => Promise<Clip>;
+  /** See {@link Reactor.downloadClipAsFile}. */
+  downloadClipAsFile: (
+    clip: Clip,
+    filename?: string | null,
+    options?: DownloadClipOptions
+  ) => Promise<Blob>;
+}
+
+export function useReactorRecording(): ReactorRecording {
+  const reactor = useReactor((state) => state.internal.reactor);
+  return useMemo<ReactorRecording>(
+    () => ({
+      requestClip: (durationSeconds) => reactor.requestClip(durationSeconds),
+      requestRecording: () => reactor.requestRecording(),
+      downloadClipAsFile: (clip, filename, options) =>
+        reactor.downloadClipAsFile(clip, filename, options),
+    }),
+    [reactor]
+  );
 }

--- a/packages/js-sdk/src/react/useClipDownload.ts
+++ b/packages/js-sdk/src/react/useClipDownload.ts
@@ -18,13 +18,15 @@ import {
  *   segments) — useful for a progress bar.  ``total`` is 0 until the
  *   manifest is parsed and the chunk count is known.
  * - ``error``: most recent attempt failed; the ``message`` is suitable
- *   for surfacing inline.  ``RecordingError`` instances are formatted
- *   as ``"<CODE>: <reason>"`` for grep-ability.
+ *   for surfacing inline (``RecordingError`` instances are formatted
+ *   as ``"<CODE>: <reason>"`` for grep-ability), and ``error`` carries
+ *   the original thrown value so callers can ``instanceof
+ *   RecordingError`` it and branch on the typed ``code``.
  */
 export type ClipDownloadState =
   | { kind: "idle" }
   | { kind: "downloading"; fetched: number; total: number }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; error: unknown };
 
 export interface UseClipDownloadOptions {
   /**
@@ -160,7 +162,7 @@ export function useClipDownload(
           : err instanceof Error
             ? err.message
             : String(err);
-      setState({ kind: "error", message });
+      setState({ kind: "error", message, error: err });
       return undefined;
     } finally {
       inFlightRef.current = false;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -42,6 +42,44 @@ export class AbortError extends Error {
   }
 }
 
+/**
+ * Thrown when an imperative method is called on a {@link Reactor}
+ * (or the store action that wraps it) before the session is
+ * `"ready"`. Carries the observed {@link ReactorStatus} so callers
+ * can render the actual state instead of a generic "not ready".
+ *
+ * Affects `sendCommand`, `publishTrack`, `unpublishTrack`, and
+ * `uploadFile`. Recording requests (`requestClip`,
+ * `requestRecording`) still reject with their own
+ * `RecordingError("DISCONNECTED", …)` to keep the recording error
+ * union self-contained.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await reactor.sendCommand("set_prompt", { prompt });
+ * } catch (err) {
+ *   if (err instanceof NotReadyError) {
+ *     console.warn(`Session not ready yet (status=${err.status})`);
+ *     return;
+ *   }
+ *   throw err;
+ * }
+ * ```
+ */
+export class NotReadyError extends Error {
+  readonly code = "NOT_READY" as const;
+  constructor(
+    public readonly operation: string,
+    public readonly status: ReactorStatus
+  ) {
+    super(
+      `Cannot ${operation}: session status is "${status}" (expected "ready")`
+    );
+    this.name = "NotReadyError";
+  }
+}
+
 /** Matches both our custom AbortError and the native DOMException thrown by fetch(). */
 export function isAbortError(error: unknown): boolean {
   return (


### PR DESCRIPTION
## Why

The base SDK has been collecting small DX paper-cuts that have made it harder for new consumers to find the right path, and that keep popping up in code review of the consumer apps (`test-frontend`, `reactor-webapp`, `public-demos`). Each one was small enough to live with on its own, so they ended up clustering. This PR is the cleanup pass.

The four highest-impact ones, from a recent walk through the SDK:

1. **The README disagrees with the code in several places.** It documents `reactor.getMediaStream("main_video")` (no such method anywhere in the codebase), `reactor.on("statusChange", …)` (the real event name is `"statusChanged"` and a typo silently never fires because `eventListeners` is a string-keyed `Map`), and a `jwtToken` field on the `Reactor` constructor that's actually stripped by `OptionsSchema` in `Reactor.ts` — the subsequent `connect()` then throws `"No authentication provided and not in local mode"` several steps away from the actual mistake. It also teaches `const { uploadFile, sendCommand } = useReactor((s) => s);`, which re-renders the component on every track update / status flip / error.

2. **The `sendCommand` "not ready" guard is split between dev and prod in the worst possible way.** In `Reactor.ts:142`:

    ```ts
    if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
      const errorMessage = `Cannot send message, status is ${this.status}`;
      console.warn("[Reactor]", errorMessage);
      return;
    }
    ```

    In dev: the guard is bypassed entirely, so `sendCommand` runs even while `status === "connecting"`. In prod: the guard fires, but it just warns and resolves the returned promise with `undefined`. The caller's `await` looks like it worked — there's no thrown error and no way to differentiate "command dropped" from "command sent". `publishTrack` had the same pattern; `uploadFile` did throw, but only a bare `Error` consumers can't `instanceof`-narrow.

3. **The React surface forces every consumer to write the same 5-line wrappers.** Subscribing to `reactor.on("error", …)` for toasts (the boilerplate in `WebcamStream.tsx:154-172`), reading a named track (`useReactor(s => s.tracks[name])` written across every demo), and calling the three recording-imperative methods through `internal.reactor` — none of these have a hook, so each demo invents one.

4. **The clip components have no way to lift events up.** `<ClipDownloadButton>` exposes its download state only through the button's label; to fire a toast on success or send a Sentry breadcrumb on failure you have to drop the component and rebuild the same logic around `useClipDownload`. `<ClipPlayer>` is the same — fatal errors paint an inline overlay with no callback path out.

Two smaller things came along for the ride: `<ReactorView muted>` defaulted to `true` even when an `audioTrack` was explicitly supplied (silently muting the first run of any audio-bearing model demo), and `<ReactorProvider>`'s big `useEffect` rebuilt the entire store on any of `[apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]` — half of which (`autoConnect`, `maxAttempts`) have nothing to do with session identity.

## What this changes

**README.** The imperative example now uses `"statusChanged"`, drops the bogus `jwtToken` constructor field (auth goes through `connect()`), and replaces the imaginary `getMediaStream` with the real `"trackReceived"` event. The React snippets either select narrow slices or use the new hooks. The recording section now shows `useReactorRecording()` instead of reaching through `internal.reactor`.

**Typed `NotReadyError`.** Added next to the existing `ConflictError` / `AbortError` in `types.ts`. Carries the observed `ReactorStatus`, a `code: "NOT_READY"` literal, and the originating `operation` so error UIs can surface the actual state instead of a generic "not ready". `sendCommand`, `publishTrack`, and `uploadFile` in `Reactor.ts` all now throw it on any non-`"ready"` status — the NODE_ENV branch is gone. `unpublishTrack` stays the way it was (no throw): teardown paths legitimately need to be callable while the transport is already closing. `<ReactorController>` catches the new error around its button-driven `sendCommand` call so the race between a click and a status flip doesn't surface as an unhandled rejection.

**New React hooks** in `react/hooks.ts`, mirroring the existing `useReactorMessage` / `useStats` shape:

- `useReactorError(handler)` — push counterpart of `useReactor((s) => s.lastError)`; fires on every error event so consumers can wire Sonner/Sentry/etc. without writing the manual subscribe-effect that's currently duplicated in `WebcamStream`.
- `useTrack(name)` — thin alias for `useReactor((s) => s.tracks[name])`.
- `useReactorRecording()` — bundles `requestClip` / `requestRecording` / `downloadClipAsFile`, identity-stable across renders so it's safe to drop into `useCallback` dep arrays.

**Clip components.** `<ClipDownloadButton>` now takes `onSuccess(blob, clip)` and `onError(err, clip)` props; the original thrown value is carried through `useClipDownload`'s state machine (`{ kind: "error"; message; error: unknown }`) so callers can `instanceof RecordingError` and branch on the typed `code`. The hook's callbacks are stable-via-ref so an inline `onSuccess={…}` doesn't cause double-fires. `<ClipPlayer>` gets `onReady(clip)` and `onError({ message, cause }, clip)` — `cause` is the underlying `RecordingError` / `hls.js` data / fetch error so the lifted error path stays typed.

**`<ReactorView>` muted default** flips from `true` to `audioTrack === undefined`. Same autoplay-policy compliance on the no-audio path; audible by default when the consumer explicitly asked for audio.

**`<ReactorProvider>` effect deps** narrowed to `[apiUrl, modelName, local, jwtSource]`. `autoConnect` and `connectOptions.maxAttempts` are read via refs at effect-run time — flipping either no longer tears the live session down. The existing `getJwt` ref idiom (added in the JWT-resolver PR) already covered the inline-resolver identity-churn case; this extends the same treatment to the other knobs.

## API surface

Three new hooks, exported from `@reactor-team/js-sdk`:

```ts
function useReactorError(handler: (error: ReactorError) => void): void;
function useTrack(name: string): MediaStreamTrack | undefined;
function useReactorRecording(): {
  requestClip: (durationSeconds: number) => Promise<Clip>;
  requestRecording: () => Promise<Clip>;
  downloadClipAsFile: (
    clip: Clip,
    filename?: string | null,
    options?: DownloadClipOptions
  ) => Promise<Blob>;
};
```

How it feels:

```tsx
function MyApp() {
  useReactorError((err) => toast.error(err.message));

  const videoTrack = useTrack("main_video");
  const { requestClip, downloadClipAsFile } = useReactorRecording();

  const snap = async () => {
    const clip = await requestClip(30);
    await downloadClipAsFile(clip, `snap-${Date.now()}.mp4`);
  };
  ...
}
```

`NotReadyError` is exported as part of the existing `types` re-export:

```ts
import { NotReadyError } from "@reactor-team/js-sdk";

try {
  await sendCommand("set_prompt", { prompt });
} catch (err) {
  if (err instanceof NotReadyError) {
    console.warn(`Session not ready (status=${err.status})`);
    return;
  }
  throw err;
}
```

Clip components with callbacks:

```tsx
<ClipDownloadButton
  clip={clip}
  onSuccess={(blob, clip) => toast.success(`Saved ${blob.size} bytes`)}
  onError={(err) => {
    if (err instanceof RecordingError && err.code === "CLIP_GONE") {
      toast.error("Clip expired — re-capture and try again");
      return;
    }
    Sentry.captureException(err);
  }}
/>

<ClipPlayer
  clip={clip}
  onReady={() => setShowSpinner(false)}
  onError={({ message, cause }) => {
    setShowSpinner(false);
    toast.error(message);
    Sentry.captureException(cause);
  }}
/>
```

`useClipDownload`'s `state` shape grows one field — `error: unknown` on the `"error"` variant — so the existing `state.message` callers keep working unchanged. Pre-existing destructures like `if (state.kind === "error") return state.message` are unaffected.

## Verification

- `pnpm -F @reactor-team/js-sdk test` — 371 tests pass (8 new in `__tests__/unit/reactor-not-ready.test.ts` covering every `NotReadyError` path, plus the existing `sendCommand` / `publishTrack` "warns when not ready" tests rewritten to assert the new throw shape).
- `pnpm -F @reactor-team/js-sdk build` — clean, `dist/index.d.ts` exposes the three new hooks, `NotReadyError`, the new `onSuccess` / `onError` / `onReady` props, and the updated `ClipDownloadState`.
- `pnpm format:check` — clean.
- Patch version bump to `2.11.1` lives in a separate commit at the tip of the branch so the release commit is reviewable in isolation.

### Deferred

A few items came up during the wider audit that aren't in this PR — open as follow-ups so this stays focused:

- A `WebcamStream` overhaul to publish microphone alongside the webcam and expose `onPermissionDenied` / `onPublished` callbacks.
- Typed `Reactor.on` / `Reactor.emit` payloads (mapped types per `ReactorEvent`).
- Splitting `RecordingError`'s `"INTERNAL_ERROR"` into `MALFORMED_PAYLOAD` (terminal) vs `RUNTIME_ERROR` (transient) so consumer retry policies stop relying on an allowlist.
- `lastError` clearing on `connect()` — deliberately left out of this PR.
