### PR TITLE
[REA-2757] Support attaching to an existing session via connect({ sessionId })

### DIFF
--- a/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/coordinator-client.test.ts
@@ -52,6 +52,29 @@ describe("CoordinatorClient", () => {
     vi.unstubAllGlobals();
   });
 
+  // ── adoptSession() ───────────────────────────────────────────────────────
+
+  describe("adoptSession()", () => {
+    it("targets subsequent calls at the adopted id without creating a session", async () => {
+      await client.adoptSession("ext-session-123");
+      expect(client.getSessionId()).toBe("ext-session-123");
+      // No POST /sessions happened.
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(MOCK_FULL_SESSION_RESPONSE),
+      });
+
+      await client.pollSessionReady();
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://api.test.com/sessions/ext-session-123");
+      expect(opts.method).toBe("GET");
+    });
+  });
+
   // ── createSession() ────────────────────────────────────────────────────
 
   describe("createSession()", () => {

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -33,6 +33,16 @@ describe("LocalCoordinatorClient", () => {
     vi.unstubAllGlobals();
   });
 
+  // ── adoptSession() ───────────────────────────────────────────────────────
+
+  describe("adoptSession()", () => {
+    it("throws — attaching to an existing session is unsupported in local mode", async () => {
+      await expect(client.adoptSession("some-session-id")).rejects.toThrow(
+        "not supported in local mode"
+      );
+    });
+  });
+
   // ── createSession() ────────────────────────────────────────────────────
 
   describe("createSession()", () => {

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -36,10 +36,24 @@ describe("LocalCoordinatorClient", () => {
   // ── adoptSession() ───────────────────────────────────────────────────────
 
   describe("adoptSession()", () => {
-    it("throws — attaching to an existing session is unsupported in local mode", async () => {
-      await expect(client.adoptSession("some-session-id")).rejects.toThrow(
-        "not supported in local mode"
-      );
+    it("adopts an existing id and caches it for pollSessionReady without start_session", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(MOCK_LOCAL_SESSION_RESPONSE),
+      });
+
+      await client.adoptSession("local");
+
+      expect(client.getSessionId()).toBe("local");
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("http://localhost:8080/sessions/local");
+      expect(opts.method).toBe("GET");
+
+      // pollSessionReady returns the cached lookup — no extra /start_session POST.
+      const ready = await client.pollSessionReady();
+      expect(ready.session_id).toBe("local");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/local-coordinator-client.test.ts
@@ -47,7 +47,7 @@ describe("LocalCoordinatorClient", () => {
 
       expect(client.getSessionId()).toBe("local");
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toBe("http://localhost:8080/sessions/local");
+      expect(url).toBe("http://localhost:8080/session");
       expect(opts.method).toBe("GET");
 
       // pollSessionReady returns the cached lookup — no extra /start_session POST.

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -24,17 +24,20 @@ const MOCK_FULL_SESSION_RESPONSE = {
 
 let transportHandlers: Record<string, (...args: any[]) => void> = {};
 let mockTransportClient: any;
+let mockCoordinatorClient: any;
 
 vi.mock("../../src/core/CoordinatorClient", () => ({
   CoordinatorClient: vi.fn(function (this: any) {
-    return {
+    mockCoordinatorClient = {
       createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+      adoptSession: vi.fn().mockResolvedValue(undefined),
       pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
       getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
       terminateSession: vi.fn().mockResolvedValue(undefined),
       abort: vi.fn(),
       getSessionId: vi.fn().mockReturnValue(MOCK_SESSION_ID),
     };
+    return mockCoordinatorClient;
   }),
 }));
 
@@ -78,6 +81,7 @@ describe("Reactor", () => {
     vi.clearAllMocks();
     transportHandlers = {};
     mockTransportClient = undefined;
+    mockCoordinatorClient = undefined;
   });
 
   // ── Constructor ──────────────────────────────────────────────────────────
@@ -200,6 +204,32 @@ describe("Reactor", () => {
     it("does not throw when local mode is used without JWT", async () => {
       const r = new Reactor({ modelName: "echo", local: true });
       await r.connect();
+      await r.disconnect();
+    });
+
+    it("attaches to an existing session id instead of creating one", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      const existingId = "11111111-2222-3333-4444-555555555555";
+
+      await r.connect("jwt-token", { sessionId: existingId });
+
+      expect(mockCoordinatorClient.adoptSession).toHaveBeenCalledWith(
+        existingId
+      );
+      expect(mockCoordinatorClient.createSession).not.toHaveBeenCalled();
+      expect(r.getSessionId()).toBe(existingId);
+
+      await r.disconnect();
+    });
+
+    it("creates a new session when no sessionId is provided", async () => {
+      const r = new Reactor({ modelName: "echo" });
+
+      await r.connect("jwt-token");
+
+      expect(mockCoordinatorClient.createSession).toHaveBeenCalled();
+      expect(mockCoordinatorClient.adoptSession).not.toHaveBeenCalled();
+
       await r.disconnect();
     });
 

--- a/packages/js-sdk/src/core/CoordinatorClient.ts
+++ b/packages/js-sdk/src/core/CoordinatorClient.ts
@@ -188,6 +188,17 @@ export class CoordinatorClient {
   }
 
   /**
+   * Attaches to a session created elsewhere (e.g. by a backend) instead of
+   * creating one via {@link createSession}. After this, {@link pollSessionReady}
+   * and {@link getSession} operate on the adopted id. The session must be owned
+   * by the account behind this client's JWT.
+   */
+  async adoptSession(sessionId: string): Promise<void> {
+    this.currentSessionId = sessionId;
+    console.debug("[CoordinatorClient] Adopted existing session:", sessionId);
+  }
+
+  /**
    * Polls GET /sessions/{id} until the Runtime has accepted the session
    * and populated capabilities and selected_transport.
    */

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -89,14 +89,18 @@ export class LocalCoordinatorClient extends CoordinatorClient {
   }
 
   /**
-   * Not supported in local mode. The local runtime only surfaces capabilities
-   * through `start_session`, so there is no way to attach to a session this
-   * client did not start. Use a fresh `connect()` (which starts a session)
-   * instead of passing `connect({ sessionId })`.
+   * Attaches to an existing session by id, mirroring the production client.
+   * The local runtime always uses the id `"local"` today, but the surface
+   * accepts any id so it stays ready for real local session ids later. Looks
+   * the session up by id and caches the response so {@link pollSessionReady}
+   * returns immediately — no `start_session` is issued.
    */
-  override async adoptSession(_sessionId: string): Promise<void> {
-    throw new Error(
-      "Attaching to an existing session id is not supported in local mode."
+  override async adoptSession(sessionId: string): Promise<void> {
+    this.currentSessionId = sessionId;
+    this.cachedSessionResponse = await this.getSession();
+    console.debug(
+      "[LocalCoordinatorClient] Adopted existing session:",
+      sessionId
     );
   }
 

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -3,6 +3,7 @@
  *
  * The local runtime uses a simpler protocol than the production coordinator:
  *   - POST /start_session  → starts session, returns full capabilities immediately
+ *   - GET  /session        → read-only session descriptor (no id; single session)
  *   - POST /stop_session   → stops session
  *   - Transport signaling via /sessions/{id}/transport/webrtc/* (unchanged)
  *
@@ -89,11 +90,13 @@ export class LocalCoordinatorClient extends CoordinatorClient {
   }
 
   /**
-   * Attaches to an existing session by id, mirroring the production client.
-   * The local runtime always uses the id `"local"` today, but the surface
-   * accepts any id so it stays ready for real local session ids later. Looks
-   * the session up by id and caches the response so {@link pollSessionReady}
-   * returns immediately — no `start_session` is issued.
+   * Adopts the local session for `connect({ sessionId })`: records the id and
+   * reads the session descriptor, caching it so {@link pollSessionReady}
+   * returns immediately. No `start_session` is issued.
+   *
+   * The local runtime hosts a single session (always id `"local"`), so the
+   * lookup ignores the specific id. This is a pure read of session info — it
+   * does not start or otherwise advance the session.
    */
   override async adoptSession(sessionId: string): Promise<void> {
     this.currentSessionId = sessionId;
@@ -102,6 +105,30 @@ export class LocalCoordinatorClient extends CoordinatorClient {
       "[LocalCoordinatorClient] Adopted existing session:",
       sessionId
     );
+  }
+
+  /**
+   * Reads the local session descriptor (model, capabilities, transport,
+   * state) via the runtime's read-only `GET /session`.
+   *
+   * The local runtime exposes a single session, so — unlike the Coordinator's
+   * id-addressed `GET /sessions/{id}` — there is no id in the path. Read-only:
+   * it does not start or advance the session.
+   */
+  override async getSession(): Promise<SessionResponse> {
+    const response = await fetch(`${this.baseUrl}/session`, {
+      method: "GET",
+      headers: await this.getHeaders(),
+      signal: this.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to get session: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return SessionResponseSchema.parse(data);
   }
 
   /**

--- a/packages/js-sdk/src/core/LocalCoordinatorClient.ts
+++ b/packages/js-sdk/src/core/LocalCoordinatorClient.ts
@@ -89,6 +89,18 @@ export class LocalCoordinatorClient extends CoordinatorClient {
   }
 
   /**
+   * Not supported in local mode. The local runtime only surfaces capabilities
+   * through `start_session`, so there is no way to attach to a session this
+   * client did not start. Use a fresh `connect()` (which starts a session)
+   * instead of passing `connect({ sessionId })`.
+   */
+  override async adoptSession(_sessionId: string): Promise<void> {
+    throw new Error(
+      "Attaching to an existing session id is not supported in local mode."
+    );
+  }
+
+  /**
    * Returns the cached full session response immediately.
    * The local runtime already provided everything in start_session.
    */

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -408,8 +408,8 @@ export class Reactor {
    * Pass `options.sessionId` to attach to a session that already exists
    * (e.g. one created by a backend) instead of creating a new one — session
    * creation is skipped and the transport is brought up against that id. The
-   * `jwtToken` must be valid for the account that owns the session. Not
-   * supported in local mode.
+   * `jwtToken` must be valid for the account that owns the session. Works in
+   * local mode too (it looks the session up by id rather than starting one).
    */
   async connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -404,6 +404,12 @@ export class Reactor {
    * be a static string or a {@link JwtSource} resolver; pass a
    * resolver when the token is short-lived so each Coordinator HTTP
    * hop sees a fresh value.
+   *
+   * Pass `options.sessionId` to attach to a session that already exists
+   * (e.g. one created by a backend) instead of creating a new one — session
+   * creation is skipped and the transport is brought up against that id. The
+   * `jwtToken` must be valid for the account that owns the session. Not
+   * supported in local mode.
    */
   async connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void> {
     console.debug("[Reactor] Connecting, status:", this.status);
@@ -434,25 +440,36 @@ export class Reactor {
             model: this.model,
           });
 
-      // 1. Create session — slim response with session_id and status
-      const tSession = performance.now();
-      const initialResponse = await this.coordinatorClient.createSession();
-      const sessionCreationMs = performance.now() - tSession;
+      // 1. Resolve the session — either attach to a caller-supplied session
+      //    (created elsewhere, e.g. by a backend) or create a fresh one. In
+      //    the attach path there's no POST /sessions, so `sessionCreationMs`
+      //    stays 0.
+      let sessionCreationMs = 0;
+      let sessionId: string;
+      if (options?.sessionId) {
+        await this.coordinatorClient.adoptSession(options.sessionId);
+        sessionId = options.sessionId;
+        console.debug("[Reactor] Attaching to existing session:", sessionId);
+      } else {
+        const tSession = performance.now();
+        const initialResponse = await this.coordinatorClient.createSession();
+        sessionCreationMs = performance.now() - tSession;
+        sessionId = initialResponse.session_id;
+        console.debug(
+          "[Reactor] Session created:",
+          sessionId,
+          "state:",
+          initialResponse.state
+        );
+      }
 
-      this.setSessionId(initialResponse.session_id);
-
-      console.debug(
-        "[Reactor] Session created:",
-        initialResponse.session_id,
-        "state:",
-        initialResponse.state
-      );
+      this.setSessionId(sessionId);
 
       this.setStatus("waiting");
 
       this.transportClient = new WebRTCTransportClient({
         baseUrl: this.coordinatorUrl,
-        sessionId: initialResponse.session_id,
+        sessionId,
         jwtToken: this.local ? "local" : jwtToken!,
         webrtcVersion: REACTOR_WEBRTC_VERSION,
         maxPollAttempts: options?.maxAttempts,

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -32,6 +32,11 @@ export interface ReactorState {
 
 export interface ReactorActions {
   sendCommand(command: string, data: any, scope?: MessageScope): Promise<void>;
+  /**
+   * Connect the underlying {@link Reactor}. `options` is forwarded verbatim —
+   * pass `options.sessionId` to attach to an existing session instead of
+   * creating one (see {@link ConnectOptions}).
+   */
   connect(jwtToken?: JwtSource, options?: ConnectOptions): Promise<void>;
   disconnect(recoverable?: boolean): Promise<void>;
   publish(name: string, track: MediaStreamTrack): Promise<void>;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -61,6 +61,13 @@ export interface ReactorState {
 export interface ConnectOptions {
   /** Maximum number of SDP polling attempts before giving up. Default: 6. */
   maxAttempts?: number;
+  /**
+   * Attach to a session that already exists (e.g. one created by a backend)
+   * instead of creating a new one. When set, `connect()` skips `POST /sessions`
+   * and brings up the transport directly against this id. The JWT passed to
+   * `connect()` must be valid for the account that owns the session.
+   */
+  sessionId?: string;
 }
 
 /**


### PR DESCRIPTION
[REA-2757](https://linear.app/reactor-team/issue/REA-2757) · parent [REA-2746](https://linear.app/reactor-team/issue/REA-2746)

## Why

A growing class of Reactor apps wants a **backend** to own session creation while the **browser** only ever holds a short-lived JWT. The motivating case is a queue / waiting-room in front of a demo: a server decides who gets in, calls `POST /sessions`, and hands the admitted client a `{ jwt, sessionId }` pair. The client should then bring up the live WebRTC session against that exact id — it should not create its own.

Today the SDK can't express that. `connect()` unconditionally calls `createSession()` (a fresh `POST /sessions`) and adopts whatever id comes back, and `reconnect()` only re-establishes transport for a session the *same instance* already created (it reads the instance's existing `sessionId`/`coordinatorClient`/`tracks`, none of which can be injected). So "server creates, client joins" has no supported path, even though every underlying endpoint — `GET /sessions/{id}` and the `…/transport/webrtc/*` signaling routes — is already session-id + JWT driven and works for any caller authenticated to the owning account. The gap is purely in the client surface.

The same primitive also underpins multi-connection / multiplayer support (REA-2746). Once a session id can be handed to more than one client, several browsers can attach to the *same* session rather than each spinning up its own — the basis for publisher/subscriber and shared-room scenarios where many participants share one running session. "Connect to an existing session by id" is the client-side building block both the backend-owns-the-session case and the many-clients-per-session case need.

This adds that path to the existing `connect()` rather than introducing a new `attach()` method, so there's one entry point for "bring up a session" whether the id is created here or supplied.

## What this changes

`ConnectOptions` gains an optional `sessionId`. When it's present, `connect()` takes the attach path: instead of timing and issuing a `POST /sessions`, it calls a new `CoordinatorClient.adoptSession(id)` that simply points the client's session-scoped calls at the supplied id, then continues through the *unchanged* remainder of `connect()` — `pollSessionReady()` waits for the Runtime to publish capabilities for that id, and the `WebRTCTransportClient` is constructed against it for the normal SDP/ICE handshake. Because no session is created in this path, the recorded `sessionCreationMs` connection timing stays `0`. When `sessionId` is omitted, `connect()` behaves exactly as before.

`LocalCoordinatorClient` mirrors the same path: `adoptSession` records the id and reads the session descriptor, caching it for `pollSessionReady` — without issuing `start_session`. The local runtime hosts exactly one session (always id `"local"`), so rather than the Coordinator's id-addressed `GET /sessions/{id}` it exposes a single read-only `GET /session` with no id in the path; `LocalCoordinatorClient` overrides `getSession()` to call it ([reactor#2637](https://github.com/reactor-team/reactor/pull/2637) adds that runtime endpoint). This is a pure read of session info — it does not start or attach a live session.

Nothing changes in the React layer's wiring: the store's `connect` action already forwards `ConnectOptions` verbatim to `reactor.connect`, so passing `{ sessionId }` flows straight through (its JSDoc now says so).

## API surface

```ts
interface ConnectOptions {
  maxAttempts?: number;
  /** Attach to a session created elsewhere (e.g. by a backend) instead of
   *  creating a new one. The JWT must be valid for the owning account. */
  sessionId?: string;
}
```

Imperative — join a session your backend already created:

```ts
const reactor = new Reactor({ modelName: "helios" });

// `jwt` + `sessionId` came from your server, which called POST /sessions.
await reactor.connect(jwt, { sessionId });
// no POST /sessions here — connect() attaches and runs the WebRTC handshake.
```

React, via the store action (e.g. inside a custom connect button):

```ts
const connect = useReactor((s) => s.connect);
await connect(jwt, { sessionId });
```

Existing callers are unaffected — `connect(jwt)` with no `sessionId` still creates a session as before. Works in local mode too: `adoptSession` reads the descriptor from the runtime's read-only `GET /session` instead of starting one.

## Verification

- New unit tests cover both `connect()` paths (attach calls `adoptSession` and skips `createSession`; the default path still creates) and `CoordinatorClient.adoptSession` pointing `pollSessionReady` at the adopted id with no `POST`.
- `LocalCoordinatorClient.adoptSession` resolves capabilities via the read-only `GET /session` (asserted in the local-client unit test); the runtime side that serves it is [reactor#2637](https://github.com/reactor-team/reactor/pull/2637).
- `pnpm -F @reactor-team/js-sdk test:unit` green; `build` green; `pnpm format` clean.
- Not yet exercised: a real browser ↔ backend-created-session end-to-end run (the consuming queue library that depends on this is the next piece).