### PR TITLE
Polish js-sdk React surface for live audio, clip callbacks, and ready guard

### DIFF
--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -112,7 +112,7 @@ For video-to-video models, drop `<WebcamStream>` inside the provider and name th
 
 ### Receive messages
 
-Models emit structured messages back to your app, such as progress updates, state snapshots, or custom model events. Subscribe with `useReactorMessage`:
+Models emit structured messages back to your app, such as progress updates, state snapshots, or custom model events. Subscribe with `useReactorMessage`. Select store fields one at a time so a component only re-renders when something it actually uses changes — passing `(s) => s` will rerender on every track frame, status flip, and error:
 
 ```tsx
 import { useReactorMessage } from "@reactor-team/js-sdk";
@@ -135,7 +135,10 @@ function FrameCounter() {
 Bind an `<input type="file">` to the model with `uploadFile` and then pass the returned [`FileRef`](https://docs.reactor.inc/api-reference/types#fileref) into any command:
 
 ```tsx
-const { uploadFile, sendCommand } = useReactor((s) => s);
+const { uploadFile, sendCommand } = useReactor((s) => ({
+  uploadFile: s.uploadFile,
+  sendCommand: s.sendCommand,
+}));
 
 const ref = await uploadFile(file);
 await sendCommand("set_image", { image: ref });
@@ -153,18 +156,17 @@ import { Reactor } from "@reactor-team/js-sdk";
 const reactor = new Reactor({
   apiUrl: "https://api.reactor.inc",
   modelName: "your-model-name",
-  jwtToken: await fetchJwt(),
 });
 
-reactor.on("statusChange", (status) => console.log("status:", status));
+reactor.on("statusChanged", (status) => console.log("status:", status));
 reactor.on("message", (msg) => console.log("model:", msg));
+reactor.on("trackReceived", (name, _track, stream) => {
+  if (name === "main_video") videoEl.srcObject = stream;
+});
 
-await reactor.connect();
+await reactor.connect(await fetchJwt());
 
 await reactor.sendCommand("set_prompt", { prompt: "a forest at dawn" });
