### PR TITLE
Exempt Dependabot commits from the DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -42,6 +42,13 @@ jobs:
             author_email=$(git show -s --format='%ae' "$sha")
             subject=$(git show -s --format='%s' "$sha")
 
+            # Dependabot opens its own PRs and cannot add a Signed-off-by
+            # trailer; its commits are machine-generated, so exempt them.
+            if [[ "$author_name" == "dependabot[bot]" || "$author_email" == *"dependabot[bot]"* ]]; then
+              echo "Skipping DCO check for Dependabot commit $sha."
+              continue
+            fi
+
             expected="Signed-off-by: ${author_name} <${author_email}>"
             body=$(git show -s --format='%B' "$sha")
 


### PR DESCRIPTION
## Why

The DCO workflow (`.github/workflows/dco.yml`) walks every commit on a PR and fails the build unless each one carries a `Signed-off-by` trailer that exactly matches the commit author. This is the right policy for human contributors, but Dependabot opens its own pull requests with machine-generated commits authored by `dependabot[bot]`, and there is no way to make it add a sign-off trailer. The result is that every dependency-update PR fails DCO and cannot be merged without a maintainer manually rewriting history — which defeats the point of automated dependency updates.

## What this changes

Inside the per-commit verification loop in the DCO workflow, before the `Signed-off-by` trailer is checked, the script now inspects the commit author. If the author name is `dependabot[bot]` or the author email belongs to the Dependabot bot account, the commit is logged and skipped via `continue`. Every other commit still goes through the existing exact-match trailer check unchanged, so human contributors are held to the same standard as before. The exemption is keyed on the bot identity rather than the PR actor, so it holds even when commits are evaluated individually in the range walk.

## Verification

- Dependabot PRs: the DCO job now prints `Skipping DCO check for Dependabot commit <sha>` and exits 0.
- Human PRs with a missing/incorrect sign-off still fail with the existing error output.
- No change to any published package or public API surface — workflow-only change.