### PR TITLE
[REA-2535] Bump examples to @reactor-team/js-sdk ^2.11.1 and adopt new patterns

### DIFF
--- a/examples/helios/app/components/SnapClip.tsx
+++ b/examples/helios/app/components/SnapClip.tsx
@@ -31,6 +31,15 @@ import {
 // clip UI renders through a portal outside the provider subtree (e.g.
 // a Sonner toast living in `app/layout.tsx`) — capture the resolver
 // with `reactor.getJwtResolver()` at action time and thread it down.
+//
+// As of `@reactor-team/js-sdk` ≥ 2.11.1, `requestClip` /
+// `requestRecording` / `downloadClipAsFile` are exposed directly on
+// the React store, so the recording surface is reachable via
+// `useReactor((s) => s.requestClip)` without the `s.internal.reactor`
+// escape hatch. The clip components also accept `onError` / `onSuccess`
+// callbacks — this panel routes both player and download failures
+// into its inline error line, and clears that line when a download
+// completes.
 export interface SnapClipProps {
   /** Length of the snap, in seconds. Default 10. */
   durationSeconds?: number;
@@ -48,9 +57,9 @@ export function SnapClip({
   filename,
   label,
 }: SnapClipProps) {
-  const { status, reactor } = useReactor((s) => ({
+  const { status, requestClip } = useReactor((s) => ({
     status: s.status,
-    reactor: s.internal.reactor,
+    requestClip: s.requestClip,
   }));
 
   const [clip, setClip] = useState<Clip | null>(null);
@@ -64,7 +73,7 @@ export function SnapClip({
     setBusy(true);
     setError(null);
     try {
-      const c = await reactor.requestClip(durationSeconds);
+      const c = await requestClip(durationSeconds);
       setClip(c);
     } catch (e) {
       setError(
@@ -101,6 +110,8 @@ export function SnapClip({
           clip={clip}
           filename={downloadName}
           onClose={() => setClip(null)}
+          onError={(e) => setError(e.message)}
+          onDownloaded={() => setError(null)}
         />
       )}
     </div>
@@ -111,10 +122,14 @@ function ClipModal({
   clip,
   filename,
   onClose,
+  onError,
+  onDownloaded,
 }: {
   clip: Clip;
   filename: string;
   onClose: () => void;
+  onError: (error: Error) => void;
+  onDownloaded: () => void;
 }) {
   return (
     <div
@@ -139,11 +154,17 @@ function ClipModal({
 
         <ClipPlayer
           clip={clip}
+          onError={onError}
           className="w-full overflow-hidden rounded-lg border border-zinc-800"
         />
 
         <div className="flex justify-end">
-          <ClipDownloadButton clip={clip} filename={filename} />
+          <ClipDownloadButton
+            clip={clip}
+            filename={filename}
+            onSuccess={onDownloaded}
+            onError={onError}
+          />
         </div>
       </div>
     </div>

--- a/examples/helios/package.json
+++ b/examples/helios/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@reactor-models/helios": "^0.9.0",
-    "@reactor-team/js-sdk": "^2.10.1",
+    "@reactor-team/js-sdk": "^2.11.1",
     "@reactor-team/ui": "^1.4.1",
     "hls.js": "^1.6.0",
     "next": "^15.5.0",

--- a/examples/helios/pnpm-lock.yaml
+++ b/examples/helios/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       '@reactor-team/js-sdk':
-        specifier: ^2.10.1
-        version: 2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
+        specifier: ^2.11.1
+        version: 2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       '@reactor-team/ui':
         specifier: ^1.4.1
         version: 1.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -270,8 +270,8 @@ packages:
     peerDependencies:
       react: '>=18'
 
-  '@reactor-team/js-sdk@2.10.1':
-    resolution: {integrity: sha512-X0OO8Wc+oaubvCj08FuwnN9CT8JZLxtokz0liLBSefjOgpV5kb/cE+8Y4XQpXEBSExGfBpu9uaauvOCIWjE5EA==}
+  '@reactor-team/js-sdk@2.11.1':
+    resolution: {integrity: sha512-KbGsE6FHz4cJdlpSSQ0Y6sfitymoJcltM1kWr6tDk6R/gofBHVayLECia6aYE5X1RSlWlciw1D9ZlD5Q0wxsng==}
     engines: {node: '>=18'}
     peerDependencies:
       hls.js: ^1.6.0
@@ -764,13 +764,13 @@ snapshots:
 
   '@reactor-models/helios@0.9.0(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@reactor-team/js-sdk': 2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
+      '@reactor-team/js-sdk': 2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
     transitivePeerDependencies:
       - hls.js
       - zustand
 
-  '@reactor-team/js-sdk@2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
+  '@reactor-team/js-sdk@2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       mp4box: 2.3.0
       react: 19.2.6

--- a/examples/helios/skill/SKILL.md
+++ b/examples/helios/skill/SKILL.md
@@ -493,7 +493,7 @@ If you build a new control that mutates the live scene (e.g. a slider for image 
 
 The Reactor base SDK exposes a recording surface that works for every model: ask for the last N seconds of the live stream, get back a `Clip`, and either preview it with `<ClipPlayer>` or download it with `<ClipDownloadButton>`. The model SDK does not own this — it lives on `@reactor-team/js-sdk` because it is the same call for Helios, Lingbot, and every future model with recording enabled.
 
-The example ships a drop-in [`app/components/SnapClip.tsx`](../app/components/SnapClip.tsx) panel that wires this together: a "Capture" button that calls `reactor.requestClip(durationSeconds)`, opens a modal with the SDK's preview player, and offers an MP4 download. It is **model-agnostic** — the same file ships unchanged in every example.
+The example ships a drop-in [`app/components/SnapClip.tsx`](../app/components/SnapClip.tsx) panel that wires this together: a "Capture" button that calls `requestClip(durationSeconds)` off the store, opens a modal with the SDK's preview player, and offers an MP4 download. It is **model-agnostic** — the same file ships unchanged in every example.
 
 ### When to reach for `@reactor-team/js-sdk` directly
 
@@ -515,10 +515,10 @@ When you scaffold a new component, ask: "Does this depend on Helios-specific eve
 
 `SnapClip` is small enough to read in one go. The shape that matters:
 
-1. **Pull the live `Reactor` instance off the store.** `useReactor((s) => s.internal.reactor)` is the canonical accessor — it works inside `<HeliosProvider>` because that provider wraps `<ReactorProvider>` internally.
+1. **Destructure the recording action off the store.** `useReactor((s) => s.requestClip)` is the canonical accessor as of `@reactor-team/js-sdk` ≥ 2.11.1 — `requestClip`, `requestRecording`, and `downloadClipAsFile` are first-class actions alongside `connect` / `disconnect` / `uploadFile`. No `s.internal.reactor` indirection.
 2. **Gate on connection status.** `useReactor((s) => s.status)` — return `null` when status is not `"ready"`, so the panel disappears on disconnect just like every other live-only control.
 3. **Catch `RecordingError`.** Recording can fail with typed reasons (`DISCONNECTED`, `RECORDER_DISABLED`, `INVALID_DURATION`, `REQUEST_TIMEOUT`). Surface them inline like `CommandError` does.
-4. **Compose `<ClipPlayer>` + `<ClipDownloadButton>` in a modal.** Both accept the same `clip` prop. The SDK's components stay usable after `reactor.disconnect()`, so the modal keeps working if the session ends mid-preview.
+4. **Compose `<ClipPlayer>` + `<ClipDownloadButton>` in a modal, route their errors through callbacks.** Both accept `onError` (and `<ClipDownloadButton>` also accepts `onSuccess(blob)`); `SnapClip` threads them into the same inline error line that `requestClip` failures use. The SDK's components stay usable after disconnect, so the modal keeps working if the session ends mid-preview.
 5. **No `getJwt` plumbing.** Both clip components auto-inherit the resolver from `<HeliosProvider getJwt={…}>` via React context (`@reactor-team/js-sdk` ≥ 2.10.1). That is the single source of truth for auth in this app — `SnapClip` doesn't need to know about the JWT route at all.
 
 ### The portal gotcha (Sonner toasts, headless modals)
@@ -535,10 +535,16 @@ Fix: capture the resolver imperatively _inside_ the provider subtree, then threa
 
 ```tsx
 function HandlerInsideProvider() {
-  const reactor = useReactor((s) => s.internal.reactor);
+  // `requestClip` is a top-level store action; `internal.reactor`
+  // stays in the escape-hatch slot for `getJwtResolver()` because
+  // that one isn't lifted onto the store surface.
+  const { requestClip, reactor } = useReactor((s) => ({
+    requestClip: s.requestClip,
+    reactor: s.internal.reactor,
+  }));
 
   const onSnap = async () => {
-    const clip = await reactor.requestClip(30);
+    const clip = await requestClip(30);
 
     // Captured here — works because we're inside the provider.
     // The closure carries it across Sonner's portal boundary.
@@ -565,11 +571,11 @@ For multi-clip galleries, store an array of `Clip` instead of a single one, rend
 
 ### Full-session recordings
 
-`reactor.requestRecording()` (no args) grabs everything from the start of recording up to now, instead of a trailing window. Same `Clip` shape, longer manifest, larger MP4. Swap the call inside `SnapClip` if you want a "Save the whole session" button instead.
+`requestRecording()` (no args, also on the store) grabs everything from the start of recording up to now, instead of a trailing window. Same `Clip` shape, longer manifest, larger MP4. Swap the call inside `SnapClip` if you want a "Save the whole session" button instead.
 
 ### Clips are short-lived
 
-The URL on a `Clip` expires after a few minutes. Do not store `Clip` objects long-term, and do not hand `clip.playlistUrl` to your users for sharing. If you want a permanent link, download the MP4 (via `<ClipDownloadButton>` or `reactor.downloadClipAsFile(clip, null)` for a Blob) and host the result yourself.
+The URL on a `Clip` expires after a few minutes. Do not store `Clip` objects long-term, and do not hand `clip.playlistUrl` to your users for sharing. If you want a permanent link, download the MP4 (via `<ClipDownloadButton>` or `downloadClipAsFile(clip, null)` for a Blob) and host the result yourself.
 
 ### Clip downloads are social-media-ready (`@reactor-team/js-sdk` ≥ 2.10.1)
 
@@ -604,7 +610,7 @@ Reach for actual `@reactor-team/ui` components only when you need their behavior
 
 ## Common mistakes when extending
 
-1. **Reaching for `@reactor-team/js-sdk` directly.** Everything Helios-specific is on `@reactor-models/helios`. If you find yourself wanting `useReactor((s) => s.internal.reactor)` for a Helios event or message, re-read the typed hooks list above. The one allowed exception is the recording surface — see [Capturing clips](#capturing-clips).
+1. **Reaching for `@reactor-team/js-sdk` directly.** Everything Helios-specific is on `@reactor-models/helios`. If you find yourself reaching for `useReactor((s) => s.internal.reactor)` for a Helios event or message, re-read the typed hooks list above. The one allowed exception is the recording surface — see [Capturing clips](#capturing-clips). And on 2.11.1+, even recording is a top-level store action (`s.requestClip` / `s.requestRecording` / `s.downloadClipAsFile`); reach for `s.internal.reactor` only for the few surfaces that aren't lifted yet (`getJwtResolver()`, raw `runtimeMessage` subscriptions).
 2. **Aggregating events to reconstruct state.** Subscribe to `useHeliosState` and read fields off the snapshot. Stop folding `chunk_complete` + `generation_started` + `generation_paused` into your own boolean flags.
 3. **Chaining `setImage + setPrompt + start` instead of using `setConditioning`.** Separate commands can be reordered on the wire — `start` slips past the still-resolving image upload and the first chunk renders with no image conditioning. When both pieces are known up front, use `setConditioning({ prompt, image })` for a single atomic message. Only fall back to `setImage` alone when the prompt arrives later from a different user action (the custom-upload flow).
 4. **Overwriting the prompt on custom-image upload.** `set_image` is a conditioning tweak. Leave the user's prompt alone — let them type one in the textarea if they need to.

--- a/examples/lingbot/app/components/SnapClip.tsx
+++ b/examples/lingbot/app/components/SnapClip.tsx
@@ -25,12 +25,21 @@ import {
 // a new model example.
 //
 // `<ClipPlayer>` and `<ClipDownloadButton>` auto-inherit the JWT
-// resolver from `<HeliosProvider getJwt={…} />` via React context
+// resolver from `<LingbotProvider getJwt={…} />` via React context
 // (`@reactor-team/js-sdk` ≥ 2.10.1). No `getJwt` prop needed here.
 // The one case where you would still pass it explicitly is when the
 // clip UI renders through a portal outside the provider subtree (e.g.
 // a Sonner toast living in `app/layout.tsx`) — capture the resolver
 // with `reactor.getJwtResolver()` at action time and thread it down.
+//
+// As of `@reactor-team/js-sdk` ≥ 2.11.1, `requestClip` /
+// `requestRecording` / `downloadClipAsFile` are exposed directly on
+// the React store, so the recording surface is reachable via
+// `useReactor((s) => s.requestClip)` without the `s.internal.reactor`
+// escape hatch. The clip components also accept `onError` / `onSuccess`
+// callbacks — this panel routes both player and download failures
+// into its inline error line, and clears that line when a download
+// completes.
 export interface SnapClipProps {
   /** Length of the snap, in seconds. Default 10. */
   durationSeconds?: number;
@@ -48,9 +57,9 @@ export function SnapClip({
   filename,
   label,
 }: SnapClipProps) {
-  const { status, reactor } = useReactor((s) => ({
+  const { status, requestClip } = useReactor((s) => ({
     status: s.status,
-    reactor: s.internal.reactor,
+    requestClip: s.requestClip,
   }));
 
   const [clip, setClip] = useState<Clip | null>(null);
@@ -64,7 +73,7 @@ export function SnapClip({
     setBusy(true);
     setError(null);
     try {
-      const c = await reactor.requestClip(durationSeconds);
+      const c = await requestClip(durationSeconds);
       setClip(c);
     } catch (e) {
       setError(
@@ -101,6 +110,8 @@ export function SnapClip({
           clip={clip}
           filename={downloadName}
           onClose={() => setClip(null)}
+          onError={(e) => setError(e.message)}
+          onDownloaded={() => setError(null)}
         />
       )}
     </div>
@@ -111,10 +122,14 @@ function ClipModal({
   clip,
   filename,
   onClose,
+  onError,
+  onDownloaded,
 }: {
   clip: Clip;
   filename: string;
   onClose: () => void;
+  onError: (error: Error) => void;
+  onDownloaded: () => void;
 }) {
   return (
     <div
@@ -139,11 +154,17 @@ function ClipModal({
 
         <ClipPlayer
           clip={clip}
+          onError={onError}
           className="w-full overflow-hidden rounded-lg border border-zinc-800"
         />
 
         <div className="flex justify-end">
-          <ClipDownloadButton clip={clip} filename={filename} />
+          <ClipDownloadButton
+            clip={clip}
+            filename={filename}
+            onSuccess={onDownloaded}
+            onError={onError}
+          />
         </div>
       </div>
     </div>

--- a/examples/lingbot/package.json
+++ b/examples/lingbot/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@reactor-models/lingbot": "latest",
-    "@reactor-team/js-sdk": "^2.10.1",
+    "@reactor-team/js-sdk": "^2.11.1",
     "@reactor-team/ui": "^1.4.1",
     "hls.js": "^1.6.0",
     "next": "^15.5.0",

--- a/examples/lingbot/pnpm-lock.yaml
+++ b/examples/lingbot/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: latest
         version: 0.2.33(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       '@reactor-team/js-sdk':
-        specifier: ^2.10.1
-        version: 2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
+        specifier: ^2.11.1
+        version: 2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       '@reactor-team/ui':
         specifier: ^1.4.1
         version: 1.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -270,8 +270,8 @@ packages:
     peerDependencies:
       react: '>=18'
 
-  '@reactor-team/js-sdk@2.10.1':
-    resolution: {integrity: sha512-X0OO8Wc+oaubvCj08FuwnN9CT8JZLxtokz0liLBSefjOgpV5kb/cE+8Y4XQpXEBSExGfBpu9uaauvOCIWjE5EA==}
+  '@reactor-team/js-sdk@2.11.1':
+    resolution: {integrity: sha512-KbGsE6FHz4cJdlpSSQ0Y6sfitymoJcltM1kWr6tDk6R/gofBHVayLECia6aYE5X1RSlWlciw1D9ZlD5Q0wxsng==}
     engines: {node: '>=18'}
     peerDependencies:
       hls.js: ^1.6.0
@@ -764,13 +764,13 @@ snapshots:
 
   '@reactor-models/lingbot@0.2.33(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
-      '@reactor-team/js-sdk': 2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
+      '@reactor-team/js-sdk': 2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))
       react: 19.2.6
     transitivePeerDependencies:
       - hls.js
       - zustand
 
-  '@reactor-team/js-sdk@2.10.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
+  '@reactor-team/js-sdk@2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       mp4box: 2.3.0
       react: 19.2.6

--- a/examples/lingbot/skill/SKILL.md
+++ b/examples/lingbot/skill/SKILL.md
@@ -518,7 +518,7 @@ The base-prompt capture trick is the reusable bit. Two places it's natural to ex
 
 The Reactor base SDK exposes a recording surface that works for every model: ask for the last N seconds of the live stream, get back a `Clip`, and either preview it with `<ClipPlayer>` or download it with `<ClipDownloadButton>`. The model SDK does not own this — it lives on `@reactor-team/js-sdk` because it is the same call for Lingbot, Helios, and every future model with recording enabled.
 
-The example ships a drop-in [`app/components/SnapClip.tsx`](../app/components/SnapClip.tsx) panel that wires this together: a "Capture" button that calls `reactor.requestClip(durationSeconds)`, opens a modal with the SDK's preview player, and offers an MP4 download. It is **model-agnostic** — the same file ships unchanged in every example.
+The example ships a drop-in [`app/components/SnapClip.tsx`](../app/components/SnapClip.tsx) panel that wires this together: a "Capture" button that calls `requestClip(durationSeconds)` off the store, opens a modal with the SDK's preview player, and offers an MP4 download. It is **model-agnostic** — the same file ships unchanged in every example.
 
 ### When to reach for `@reactor-team/js-sdk` directly
 
@@ -540,10 +540,10 @@ When you scaffold a new component, ask: "Does this depend on Lingbot-specific ev
 
 `SnapClip` is small enough to read in one go. The shape that matters:
 
-1. **Pull the live `Reactor` instance off the store.** `useReactor((s) => s.internal.reactor)` is the canonical accessor — it works inside `<LingbotProvider>` because that provider wraps `<ReactorProvider>` internally.
+1. **Destructure the recording action off the store.** `useReactor((s) => s.requestClip)` is the canonical accessor as of `@reactor-team/js-sdk` ≥ 2.11.1 — `requestClip`, `requestRecording`, and `downloadClipAsFile` are first-class actions alongside `connect` / `disconnect` / `uploadFile`. No `s.internal.reactor` indirection.
 2. **Gate on connection status.** `useReactor((s) => s.status)` — return `null` when status is not `"ready"`, so the panel disappears on disconnect just like every other live-only control.
 3. **Catch `RecordingError`.** Recording can fail with typed reasons (`DISCONNECTED`, `RECORDER_DISABLED`, `INVALID_DURATION`, `REQUEST_TIMEOUT`). Surface them inline like `CommandError` does.
-4. **Compose `<ClipPlayer>` + `<ClipDownloadButton>` in a modal.** Both accept the same `clip` prop. The SDK's components stay usable after `reactor.disconnect()`, so the modal keeps working if the session ends mid-preview.
+4. **Compose `<ClipPlayer>` + `<ClipDownloadButton>` in a modal, route their errors through callbacks.** Both accept `onError` (and `<ClipDownloadButton>` also accepts `onSuccess(blob)`); `SnapClip` threads them into the same inline error line that `requestClip` failures use. The SDK's components stay usable after disconnect, so the modal keeps working if the session ends mid-preview.
 5. **No `getJwt` plumbing.** Both clip components auto-inherit the resolver from `<LingbotProvider getJwt={…}>` via React context (`@reactor-team/js-sdk` ≥ 2.10.1). That is the single source of truth for auth in this app — `SnapClip` doesn't need to know about the JWT route at all.
 
 ### The portal gotcha (Sonner toasts, headless modals)
@@ -560,10 +560,16 @@ Fix: capture the resolver imperatively _inside_ the provider subtree, then threa
 
 ```tsx
 function HandlerInsideProvider() {
-  const reactor = useReactor((s) => s.internal.reactor);
+  // `requestClip` is a top-level store action; `internal.reactor`
+  // stays in the escape-hatch slot for `getJwtResolver()` because
+  // that one isn't lifted onto the store surface.
+  const { requestClip, reactor } = useReactor((s) => ({
+    requestClip: s.requestClip,
+    reactor: s.internal.reactor,
+  }));
 
   const onSnap = async () => {
-    const clip = await reactor.requestClip(30);
+    const clip = await requestClip(30);
 
     // Captured here — works because we're inside the provider.
     // The closure carries it across Sonner's portal boundary.
@@ -590,11 +596,11 @@ For multi-clip galleries, store an array of `Clip` instead of a single one, rend
 
 ### Full-session recordings
 
-`reactor.requestRecording()` (no args) grabs everything from the start of recording up to now, instead of a trailing window. Same `Clip` shape, longer manifest, larger MP4. Swap the call inside `SnapClip` if you want a "Save the whole session" button instead.
+`requestRecording()` (no args, also on the store) grabs everything from the start of recording up to now, instead of a trailing window. Same `Clip` shape, longer manifest, larger MP4. Swap the call inside `SnapClip` if you want a "Save the whole session" button instead.
 
 ### Clips are short-lived
 
-The URL on a `Clip` expires after a few minutes. Do not store `Clip` objects long-term, and do not hand `clip.playlistUrl` to your users for sharing. If you want a permanent link, download the MP4 (via `<ClipDownloadButton>` or `reactor.downloadClipAsFile(clip, null)` for a Blob) and host the result yourself.
+The URL on a `Clip` expires after a few minutes. Do not store `Clip` objects long-term, and do not hand `clip.playlistUrl` to your users for sharing. If you want a permanent link, download the MP4 (via `<ClipDownloadButton>` or `downloadClipAsFile(clip, null)` for a Blob) and host the result yourself.
 
 ### Clip downloads are social-media-ready (`@reactor-team/js-sdk` ≥ 2.10.1)
 
@@ -629,7 +635,7 @@ Reach for actual `@reactor-team/ui` components only when you need their behavior
 
 ## Common mistakes when extending
 
-1. **Reaching for `@reactor-team/js-sdk` directly.** Everything Lingbot-specific is on `@reactor-models/lingbot`. If you find yourself wanting `useReactor((s) => s.internal.reactor)` for a Lingbot event or message, re-read the typed hooks list above. The one allowed exception is the recording surface — see [Capturing clips](#capturing-clips).
+1. **Reaching for `@reactor-team/js-sdk` directly.** Everything Lingbot-specific is on `@reactor-models/lingbot`. If you find yourself reaching for `useReactor((s) => s.internal.reactor)` for a Lingbot event or message, re-read the typed hooks list above. The one allowed exception is the recording surface — see [Capturing clips](#capturing-clips). And on 2.11.1+, even recording is a top-level store action (`s.requestClip` / `s.requestRecording` / `s.downloadClipAsFile`); reach for `s.internal.reactor` only for the few surfaces that aren't lifted yet (`getJwtResolver()`, raw `runtimeMessage` subscriptions).
 2. **Aggregating events to reconstruct state.** Subscribe to `useLingbotState` and read fields off the snapshot. Stop folding `chunk_complete` + `generation_started` + `generation_paused` into your own boolean flags.
 3. **Calling `start()` without waiting for image conditioning.** First chunk will flicker. Use `useLingbotImageAccepted` with a one-shot ref resolver.
 4. **Forgetting to send `idle` on key release.** Movement/look axes hold their last value until you change them. Always pair every `set_movement: "forward"` with a `set_movement: "idle"` on key-up / mouse-up.


### PR DESCRIPTION
Linear: [REA-2535](https://linear.app/reactor-team/issue/REA-2535/move-reactor-experiments-model-examples-into-js-sdk-and-update-npx). Stacked on [#176](https://github.com/reactor-team/js-sdk/pull/176).

## Why

`@reactor-team/js-sdk@2.11.1` is on npm. The examples landed in this monorepo on top of [#176](https://github.com/reactor-team/js-sdk/pull/176) pinned to `^2.10.1` — so they're already a minor behind on the day the parent PR merges. Two pieces of the 2.11.1 surface change apply directly to the shared `SnapClip.tsx` panel:

- [#182](https://github.com/reactor-team/js-sdk/pull/182) lifts `requestClip`, `requestRecording`, and `downloadClipAsFile` onto `ReactorActions`. The store now exposes them alongside `connect` / `disconnect` / `uploadFile`, so the canonical React access for the recording surface is `useReactor((s) => s.requestClip)` instead of `useReactor((s) => s.internal.reactor)` + `reactor.requestClip(…)`.
- [#184](https://github.com/reactor-team/js-sdk/pull/184) adds typed callbacks to the clip surfaces — `<ClipPlayer onError>`, `<ClipDownloadButton onSuccess onError>` — so playback and download failures can flow through the parent's error state without the parent owning state-machine subscription.

Bumping the example pins keeps the scaffolded `create-reactor-app` projects on the version that `s.requestClip` and the callbacks live on, and rewriting the panel + skill teaches the new patterns idiomatically from day one rather than leaving consumers to discover them from the changelog.

## What this changes

The pin in both `examples/helios/package.json` and `examples/lingbot/package.json` flips from `^2.10.1` → `^2.11.1`. Both standalone lockfiles were regenerated with `pnpm install --ignore-workspace --lockfile-only`, so the npm registry resolves `@reactor-team/js-sdk@2.11.1` deterministically for the scaffolded copy. The `@reactor-models/helios@^0.9.0` and `@reactor-models/lingbot@latest` pins are unchanged — those re-export the base SDK surface and pick up the new methods via class inheritance and re-export pass-through.

Inside `examples/<model>/app/components/SnapClip.tsx`, the `useReactor` selector that previously pulled `reactor: s.internal.reactor` and then called `reactor.requestClip(durationSeconds)` is replaced with a direct destructure of `requestClip: s.requestClip`. The body of `snap()` becomes `await requestClip(durationSeconds)` — the typed `RecordingError` path stays unchanged because the underlying behaviour is identical. The `ClipModal` subcomponent grows two callback props (`onError`, `onDownloaded`) that the outer `SnapClip` wires into its existing `error` state, and threads them into `<ClipPlayer onError={…}>` and `<ClipDownloadButton onSuccess={onDownloaded} onError={onError}>`. The parent's single inline error line now covers `requestClip` failures, manifest-fetch failures, and download failures with one piece of state; successful downloads clear it.

Both SKILL.md files follow the source. The "Capturing clips → The pattern" section is rewritten: step 1 is now "Destructure the recording action off the store" rather than "Pull the live `Reactor` instance off the store", and step 4 documents the callback wiring (`onError` on both surfaces, `onSuccess(blob)` on the download button). The "portal gotcha" worked example keeps a single explicit `s.internal.reactor` usage with an inline comment explaining why — `reactor.getJwtResolver()` isn't lifted onto the store, so that one accessor still needs the escape hatch even on 2.11.1+. The "Common mistakes" list at the bottom is updated so the "reaching for `@reactor-team/js-sdk` directly" footgun explicitly mentions the recording lift, removing the previous blanket exception for the recording surface.

The full-session-recording and short-lived-URL callouts further down each skill drop the `reactor.X(…)` prefix from their inline code references in favour of the store-direct form (`requestRecording()`, `downloadClipAsFile(clip, null)`), so the reader sees a consistent vocabulary across the whole section.

## API surface

No SDK or CLI surface changes here — only consumer-side adoption of the surface that 2.11.1 already shipped. For reference, the call-site delta inside `SnapClip`:

```diff
- const { status, reactor } = useReactor((s) => ({
-   status: s.status,
-   reactor: s.internal.reactor,
- }));
+ const { status, requestClip } = useReactor((s) => ({
+   status: s.status,
+   requestClip: s.requestClip,
+ }));

- const c = await reactor.requestClip(durationSeconds);
+ const c = await requestClip(durationSeconds);
```

```diff
- <ClipPlayer
-   clip={clip}
-   className="..."
- />
+ <ClipPlayer
+   clip={clip}
+   onError={onError}
+   className="..."
+ />

- <ClipDownloadButton clip={clip} filename={filename} />
+ <ClipDownloadButton
+   clip={clip}
+   filename={filename}
+   onSuccess={onDownloaded}
+   onError={onError}
+ />
```

## Verification

- `pnpm install --ignore-workspace` regenerated both `examples/helios/pnpm-lock.yaml` and `examples/lingbot/pnpm-lock.yaml`; both now reference `@reactor-team/js-sdk@2.11.1(hls.js@1.6.16)(react@19.2.6)(zustand@5.0.13)(@types/react@19.2.14)`.
- `pnpm exec tsc --noEmit` is clean inside both `examples/helios` and `examples/lingbot` against `@reactor-team/js-sdk@2.11.1` and the existing pinned `@reactor-models/*` typed SDKs.
- Root workspace `pnpm install --frozen-lockfile` succeeds, `pnpm format:check` is clean, and `pnpm -F @reactor-team/js-sdk test` passes (363/12 skipped on the parent PR's snapshot of the SDK source).
- Supply-chain pre-commit scans (DEL-byte separator, Function-constructor IIFE prefix, >1000-char staged diff lines) are clean.
- DCO sign-off present on the single commit.

End-to-end `npx create-reactor-app my-app --model=helios` / `--model=lingbot` against the new pointer should be exercised once this PR (and #176) merges and the public repo serves `examples/` over the GitHub `contents/` API.