-
-const stream = reactor.getMediaStream("main_video");
-videoEl.srcObject = stream;
 ```
 
 ---

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
-import { NotReadyError } from "../../src/types";
 
 const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
 
@@ -319,29 +318,39 @@ describe("Reactor", () => {
   // ── sendCommand() guard ───────────────────────────────────────────────
 
   describe("sendCommand()", () => {
-    it("throws NotReadyError when not ready", async () => {
+    it("resolves (does not reject) when not ready", async () => {
       const r = new Reactor({ modelName: "echo" });
 
       await expect(
         r.sendCommand("set_effect", { effect: "grayscale" })
-      ).rejects.toMatchObject({
-        name: "NotReadyError",
-        operation: 'send command "set_effect"',
-        status: "disconnected",
-      });
+      ).resolves.toBeUndefined();
     });
 
-    it("throws NotReadyError carrying the operation and live status", async () => {
+    it("populates lastError with a recoverable NOT_READY entry when not ready", async () => {
       const r = new Reactor({ modelName: "echo" });
-      try {
-        await r.sendCommand("set_effect", { effect: "grayscale" });
-        expect.fail("sendCommand should have thrown");
-      } catch (err) {
-        expect(err).toBeInstanceOf(NotReadyError);
-        const e = err as NotReadyError;
-        expect(e.status).toBe("disconnected");
-        expect(e.operation).toBe('send command "set_effect"');
-      }
+
+      await r.sendCommand("set_effect", { effect: "grayscale" });
+
+      expect(r.getLastError()).toMatchObject({
+        code: "NOT_READY",
+        component: "api",
+        recoverable: true,
+      });
+      expect(r.getLastError()?.message).toContain('"set_effect"');
+      expect(r.getLastError()?.message).toContain('"disconnected"');
+    });
+
+    it("emits an `error` event subscribers can react to when not ready", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      const handler = vi.fn();
+      r.on("error", handler);
+
+      await r.sendCommand("set_effect", { effect: "grayscale" });
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "NOT_READY", recoverable: true })
+      );
     });
   });
 

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Reactor, DEFAULT_BASE_URL } from "../../src/core/Reactor";
+import { NotReadyError } from "../../src/types";
 
 const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
 
@@ -318,16 +319,29 @@ describe("Reactor", () => {
   // ── sendCommand() guard ───────────────────────────────────────────────
 
   describe("sendCommand()", () => {
-    it("warns and returns when not ready", async () => {
+    it("throws NotReadyError when not ready", async () => {
       const r = new Reactor({ modelName: "echo" });
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await r.sendCommand("set_effect", { effect: "grayscale" });
+      await expect(
+        r.sendCommand("set_effect", { effect: "grayscale" })
+      ).rejects.toMatchObject({
+        name: "NotReadyError",
+        operation: 'send command "set_effect"',
+        status: "disconnected",
+      });
+    });
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[Reactor]",
-        expect.stringContaining("Cannot send message")
-      );
+    it("throws NotReadyError carrying the operation and live status", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      try {
+        await r.sendCommand("set_effect", { effect: "grayscale" });
+        expect.fail("sendCommand should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotReadyError);
+        const e = err as NotReadyError;
+        expect(e.status).toBe("disconnected");
+        expect(e.operation).toBe('send command "set_effect"');
+      }
     });
   });
 

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -7,6 +7,7 @@ import {
   type ConnectOptions,
   type ConnectionStats,
   type ConnectionTimings,
+  NotReadyError,
   isAbortError,
 } from "../types";
 import { type JwtResolver, type JwtSource, normalizeJwtSource } from "./auth";
@@ -139,10 +140,8 @@ export class Reactor {
     data: any,
     scope: MessageScope = "application"
   ): Promise<void> {
-    if (process.env.NODE_ENV !== "development" && this.status !== "ready") {
-      const errorMessage = `Cannot send message, status is ${this.status}`;
-      console.warn("[Reactor]", errorMessage);
-      return;
+    if (this.status !== "ready") {
+      throw new NotReadyError(`send command "${command}"`, this.status);
     }
 
     try {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -7,7 +7,6 @@ import {
   type ConnectOptions,
   type ConnectionStats,
   type ConnectionTimings,
-  NotReadyError,
   isAbortError,
 } from "../types";
 import { type JwtResolver, type JwtSource, normalizeJwtSource } from "./auth";
@@ -140,8 +139,24 @@ export class Reactor {
     data: any,
     scope: MessageScope = "application"
   ): Promise<void> {
+    // Pre-flight: a command sent before the transport is `"ready"`
+    // can't go on the wire. We surface this through the same
+    // `lastError` / `"error"` event channel as transport-side
+    // failures (`MESSAGE_SEND_FAILED`, `TRACK_PUBLISH_FAILED`, …)
+    // rather than rejecting the Promise — most call sites are
+    // unawaited React event handlers, and routing through `lastError`
+    // lets `useReactor(s => s.lastError)` paint the failure without
+    // forcing every caller into a `try/catch`.  The error is
+    // recoverable: re-issuing the command once `status` flips back
+    // to `"ready"` is the correct retry.
     if (this.status !== "ready") {
-      throw new NotReadyError(`send command "${command}"`, this.status);
+      this.createError(
+        "NOT_READY",
+        `Cannot send command "${command}" while status is "${this.status}". Must be "ready".`,
+        "api",
+        true
+      );
+      return;
     }
 
     try {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -139,16 +139,8 @@ export class Reactor {
     data: any,
     scope: MessageScope = "application"
   ): Promise<void> {
-    // Pre-flight: a command sent before the transport is `"ready"`
-    // can't go on the wire. We surface this through the same
-    // `lastError` / `"error"` event channel as transport-side
-    // failures (`MESSAGE_SEND_FAILED`, `TRACK_PUBLISH_FAILED`, …)
-    // rather than rejecting the Promise — most call sites are
-    // unawaited React event handlers, and routing through `lastError`
-    // lets `useReactor(s => s.lastError)` paint the failure without
-    // forcing every caller into a `try/catch`.  The error is
-    // recoverable: re-issuing the command once `status` flips back
-    // to `"ready"` is the correct retry.
+    // Pre-flight failure: reported through `lastError` so unawaited
+    // callers observe it without a `try/catch`.
     if (this.status !== "ready") {
       this.createError(
         "NOT_READY",

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -63,18 +63,13 @@ export interface ClipDownloadButtonProps {
   /** Forwarded to the underlying ``<button>``.  ORed with the internal "downloading" state. */
   disabled?: boolean;
   /**
-   * Fires once the download completes successfully with the
-   * assembled MP4 ``Blob``.  Typical use is to drop a toast or
-   * mark the clip as saved — re-uploading the blob, generating a
-   * ``URL.createObjectURL``, etc. is also fair game.
+   * Fires when the download completes with the assembled MP4 ``Blob``.
    */
   onSuccess?: (blob: Blob) => void;
   /**
-   * Fires when the download fails.  Receives a plain ``Error``
-   * whose message mirrors the inline state shown in the button
-   * (``"<CODE>: <reason>"`` for ``RecordingError``s).  Use this to
-   * forward failures into Sentry / Sonner / a parent component
-   * instead of relying on the in-button ``title`` tooltip.
+   * Fires when the download fails.  Message mirrors the in-button
+   * state — ``"<CODE>: <reason>"`` for ``RecordingError``s, the
+   * plain error message otherwise.
    */
   onError?: (error: Error) => void;
 }
@@ -94,9 +89,8 @@ export function ClipDownloadButton({
   const downloading = state.kind === "downloading";
   const isDisabled = downloading || !!disabled;
 
-  // Latest-value refs so callback identity churn doesn't re-fire the
-  // error effect or re-create the click handler on every parent
-  // render — same idiom used in `ClipPlayer` / `useClipDownload`.
+  // Held in refs so inline callback identity doesn't churn the
+  // error-emit effect or the click handler on every parent render.
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
   useEffect(() => {
@@ -104,12 +98,9 @@ export function ClipDownloadButton({
     onErrorRef.current = onError;
   });
 
-  // Drive `onError` from the underlying state machine. `download()`
-  // resolves to `undefined` on failure (the hook surfaces errors via
-  // state, not by rejecting), so we hook the state transition into
-  // the error callback rather than the click handler. Re-running on
-  // every state change is intentional: a retry → error → retry →
-  // error cycle should call `onError` each time.
+  // `useClipDownload.download()` resolves to `undefined` on failure
+  // (the hook surfaces errors through state, not by rejecting).
+  // Each retry that lands back in `"error"` re-fires `onError`.
   useEffect(() => {
     if (state.kind === "error") {
       onErrorRef.current?.(new Error(state.message));

--- a/packages/js-sdk/src/react/ClipDownloadButton.tsx
+++ b/packages/js-sdk/src/react/ClipDownloadButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import type { Clip } from "../utils/recording";
 import { useClipDownload, type ClipDownloadState } from "./useClipDownload";
 
@@ -62,6 +62,21 @@ export interface ClipDownloadButtonProps {
   style?: React.CSSProperties;
   /** Forwarded to the underlying ``<button>``.  ORed with the internal "downloading" state. */
   disabled?: boolean;
+  /**
+   * Fires once the download completes successfully with the
+   * assembled MP4 ``Blob``.  Typical use is to drop a toast or
+   * mark the clip as saved — re-uploading the blob, generating a
+   * ``URL.createObjectURL``, etc. is also fair game.
+   */
+  onSuccess?: (blob: Blob) => void;
+  /**
+   * Fires when the download fails.  Receives a plain ``Error``
+   * whose message mirrors the inline state shown in the button
+   * (``"<CODE>: <reason>"`` for ``RecordingError``s).  Use this to
+   * forward failures into Sentry / Sonner / a parent component
+   * instead of relying on the in-button ``title`` tooltip.
+   */
+  onError?: (error: Error) => void;
 }
 
 export function ClipDownloadButton({
@@ -72,10 +87,34 @@ export function ClipDownloadButton({
   className,
   style,
   disabled,
+  onSuccess,
+  onError,
 }: ClipDownloadButtonProps) {
   const { state, download } = useClipDownload(clip, { filename, getJwt });
   const downloading = state.kind === "downloading";
   const isDisabled = downloading || !!disabled;
+
+  // Latest-value refs so callback identity churn doesn't re-fire the
+  // error effect or re-create the click handler on every parent
+  // render — same idiom used in `ClipPlayer` / `useClipDownload`.
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  });
+
+  // Drive `onError` from the underlying state machine. `download()`
+  // resolves to `undefined` on failure (the hook surfaces errors via
+  // state, not by rejecting), so we hook the state transition into
+  // the error callback rather than the click handler. Re-running on
+  // every state change is intentional: a retry → error → retry →
+  // error cycle should call `onError` each time.
+  useEffect(() => {
+    if (state.kind === "error") {
+      onErrorRef.current?.(new Error(state.message));
+    }
+  }, [state]);
 
   const content =
     typeof children === "function"
@@ -88,7 +127,9 @@ export function ClipDownloadButton({
     <button
       type="button"
       onClick={() => {
-        void download();
+        void download().then((blob) => {
+          if (blob) onSuccessRef.current?.(blob);
+        });
       }}
       disabled={isDisabled}
       title={state.kind === "error" ? state.message : undefined}

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -94,12 +94,10 @@ export interface ClipPlayerProps {
   className?: string;
   style?: React.CSSProperties;
   /**
-   * Fires when the player surfaces its inline error overlay.
-   * Receives the originating error (a ``RecordingError`` for
-   * manifest-fetch failures, a generic ``Error`` for hls.js / native
-   * playback failures and missing-peer-dep cases) so the consumer
-   * can forward it into Sentry / Sonner / etc. without parsing the
-   * overlay string.
+   * Fires when the player enters its inline error state.  Receives
+   * the originating error: a ``RecordingError`` for manifest-fetch
+   * failures, a plain ``Error`` for hls.js / native playback or
+   * missing-peer-dep cases.
    */
   onError?: (error: Error) => void;
 }
@@ -151,10 +149,8 @@ export function ClipPlayer({
     storeRef.current = store;
   });
 
-  // Surface phase transitions into `error` to the consumer.  Fires
-  // once per error — each subsequent `clip` change resets the phase
-  // back through `waiting`/`loading` before potentially re-entering
-  // `error`, at which point this fires again.
+  // Re-fires per error transition: each new `clip` resets through
+  // `waiting` / `loading` before potentially re-entering `error`.
   useEffect(() => {
     if (phase.kind === "error") {
       onErrorRef.current?.(phase.error);

--- a/packages/js-sdk/src/react/ClipPlayer.tsx
+++ b/packages/js-sdk/src/react/ClipPlayer.tsx
@@ -93,13 +93,22 @@ export interface ClipPlayerProps {
   muted?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Fires when the player surfaces its inline error overlay.
+   * Receives the originating error (a ``RecordingError`` for
+   * manifest-fetch failures, a generic ``Error`` for hls.js / native
+   * playback failures and missing-peer-dep cases) so the consumer
+   * can forward it into Sentry / Sonner / etc. without parsing the
+   * overlay string.
+   */
+  onError?: (error: Error) => void;
 }
 
 type Phase =
   | { kind: "waiting" }
   | { kind: "loading" }
   | { kind: "ready" }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; error: Error };
 
 export function ClipPlayer({
   clip,
@@ -109,6 +118,7 @@ export function ClipPlayer({
   muted = true,
   className,
   style,
+  onError,
 }: ClipPlayerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
@@ -128,6 +138,7 @@ export function ClipPlayer({
   const getJwtRef = useRef(getJwt);
   const autoPlayRef = useRef(autoPlay);
   const slackMsRef = useRef(slackMs);
+  const onErrorRef = useRef(onError);
   // Same ref pattern: the resolver is looked up inside `setup` at
   // request time, so a provider swap is picked up on next attach
   // without tearing the player down.
@@ -136,8 +147,19 @@ export function ClipPlayer({
     getJwtRef.current = getJwt;
     autoPlayRef.current = autoPlay;
     slackMsRef.current = slackMs;
+    onErrorRef.current = onError;
     storeRef.current = store;
   });
+
+  // Surface phase transitions into `error` to the consumer.  Fires
+  // once per error — each subsequent `clip` change resets the phase
+  // back through `waiting`/`loading` before potentially re-entering
+  // `error`, at which point this fires again.
+  useEffect(() => {
+    if (phase.kind === "error") {
+      onErrorRef.current?.(phase.error);
+    }
+  }, [phase]);
 
   // Playback pipeline: fetch manifest (with optional JWT) → wrap in
   // blob URL → attach via native HLS (Safari) or hls.js (everyone
@@ -152,9 +174,13 @@ export function ClipPlayer({
     let hlsInstance: { destroy: () => void } | null = null;
     let manifestBlobUrl: string | null = null;
 
-    const fail = (message: string) => {
+    const fail = (error: Error) => {
       if (cancelled) return;
-      setPhase({ kind: "error", message });
+      const message =
+        error instanceof RecordingError
+          ? `${error.code}: ${error.reason}`
+          : error.message;
+      setPhase({ kind: "error", message, error });
     };
 
     const attachPlayer = async (manifestUrl: string) => {
@@ -182,13 +208,17 @@ export function ClipPlayer({
         HlsCtor = mod.default;
       } catch {
         fail(
-          "HLS playback unavailable in this browser. Install `hls.js` as a peer dependency, or use Download."
+          new Error(
+            "HLS playback unavailable in this browser. Install `hls.js` as a peer dependency, or use Download."
+          )
         );
         return;
       }
       if (cancelled) return;
       if (!HlsCtor.isSupported()) {
-        fail("This browser cannot play HLS clips. Use Download instead.");
+        fail(
+          new Error("This browser cannot play HLS clips. Use Download instead.")
+        );
         return;
       }
       const hls = new HlsCtor();
@@ -211,7 +241,7 @@ export function ClipPlayer({
         // `levelLoadError`) that the user-facing overlay would
         // otherwise hide.  Fatal errors still hard-fail the player.
         if (data.fatal) {
-          fail(`Playback error: ${data.details ?? "unknown"}`);
+          fail(new Error(`Playback error: ${data.details ?? "unknown"}`));
           return;
         }
         console.warn("[Reactor.ClipPlayer] hls.js non-fatal error", data);
@@ -247,13 +277,7 @@ export function ClipPlayer({
         if (err instanceof DOMException && err.name === "AbortError") {
           return;
         }
-        const message =
-          err instanceof RecordingError
-            ? `${err.code}: ${err.reason}`
-            : err instanceof Error
-              ? err.message
-              : String(err);
-        fail(message);
+        fail(err instanceof Error ? err : new Error(String(err)));
       }
     };
 

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -246,13 +246,10 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
-    // Only the "what session are we talking to" inputs tear the
-    // store down: target Coordinator (`apiUrl`), model selection
-    // (`modelName`), local-mode flag, and auth source. `autoConnect`
-    // is read for the first-mount decision but flipping it later
-    // shouldn't kill an existing session; `maxAttempts` is just
-    // initial-handshake polling config and has no meaning after
-    // connect — both intentionally omitted from the dep array.
+    // `autoConnect` is a first-mount-only signal and `maxAttempts`
+    // is initial-handshake polling config; neither identifies the
+    // session, so they're intentionally out of the deps to stop
+    // mid-mount prop changes from tearing the live session down.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, modelName, local, jwtSource]);
 

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -246,8 +246,15 @@ export function ReactorProvider({
           console.error("[ReactorProvider] Failed to disconnect:", error);
         });
     };
+    // Only the "what session are we talking to" inputs tear the
+    // store down: target Coordinator (`apiUrl`), model selection
+    // (`modelName`), local-mode flag, and auth source. `autoConnect`
+    // is read for the first-mount decision but flipping it later
+    // shouldn't kill an existing session; `maxAttempts` is just
+    // initial-handshake polling config and has no meaning after
+    // connect — both intentionally omitted from the dep array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]);
+  }, [apiUrl, modelName, local, jwtSource]);
 
   return (
     <ReactorContext.Provider value={storeRef.current}>

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -25,7 +25,15 @@ export interface ReactorViewProps {
   videoObjectFit?: NonNullable<
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
-  /** Controls whether inbound audio plays. Default true (muted) to satisfy browser autoplay policies. */
+  /**
+   * Controls whether inbound audio plays.  Defaults to `true`
+   * (muted) when no `audioTrack` is configured — there's no audio
+   * to surface and `muted` keeps the underlying `<video>` element
+   * within browser autoplay policies.  Defaults to `false` when
+   * `audioTrack` is set, because the consumer asking for audio
+   * almost always wants it audible.  Pass an explicit value to
+   * override either default.
+   */
   muted?: boolean;
 }
 
@@ -37,7 +45,7 @@ export function ReactorView({
   className,
   style,
   videoObjectFit = "contain",
-  muted = true,
+  muted = audioTrack === undefined,
 }: ReactorViewProps) {
   const { videoMediaTrack, audioMediaTrack } = useReactor((state) => ({
     videoMediaTrack: state.tracks[track] ?? null,

--- a/packages/js-sdk/src/react/ReactorView.tsx
+++ b/packages/js-sdk/src/react/ReactorView.tsx
@@ -26,12 +26,10 @@ export interface ReactorViewProps {
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
   /**
-   * Controls whether inbound audio plays.  Defaults to `true`
-   * (muted) when no `audioTrack` is configured — there's no audio
-   * to surface and `muted` keeps the underlying `<video>` element
-   * within browser autoplay policies.  Defaults to `false` when
-   * `audioTrack` is set, because the consumer asking for audio
-   * almost always wants it audible.  Pass an explicit value to
+   * Controls whether inbound audio plays.  Default is `true`
+   * (muted) when no `audioTrack` is set — keeps the underlying
+   * `<video>` element within browser autoplay policies; `false`
+   * when an `audioTrack` is set.  Pass an explicit value to
    * override either default.
    */
   muted?: boolean;

--- a/packages/js-sdk/src/react/WebcamStream.tsx
+++ b/packages/js-sdk/src/react/WebcamStream.tsx
@@ -22,8 +22,7 @@ export interface WebcamStreamProps {
   /**
    * The name of the sendonly **audio** track to publish the mic to.
    * Ignored when {@link audio} is `false` (the default); required
-   * otherwise — without it the mic stream has nowhere to go and the
-   * component logs a warning instead of publishing.
+   * otherwise.
    */
   audioTrack?: string;
   className?: string;
@@ -34,25 +33,20 @@ export interface WebcamStreamProps {
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
   /**
-   * Fires once `getUserMedia` is rejected with `NotAllowedError` /
-   * `PermissionDeniedError`.  Use this to render a custom
-   * permission-denied UI instead of (or alongside) the inline
-   * placeholder this component already shows.
+   * Fires once `getUserMedia` is rejected with `NotAllowedError`
+   * or `PermissionDeniedError`.
    */
   onPermissionDenied?: () => void;
   /**
-   * Fires after the local media stream has been published to the
-   * Reactor session (both video and audio when {@link audio} is
-   * enabled).  Re-fires after a reconnect, so consumers can use it
-   * to toggle a "live" indicator without tracking status themselves.
+   * Fires after the local media stream has been published (both
+   * video and audio when {@link audio} is enabled).  Re-fires
+   * after a reconnect.
    */
   onPublished?: () => void;
   /**
-   * Fires when a non-permission `getUserMedia` failure or a
-   * publish/unpublish call throws — i.e. the cases the component
-   * currently logs to `console.error` and otherwise swallows.
-   * Permission denials are routed to {@link onPermissionDenied}
-   * instead.
+   * Fires on non-permission `getUserMedia` failures and on
+   * publish / unpublish rejections.  Permission denials route to
+   * {@link onPermissionDenied} instead.
    */
   onError?: (error: Error) => void;
 }
@@ -86,9 +80,8 @@ export function WebcamStream({
 
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  // Latest-value refs so the callbacks can be invoked from inside
-  // long-lived effects without dragging their identity into the dep
-  // arrays — same pattern used by `useClipDownload` / `ClipPlayer`.
+  // Held in refs so inline callback identity doesn't churn the
+  // publish/unpublish effect on every parent render.
   const onPermissionDeniedRef = useRef(onPermissionDenied);
   const onPublishedRef = useRef(onPublished);
   const onErrorRef = useRef(onError);
@@ -98,10 +91,8 @@ export function WebcamStream({
     onErrorRef.current = onError;
   });
 
-  // Audio is on iff the consumer asked for it AND told us where to
-  // publish. Without an `audioTrack` the captured audio stream has
-  // nowhere to go, so we capture video-only and surface a warning —
-  // a silent demotion would be a worse footgun.
+  // Without an `audioTrack` the captured mic has nowhere to publish;
+  // warn rather than silently capturing video-only.
   const audioRequested = audio !== false && audio !== undefined;
   const audioEnabled = audioRequested && !!audioTrack;
   if (audioRequested && !audioTrack) {
@@ -143,10 +134,9 @@ export function WebcamStream({
   const stopWebcam = async () => {
     console.debug("[WebcamPublisher] Stopping webcam");
 
-    // Unpublish video + (optional) audio in parallel; either failure
-    // is logged but doesn't block the local-track teardown below
-    // because the underlying `MediaStreamTrack`s must always stop or
-    // the camera/mic indicator stays on after the component unmounts.
+    // Unpublish failures are logged but don't block local-track
+    // teardown — leaving tracks running keeps the camera/mic
+    // indicator on after unmount.
     const unpublishTasks: Array<Promise<void>> = [unpublish(track)];
     if (audioEnabled && audioTrack) {
       unpublishTasks.push(unpublish(audioTrack));
@@ -196,11 +186,7 @@ export function WebcamStream({
     }
   }, [stream]);
 
-  // Auto-publish when reactor is ready and webcam is active. Video
-  // and audio (when enabled) publish in parallel and `onPublished`
-  // fires once both have succeeded; a single failure surfaces via
-  // `onError` and leaves `isPublishing` at false so the next status
-  // tick can retry.
+  // Auto-publish when reactor is ready and webcam is active.
   useEffect(() => {
     if (!stream) {
       return;

--- a/packages/js-sdk/src/react/WebcamStream.tsx
+++ b/packages/js-sdk/src/react/WebcamStream.tsx
@@ -6,11 +6,26 @@ import React from "react";
 
 export interface WebcamStreamProps {
   /**
-   * The name of the sendonly track to publish the webcam to.
+   * The name of the sendonly **video** track to publish the webcam to.
    * Must match a track name declared in the server capabilities.
    * Check the model's documentation for available track names.
    */
   track: string;
+  /**
+   * Capture and publish the microphone alongside the webcam.  Pass
+   * `true` for default constraints, or an explicit
+   * `MediaTrackConstraints` to control sample rate / device / echo
+   * cancellation.  Requires {@link audioTrack} so the SDK knows
+   * which sendonly track to publish the mic to.  Default `false`.
+   */
+  audio?: boolean | MediaTrackConstraints;
+  /**
+   * The name of the sendonly **audio** track to publish the mic to.
+   * Ignored when {@link audio} is `false` (the default); required
+   * otherwise — without it the mic stream has nowhere to go and the
+   * component logs a warning instead of publishing.
+   */
+  audioTrack?: string;
   className?: string;
   style?: React.CSSProperties;
   videoConstraints?: MediaTrackConstraints;
@@ -18,10 +33,34 @@ export interface WebcamStreamProps {
   videoObjectFit?: NonNullable<
     React.VideoHTMLAttributes<HTMLVideoElement>["style"]
   >["objectFit"];
+  /**
+   * Fires once `getUserMedia` is rejected with `NotAllowedError` /
+   * `PermissionDeniedError`.  Use this to render a custom
+   * permission-denied UI instead of (or alongside) the inline
+   * placeholder this component already shows.
+   */
+  onPermissionDenied?: () => void;
+  /**
+   * Fires after the local media stream has been published to the
+   * Reactor session (both video and audio when {@link audio} is
+   * enabled).  Re-fires after a reconnect, so consumers can use it
+   * to toggle a "live" indicator without tracking status themselves.
+   */
+  onPublished?: () => void;
+  /**
+   * Fires when a non-permission `getUserMedia` failure or a
+   * publish/unpublish call throws — i.e. the cases the component
+   * currently logs to `console.error` and otherwise swallows.
+   * Permission denials are routed to {@link onPermissionDenied}
+   * instead.
+   */
+  onError?: (error: Error) => void;
 }
 
 export function WebcamStream({
   track,
+  audio = false,
+  audioTrack,
   className,
   style,
   videoConstraints = {
@@ -30,6 +69,9 @@ export function WebcamStream({
   },
   showWebcam = true,
   videoObjectFit = "contain",
+  onPermissionDenied,
+  onPublished,
+  onError,
 }: WebcamStreamProps) {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
@@ -44,14 +86,37 @@ export function WebcamStream({
 
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  // Start webcam
+  // Latest-value refs so the callbacks can be invoked from inside
+  // long-lived effects without dragging their identity into the dep
+  // arrays — same pattern used by `useClipDownload` / `ClipPlayer`.
+  const onPermissionDeniedRef = useRef(onPermissionDenied);
+  const onPublishedRef = useRef(onPublished);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onPermissionDeniedRef.current = onPermissionDenied;
+    onPublishedRef.current = onPublished;
+    onErrorRef.current = onError;
+  });
+
+  // Audio is on iff the consumer asked for it AND told us where to
+  // publish. Without an `audioTrack` the captured audio stream has
+  // nowhere to go, so we capture video-only and surface a warning —
+  // a silent demotion would be a worse footgun.
+  const audioRequested = audio !== false && audio !== undefined;
+  const audioEnabled = audioRequested && !!audioTrack;
+  if (audioRequested && !audioTrack) {
+    console.warn(
+      "[WebcamStream] `audio` was set but `audioTrack` is missing; capturing video-only."
+    );
+  }
+
   const startWebcam = async () => {
     console.debug("[WebcamPublisher] Starting webcam");
 
     try {
       const mediaStream = await navigator.mediaDevices.getUserMedia({
         video: videoConstraints,
-        audio: false,
+        audio: audioEnabled ? (audio === true ? true : audio) : false,
       });
 
       console.debug("[WebcamPublisher] Webcam started successfully");
@@ -60,32 +125,47 @@ export function WebcamStream({
     } catch (err) {
       console.error("[WebcamPublisher] Failed to start webcam:", err);
 
-      // Check if the error is a permission denial
       if (
         err instanceof DOMException &&
         (err.name === "NotAllowedError" || err.name === "PermissionDeniedError")
       ) {
         console.debug("[WebcamPublisher] Camera permission denied");
         setPermissionDenied(true);
+        onPermissionDeniedRef.current?.();
+      } else {
+        onErrorRef.current?.(
+          err instanceof Error ? err : new Error(String(err))
+        );
       }
     }
   };
 
-  // Stop webcam
   const stopWebcam = async () => {
     console.debug("[WebcamPublisher] Stopping webcam");
 
-    // Unpublish if currently publishing
-    try {
-      await unpublish(track);
-      console.debug("[WebcamPublisher] Unpublished before stopping");
-    } catch (err) {
-      console.error("[WebcamPublisher] Error unpublishing before stop:", err);
+    // Unpublish video + (optional) audio in parallel; either failure
+    // is logged but doesn't block the local-track teardown below
+    // because the underlying `MediaStreamTrack`s must always stop or
+    // the camera/mic indicator stays on after the component unmounts.
+    const unpublishTasks: Array<Promise<void>> = [unpublish(track)];
+    if (audioEnabled && audioTrack) {
+      unpublishTasks.push(unpublish(audioTrack));
+    }
+    const results = await Promise.allSettled(unpublishTasks);
+    for (const r of results) {
+      if (r.status === "rejected") {
+        console.error(
+          "[WebcamPublisher] Error unpublishing before stop:",
+          r.reason
+        );
+        onErrorRef.current?.(
+          r.reason instanceof Error ? r.reason : new Error(String(r.reason))
+        );
+      }
     }
 
     setIsPublishing(false);
 
-    // Stop all tracks
     stream?.getTracks().forEach((t) => {
       t.stop();
       console.debug("[WebcamPublisher] Stopped track:", t.kind);
@@ -116,7 +196,11 @@ export function WebcamStream({
     }
   }, [stream]);
 
-  // Auto-publish when reactor is ready and webcam is active
+  // Auto-publish when reactor is ready and webcam is active. Video
+  // and audio (when enabled) publish in parallel and `onPublished`
+  // fires once both have succeeded; a single failure surfaces via
+  // `onError` and leaves `isPublishing` at false so the next status
+  // tick can retry.
   useEffect(() => {
     if (!stream) {
       return;
@@ -126,29 +210,52 @@ export function WebcamStream({
       console.debug(
         "[WebcamPublisher] Reactor ready, auto-publishing webcam stream"
       );
-      const videoTrack = stream.getVideoTracks()[0];
-      if (videoTrack) {
-        publish(track, videoTrack)
-          .then(() => {
-            console.debug("[WebcamPublisher] Auto-publish successful");
-            setIsPublishing(true);
-          })
-          .catch((err) => {
-            console.error("[WebcamPublisher] Auto-publish failed:", err);
-          });
-      }
-    } else if (status !== "ready" && isPublishing) {
-      console.debug("[WebcamPublisher] Reactor not ready, auto-unpublishing");
-      unpublish(track)
+      const videoMediaTrack = stream.getVideoTracks()[0];
+      const audioMediaTrack =
+        audioEnabled && audioTrack ? stream.getAudioTracks()[0] : null;
+      const tasks: Array<Promise<void>> = [];
+      if (videoMediaTrack) tasks.push(publish(track, videoMediaTrack));
+      if (audioMediaTrack && audioTrack)
+        tasks.push(publish(audioTrack, audioMediaTrack));
+      if (tasks.length === 0) return;
+      Promise.all(tasks)
         .then(() => {
-          console.debug("[WebcamPublisher] Auto-unpublish successful");
-          setIsPublishing(false);
+          console.debug("[WebcamPublisher] Auto-publish successful");
+          setIsPublishing(true);
+          onPublishedRef.current?.();
         })
         .catch((err) => {
-          console.error("[WebcamPublisher] Auto-unpublish failed:", err);
+          console.error("[WebcamPublisher] Auto-publish failed:", err);
+          onErrorRef.current?.(
+            err instanceof Error ? err : new Error(String(err))
+          );
         });
+    } else if (status !== "ready" && isPublishing) {
+      console.debug("[WebcamPublisher] Reactor not ready, auto-unpublishing");
+      const tasks: Array<Promise<void>> = [unpublish(track)];
+      if (audioEnabled && audioTrack) tasks.push(unpublish(audioTrack));
+      Promise.allSettled(tasks).then((results) => {
+        for (const r of results) {
+          if (r.status === "rejected") {
+            console.error("[WebcamPublisher] Auto-unpublish failed:", r.reason);
+            onErrorRef.current?.(
+              r.reason instanceof Error ? r.reason : new Error(String(r.reason))
+            );
+          }
+        }
+        setIsPublishing(false);
+      });
     }
-  }, [status, stream, isPublishing, publish, unpublish, track]);
+  }, [
+    status,
+    stream,
+    isPublishing,
+    publish,
+    unpublish,
+    track,
+    audioEnabled,
+    audioTrack,
+  ]);
 
   // Listen for error events from Reactor
   useEffect(() => {

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -42,6 +42,23 @@ export class AbortError extends Error {
   }
 }
 
+/**
+ * Thrown by operations that require an active `"ready"` session when
+ * the Reactor is in any other state — e.g. calling `sendCommand`
+ * while `status === "connecting"`.  Carries the operation that was
+ * attempted and the live status so callers can branch (typically:
+ * disable a button, show a spinner, queue the action for later).
+ */
+export class NotReadyError extends Error {
+  constructor(
+    public readonly operation: string,
+    public readonly status: ReactorStatus
+  ) {
+    super(`Cannot ${operation} while status is "${status}". Must be "ready".`);
+    this.name = "NotReadyError";
+  }
+}
+
 /** Matches both our custom AbortError and the native DOMException thrown by fetch(). */
 export function isAbortError(error: unknown): boolean {
   return (

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -42,23 +42,6 @@ export class AbortError extends Error {
   }
 }
 
-/**
- * Thrown by operations that require an active `"ready"` session when
- * the Reactor is in any other state — e.g. calling `sendCommand`
- * while `status === "connecting"`.  Carries the operation that was
- * attempted and the live status so callers can branch (typically:
- * disable a button, show a spinner, queue the action for later).
- */
-export class NotReadyError extends Error {
-  constructor(
-    public readonly operation: string,
-    public readonly status: ReactorStatus
-  ) {
-    super(`Cannot ${operation} while status is "${status}". Must be "ready".`);
-    this.name = "NotReadyError";
-  }
-}
-
 /** Matches both our custom AbortError and the native DOMException thrown by fetch(). */
 export function isAbortError(error: unknown): boolean {
   return (


### PR DESCRIPTION
## Why

A recent DX audit of `@reactor-team/js-sdk` against three consumer codebases — `test-frontend`, the `reactor-webapp` sandbox, and `public-demos/session-recorder` — surfaced a cluster of overlapping footguns in the React surface. None of them is fatal on its own, but they keep biting new consumers in the same way: an audio-bearing model that ships silent, a clip download you can't wire a toast to without forking the component, a `sendCommand` that silently no-ops in production but not in development. Six are addressed here. They belong in one PR because three share an identical implementation idiom (latest-value refs for inline callback identity) and several share the same review question — "what counts as session input?". The remaining audit items (`lastError` clearing semantics, missing convenience hooks, typed event payloads, the `disconnect(recoverable)` rename) are deferred to follow-up PRs.

The specific problems on `main` today:

**Inverted ready guard on `Reactor.sendCommand`.** The guard in `Reactor.ts` reads `process.env.NODE_ENV !== "development" && this.status !== "ready"` — so in production it silently warns and returns when the session isn't ready, and in development it bypasses the check entirely. A command issued during `"connecting"` therefore "works" in dev and silently no-ops in prod — the worst possible split.

**`<ReactorView>` mutes model audio by default.** The default is `muted: true` even when the consumer explicitly opts into model audio via `audioTrack`. Every audio-bearing demo launches silent and requires a second prop to hear anything.

**`<WebcamStream>` is hard-coded to `audio: false`** in `getUserMedia`. Any voice-conditioned model has to fork the component just to publish the microphone.

**Clip components surface errors only through internal state** — the button via the `<button>`'s `title` tooltip, the player via an inline overlay. There's no way to fire a Sonner toast, route into Sentry, or otherwise react to a failure from outside the component without rebuilding it.

**`<ReactorProvider>`'s effect dep array is too wide.** It includes `autoConnect` and `maxAttempts`, neither of which has any meaning after the initial handshake — but a mid-mount change to either tears the whole session down.

**The published `README.md` has four broken snippets**: `reactor.getMediaStream(…)` doesn't exist, `reactor.on("statusChange", …)` is a typo for `"statusChanged"` (silently never fires), `new Reactor({ …, jwtToken })` has Zod silently strip the field and the follow-up `connect()` then throw "No authentication provided", and a `useReactor((s) => s)` destructure re-renders the component on every state change.

## What this changes

The README sweep ships as its own commit on top of the branch so it stays reviewable as a doc-only change. The behaviour changes all live downstream of it, grouped by the surface they touch.

### `sendCommand` failures flow through `lastError`, not a Promise rejection

In `Reactor.ts`, `sendCommand`'s `NODE_ENV`-conditioned branch is gone — the guard is now consistent across environments. When `status !== "ready"`, the method invokes the same `createError(code, message, component, recoverable)` helper that the rest of the class already uses for transport-side failures like `MESSAGE_SEND_FAILED` and `TRACK_PUBLISH_FAILED`. It writes a recoverable entry with `code: "NOT_READY"` into `lastError`, emits the `"error"` event, and resolves to `undefined`.

This keeps `sendCommand` non-throwing — important because most call sites are unawaited React event handlers — and pushes the failure through the channel React consumers already idiomatically subscribe to (`useReactor(s => s.lastError)`). It also means the dev / prod inversion is fixed without breaking ungated `onClick={() => sendCommand(...)}` patterns that previously relied on the silent no-op.

The `reactor.test.ts` "warns and returns when not ready" assertion is replaced with three new ones covering (a) the promise resolves to `undefined`, (b) `getLastError()` carries the `NOT_READY` entry with the operation and status interpolated into its message, (c) the `"error"` event fires exactly once.

### `<ReactorView>` flips `muted` to follow `audioTrack`

The default changes from a hard-coded `true` to `audioTrack === undefined`. Video-only models stay muted by default (preserves browser autoplay compliance), and audio models become audible the moment a consumer asks for audio — no second prop needed. Consumers who want to override either default still pass `muted` explicitly.

### `<WebcamStream>` gains microphone capture and lifecycle callbacks

The component grows two media props — `audio?: boolean | MediaTrackConstraints` and `audioTrack?: string` — and three callbacks: `onPermissionDenied`, `onPublished`, and `onError`. `getUserMedia` is upgraded in place to accept the audio constraint. The auto-publish effect now drives `publish(track, videoMediaTrack)` and `publish(audioTrack, audioMediaTrack)` in parallel via `Promise.all`, and `Promise.allSettled` on the unpublish side so a failure on one track doesn't strand the other on the sender. The callbacks live behind latest-value refs — the same idiom already used by `useClipDownload` and `ClipPlayer` — so an inline `onError={(e) => …}` doesn't churn the publish effect on every parent render.

### Clip components expose typed callbacks

`<ClipDownloadButton>` gains `onSuccess(blob)` driven off the `useClipDownload.download()` return value, and `onError(error)` driven off the hook's `state.kind === "error"` transition. Repeated failures in a retry loop fire `onError` each time, matching the existing state machine.

`<ClipPlayer>` gains `onError(error)` plus a small internal change: the playback `Phase` state now keeps the original `Error` object (previously the catch site collapsed it into a string for the overlay). `RecordingError` instances from `fetchPlaylist` therefore reach `onError` with their `code` and `reason` intact; `hls.js` failures and missing-peer-dep cases reach it as a plain `Error` with a descriptive message.

### `<ReactorProvider>` narrows what counts as "session input"

The effect dep array drops from `[apiUrl, modelName, autoConnect, local, jwtSource, maxAttempts]` to `[apiUrl, modelName, local, jwtSource]`. `autoConnect` only drives the first-mount decision, and `maxAttempts` is initial-handshake polling config — both intentionally omitted, with a comment in the file explaining the reasoning so the next reader doesn't put them back.

## API surface

Four new prop blocks on existing components. No new exported types, no removals, no renames — every existing call site keeps working.

```ts
// ReactorView — change in default, not in signature
muted?: boolean; // default is now `audioTrack === undefined`

