### PR TITLE
Add CI workflow and fix README build badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test:unit
+      - run: pnpm format:check

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@reactor-team/js-sdk)](https://www.npmjs.com/package/@reactor-team/js-sdk)
 [![npm downloads](https://img.shields.io/npm/dm/@reactor-team/js-sdk)](https://www.npmjs.com/package/@reactor-team/js-sdk)
-[![build](https://img.shields.io/github/actions/workflow/status/reactor-team/js-sdk/ci.yml?branch=main)](https://github.com/reactor-team/js-sdk/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/reactor-team/js-sdk/ci.yml?branch=main)](https://github.com/reactor-team/js-sdk/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue)](./LICENSE)
 
 The official JavaScript SDK for building real-time AI video applications with [Reactor](https://reactor.inc).


### PR DESCRIPTION
## Summary
- Add a `ci.yml` GitHub Actions workflow that runs build, unit tests, and format check on pushes to `main` and PRs
- Fix the README build badge to point to the new CI workflow (was referencing a nonexistent `ci.yml`)

## Test plan
- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm badge resolves after merge to `main`