### PR TITLE
update API keys link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ pnpm install
 pnpm dev
 ```
 
-API keys come from [reactor.inc/dashboard](https://www.reactor.inc/dashboard/account?section=api-keys). The example mints short-lived JWTs server-side via `app/api/reactor/token/route.ts` and hands the resolver to `<ModelProvider getJwt={fetchToken}>` — see each example's `skill/SKILL.md` for the design rationale.
+API keys come from [reactor.inc/account/api-keys](https://www.reactor.inc/account/api-keys). The example mints short-lived JWTs server-side via `app/api/reactor/token/route.ts` and hands the resolver to `<ModelProvider getJwt={fetchToken}>` — see each example's `skill/SKILL.md` for the design rationale.
 
 ## Scaffolding from these templates
 

--- a/examples/helios/README.md
+++ b/examples/helios/README.md
@@ -26,7 +26,7 @@ Connect, send a prompt, and watch the model produce a continuous video stream yo
 
 ## Quick start
 
-You'll need a Reactor API key — grab one at [reactor.inc/dashboard](https://www.reactor.inc/dashboard/account?section=api-keys). It starts with `rk_`.
+You'll need a Reactor API key — grab one at [reactor.inc/account/api-keys](https://www.reactor.inc/account/api-keys). It starts with `rk_`.
 
 ```bash
 cp .env.example .env

--- a/examples/helios/app/SetupRequired.tsx
+++ b/examples/helios/app/SetupRequired.tsx
@@ -1,7 +1,6 @@
 import { Header } from "./components/Header";
 
-const DASHBOARD_URL =
-  "https://www.reactor.inc/dashboard/account?section=api-keys";
+const ACCOUNT_API_KEYS_URL = "https://www.reactor.inc/account/api-keys";
 
 // Server Component shown when REACTOR_API_KEY is missing from the
 // environment. Pure markup — no hooks, no UI-lib components, so it
@@ -30,7 +29,7 @@ export function SetupRequired() {
               <span>
                 Create an API key at{" "}
                 <a
-                  href={DASHBOARD_URL}
+                  href={ACCOUNT_API_KEYS_URL}
                   target="_blank"
                   rel="noreferrer"
                   className="text-brand underline-offset-2 hover:underline"

--- a/examples/lingbot/README.md
+++ b/examples/lingbot/README.md
@@ -25,7 +25,7 @@ Pick a starting image, watch it come alive as a continuous video stream, and dri
 
 ## Quick start
 
-You'll need a Reactor API key — grab one at [reactor.inc/dashboard](https://www.reactor.inc/dashboard/account?section=api-keys). It starts with `rk_`.
+You'll need a Reactor API key — grab one at [reactor.inc/account/api-keys](https://www.reactor.inc/account/api-keys). It starts with `rk_`.
 
 ```bash
 cp .env.example .env

--- a/examples/lingbot/app/SetupRequired.tsx
+++ b/examples/lingbot/app/SetupRequired.tsx
@@ -1,7 +1,6 @@
 import { Header } from "./components/Header";
 
-const DASHBOARD_URL =
-  "https://www.reactor.inc/dashboard/account?section=api-keys";
+const ACCOUNT_API_KEYS_URL = "https://www.reactor.inc/account/api-keys";
 
 // Server Component shown when REACTOR_API_KEY is missing from the
 // environment. Pure markup — no hooks, no UI-lib components, so it
@@ -30,7 +29,7 @@ export function SetupRequired() {
               <span>
                 Create an API key at{" "}
                 <a
-                  href={DASHBOARD_URL}
+                  href={ACCOUNT_API_KEYS_URL}
                   target="_blank"
                   rel="noreferrer"
                   className="text-brand underline-offset-2 hover:underline"


### PR DESCRIPTION
## Summary
Fixes broken API key links in the example apps and docs. The old https://www.reactor.inc/dashboard/account?section=api-keys URL returns a 404; it’s updated to https://www.reactor.inc/account/api-keys.

## Context
While onboarding and trying to run the examples, I hit the “Create an API key” link in the setup flow and landed on a 404. The examples still pointed at an outdated dashboard URL that no longer resolves.

## Changes
- Update API key links in `examples/README.md`, `examples/helios/README.md`, and `examples/lingbot/README.md`
- Update the setup screen link in `examples/helios/app/SetupRequired.tsx` and `examples/lingbot/app/SetupRequired.tsx`
- Replace https://www.reactor.inc/dashboard/account?section=api-keys with https://www.reactor.inc/account/api-keys