// WebcamStream
audio?: boolean | MediaTrackConstraints;
audioTrack?: string;
onPermissionDenied?: () => void;
onPublished?: () => void;
onError?: (error: Error) => void;

// ClipDownloadButton
onSuccess?: (blob: Blob) => void;
onError?: (error: Error) => void;

// ClipPlayer
onError?: (error: Error) => void;
```

How the new ready guard feels at the call site — same channel React consumers already use for transport failures:

```tsx
const { sendCommand, lastError } = useReactor((s) => ({
  sendCommand: s.sendCommand,
  lastError: s.lastError,
}));

return (
  <>
    <button onClick={() => sendCommand("set_prompt", { prompt })}>
      Set
    </button>
    {lastError?.code === "NOT_READY" && (
      <p>Hang on — still connecting…</p>
    )}
  </>
);
```

A voice-conditioned `<WebcamStream>` that routes failures into a toast / Sentry:

```tsx
<WebcamStream
  track="webcam"
  audioTrack="microphone"
  audio={{ echoCancellation: true, noiseSuppression: true }}
  onPermissionDenied={() => toast.error("Mic / camera access required")}
  onPublished={() => toast.success("Live")}
  onError={(err) => Sentry.captureException(err)}
/>
```

A clip surface that integrates with toasts and error reporting without forking the components:

```tsx
<ClipDownloadButton
  clip={clip}
  filename={`snap-${Date.now()}.mp4`}
  onSuccess={() => toast.success("Saved to Downloads")}
  onError={(err) => toast.error(err.message)}
/>

<ClipPlayer clip={clip} onError={(err) => Sentry.captureException(err)} />
```

## Verification

- `pnpm -F @reactor-team/js-sdk test` — **365 passed, 12 skipped**. One prior `"warns and returns when not ready"` assertion removed; three new `sendCommand` assertions added covering the resolve, the `lastError` shape, and the `"error"` event emission.
- `pnpm -F @reactor-team/js-sdk build` — clean. `dist/index.d.ts` shows the new prop blocks on `WebcamStreamProps`, `ClipDownloadButtonProps`, and `ClipPlayerProps`. No new exported symbols.
- `pnpm format:check` — clean.
- The README sweep is a doc-only first commit; the imperative + recording snippets were checked against the typed API surface before commit.

### Behavioural changes worth flagging

Three observable behaviour changes ship under no public-surface deltas. Each is the *intended* fix for an audit-documented footgun, but each is technically observable by existing consumers:

- `Reactor.sendCommand` now consistently writes `lastError.code = "NOT_READY"` and emits the `"error"` event when called before `"ready"`, in both dev and prod. Previously: dev bypassed the check entirely, prod silently warned and returned. The promise still resolves to `undefined` either way, so unawaited `onClick={() => sendCommand(...)}` patterns aren't broken — they now just have an observable error trail.
- `<ReactorView audioTrack="main_audio" />` (without an explicit `muted` prop) now plays audio. Previously: silent.
- `<ReactorProvider>` no longer rebuilds the store on `autoConnect` / `maxAttempts` prop changes. Previously: mid-mount changes to either tore the session down. Almost certainly nobody depended on this.

### Not included on purpose

- **No version bump.** PR #182 already claims `2.11.1`. These two should ship together — the maintainer can either land #184 as `2.11.2` or fold them at merge time.
- **The `useReactor((s) => s.internal.reactor); reactor.requestClip(10)` block** in `README.md` (around line 192) is not touched here. It's still correct on `main`; it goes stale only after #182 lands, so that PR owns the update.
