### PR TITLE
js-sdk: default autoResumeTracks to true and tidy multi-connection PR

### DIFF
--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -58,6 +58,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),
       unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      pauseTrack: vi.fn(),
+      resumeTrack: vi.fn(),
       on: vi.fn((event: string, handler: any) => {
         transportHandlers[event] = handler;
       }),

--- a/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-extended.test.ts
@@ -70,6 +70,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),
       unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      pauseTrack: vi.fn(),
+      resumeTrack: vi.fn(),
       on: vi.fn((event: string, handler: any) => {
         transportHandlers[event] = handler;
       }),

--- a/packages/js-sdk/__tests__/unit/reactor-moderation.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-moderation.test.ts
@@ -52,6 +52,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),
       unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      pauseTrack: vi.fn(),
+      resumeTrack: vi.fn(),
       on: vi.fn((event: string, handler: any) => {
         transportHandlers[event] = handler;
       }),

--- a/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-recording.test.ts
@@ -62,6 +62,8 @@ vi.mock("../../src/core/WebRTCTransportClient", () => ({
       sendCommand: vi.fn(),
       publishTrack: vi.fn().mockResolvedValue(undefined),
       unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      pauseTrack: vi.fn(),
+      resumeTrack: vi.fn(),
       on: vi.fn((event: string, handler: any) => {
         transportHandlers[event] = handler;
       }),

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -478,7 +478,7 @@ describe("Reactor", () => {
       await r.disconnect();
     });
 
-    it("does not call resumeTrack when autoResumeTracks is false (default)", async () => {
+    it("calls resumeTrack for all recvonly tracks by default (autoResumeTracks defaults to true)", async () => {
       const r = new Reactor({ modelName: "echo" });
       const { CoordinatorClient } = await import("../../src/core/CoordinatorClient");
       vi.mocked(CoordinatorClient).mockImplementationOnce(function (this: any) {
@@ -486,6 +486,24 @@ describe("Reactor", () => {
       });
 
       await r.connect("jwt");
+      transportHandlers["statusChanged"]?.("connected");
+
+      expect(mockTransportClient.resumeTrack).toHaveBeenCalledWith("main_video");
+      expect(mockTransportClient.resumeTrack).toHaveBeenCalledWith("main_audio");
+      expect(mockTransportClient.resumeTrack).not.toHaveBeenCalledWith("webcam");
+
+      await r.disconnect();
+    });
+
+    it("does not call resumeTrack when autoResumeTracks is explicitly false", async () => {
+      const r = new Reactor({ modelName: "echo" });
+      const { CoordinatorClient } = await import("../../src/core/CoordinatorClient");
+      vi.mocked(CoordinatorClient).mockImplementationOnce(function (this: any) {
+        return mockCoordinator();
+      });
+
+      await r.connect("jwt", { autoResumeTracks: false });
+      transportHandlers["statusChanged"]?.("connected");
 
       expect(mockTransportClient.resumeTrack).not.toHaveBeenCalled();
 

--- a/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/webrtc-transport-client.test.ts
@@ -409,6 +409,60 @@ describe("WebRTCTransportClient", () => {
     });
   });
 
+  // ── connect() with a provided connectionId ────────────────────────────
+
+  describe("connect() with a provided connectionId", () => {
+    it("adopts the id, skips registration, and posts the offer to that connection", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
+      mockSdpOfferAccepted();
+      mockSdpAnswerReady();
+      await client.connect(false, 7777);
+
+      // No POST .../connections registration call was made.
+      const registerCall = mockFetch.mock.calls.find((c) =>
+        String(c[0]).endsWith("/connections")
+      );
+      expect(registerCall).toBeUndefined();
+
+      // call[0] = ICE servers (prepare); call[1] = SDP offer POST to the id.
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        "https://api.test.com/sessions/test-session-id/transport/webrtc/connections/7777/sdp_params"
+      );
+      expect(mockFetch.mock.calls[1][1].method).toBe("POST");
+    });
+
+    it("rejects an out-of-range connectionId before any network call", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+      const callsAfterPrepare = mockFetch.mock.calls.length;
+
+      await expect(client.connect(false, 999)).rejects.toThrow(
+        "Invalid connectionId"
+      );
+      expect(mockFetch.mock.calls.length).toBe(callsAfterPrepare);
+    });
+
+    it("surfaces a clear error when the connection is not found (404)", async () => {
+      const client = createClient();
+      mockIceServersFetch();
+      await client.prepare(MOCK_TRACKS);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('{"error":"connection"}'),
+      });
+
+      await expect(client.connect(false, 7777)).rejects.toThrow(
+        /Connection 7777 not found/
+      );
+    });
+  });
+
   // ── abort() ───────────────────────────────────────────────────────────
 
   describe("abort()", () => {

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -521,7 +521,7 @@ export class Reactor {
         this.emit("capabilitiesReceived", this.capabilities);
 
         const tConnect = performance.now();
-        await this.transportClient.connect();
+        await this.transportClient.connect(false, options?.connectionId);
         transportConnectingMs = performance.now() - tConnect;
       } else {
         // 2b. Sequential path: tracks come from the poll response, but
@@ -544,7 +544,7 @@ export class Reactor {
 
         const tTransport = performance.now();
         await this.transportClient.prepare(this.tracks);
-        await this.transportClient.connect();
+        await this.transportClient.connect(false, options?.connectionId);
         transportConnectingMs = performance.now() - tTransport;
       }
 

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -502,7 +502,7 @@ export class Reactor {
       let sessionPollingMs: number;
       let transportConnectingMs: number;
 
-      this.autoResumeTracks = options?.autoResumeTracks ?? false;
+      this.autoResumeTracks = options?.autoResumeTracks ?? true;
 
       if (this.presetTracks) {
         // 2a. Parallel path: tracks are known at build time, so we can
@@ -606,7 +606,7 @@ export class Reactor {
           this.finalizeConnectionTimings();
 
           if (this.autoResumeTracks) {
-            for (const track of this.tracks) {``
+            for (const track of this.tracks) {
               if (track.direction === "recvonly") {
                 this.resumeTrack(track.name);
               }
@@ -633,7 +633,6 @@ export class Reactor {
     client.on(
       "trackReceived",
       (name: string, track: MediaStreamTrack, stream: MediaStream) => {
-        console.log("[Reactor] trackReceived", name, track, stream);
         if (this.transportClient !== client) return;
         this.emit("trackReceived", name, track, stream);
 

--- a/packages/js-sdk/src/core/TransportClient.ts
+++ b/packages/js-sdk/src/core/TransportClient.ts
@@ -84,8 +84,11 @@ export interface TransportClient {
    *
    * @param reconnect If true, signals a reconnection to an existing
    *   session rather than an initial connection.
+   * @param connectionId If provided, adopt this pre-registered connection id
+   *   instead of minting a new one. The id must already exist (and be open)
+   *   under the session; otherwise `connect()` rejects.
    */
-  connect(reconnect?: boolean): Promise<void>;
+  connect(reconnect?: boolean, connectionId?: number): Promise<void>;
 
   /**
    * Tears down the transport connection and releases all resources.

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -48,6 +48,12 @@ const MAX_BACKOFF_MS = 15_000;
 const BACKOFF_MULTIPLIER = 2;
 const DEFAULT_MAX_POLL_ATTEMPTS = 6;
 
+// Accepted range for a server-minted connection id, mirroring the Coordinator's
+// validation (`connection_id > 1000 && <= 9999`). Used to fail fast on an
+// obviously invalid caller-supplied id before hitting the network.
+const MIN_CONNECTION_ID = 1000;
+const MAX_CONNECTION_ID = 9999;
+
 /**
  * Debounce window for coalescing trickle ICE candidates into a single
  * POST. Browsers fire {@link RTCPeerConnection.onicecandidate} in bursts
@@ -321,6 +327,22 @@ export class WebRTCTransportClient implements TransportClient {
 
     if (response.status !== 202) {
       const errorText = await response.text();
+      // A caller-supplied connection id that the server doesn't recognise (or
+      // that has already been closed) surfaces here as a 404; an out-of-range
+      // id as a 400. Make those actionable rather than a bare status dump.
+      if (response.status === 404) {
+        throw new Error(
+          `[WebRTCTransport] Connection ${connectionId} not found or already ` +
+            `closed (404). A supplied connectionId must reference a connection ` +
+            `registered under this session (POST .../connections) that is still ` +
+            `open. ${errorText}`
+        );
+      }
+      if (response.status === 400) {
+        throw new Error(
+          `[WebRTCTransport] Connection ${connectionId} rejected (400): ${errorText}`
+        );
+      }
       throw new Error(`Failed to send SDP offer: ${response.status} ${errorText}`);
     }
 
@@ -551,7 +573,7 @@ export class WebRTCTransportClient implements TransportClient {
     console.debug("[WebRTCTransport] SDP offer prepared");
   }
 
-  async connect(reconnect: boolean = false): Promise<void> {
+  async connect(reconnect: boolean = false, connectionId?: number): Promise<void> {
     if (!this.pendingSdpOffer || !this.pendingTrackMapping) {
       throw new Error(
         "[WebRTCTransport] No prepared connection. Call prepare() first."
@@ -563,9 +585,24 @@ export class WebRTCTransportClient implements TransportClient {
     this.pendingSdpOffer = undefined;
     this.pendingTrackMapping = undefined;
 
-    // For a fresh connection, register to obtain an integer connection id.
-    // For a reconnect, reuse the existing id (PUT replaces the SDP on the same slot).
-    if (!reconnect || this.connectionId === undefined) {
+    if (connectionId !== undefined) {
+      // Caller supplied a connection id (e.g. a backend pre-registered it via
+      // POST .../connections and handed it over). Adopt it and skip
+      // registration — the server validates existence when we send the offer.
+      if (
+        !Number.isInteger(connectionId) ||
+        connectionId <= MIN_CONNECTION_ID ||
+        connectionId > MAX_CONNECTION_ID
+      ) {
+        throw new Error(
+          `[WebRTCTransport] Invalid connectionId ${connectionId}: must be an ` +
+            `integer in (${MIN_CONNECTION_ID}, ${MAX_CONNECTION_ID}]`
+        );
+      }
+      this.connectionId = connectionId;
+    } else if (!reconnect || this.connectionId === undefined) {
+      // For a fresh connection, register to obtain an integer connection id.
+      // For a reconnect, reuse the existing id (PUT replaces the SDP on the same slot).
       this.connectionId = await this.registerConnection();
     }
 

--- a/packages/js-sdk/src/react/ReactorProvider.tsx
+++ b/packages/js-sdk/src/react/ReactorProvider.tsx
@@ -137,11 +137,16 @@ export function ReactorProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoResumeTracks, maxAttempts]);
 
-  // On page unload, close the peer connection without terminating the session.
-  // The session will be cleaned up by server-side timeouts.
+  // On page unload, perform a non-recoverable disconnect. The session's
+  // creator tears the session down (DELETE), matching the pre-multi-connection
+  // behaviour; a client that adopted an existing session (connect({ sessionId }))
+  // only closes its own transport and leaves the session alive for its owner.
+  // This gating lives in Reactor.disconnect() via the `createdSession` flag, so
+  // passing `false` here is safe for both roles. We can't await during unload,
+  // so the DELETE is best-effort (same as before).
   useEffect(() => {
     const handleBeforeUnload = () => {
-      storeRef.current?.getState().internal.reactor.disconnect(true);
+      storeRef.current?.getState().internal.reactor.disconnect(false);
     };
 
     window.addEventListener("beforeunload", handleBeforeUnload);

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -78,6 +78,18 @@ export interface ConnectOptions {
    * `connect()` must be valid for the account that owns the session.
    */
   sessionId?: string;
+  /**
+   * Use a specific WebRTC connection id instead of minting one. When omitted
+   * (default), the transport registers a fresh connection (`POST .../connections`)
+   * and the server mints the id. When set, the transport skips registration and
+   * sends its SDP offer directly to that connection — so the id must already have
+   * been registered under this session (e.g. a backend called `POST .../connections`
+   * and handed the id to this client) and must still be open.
+   *
+   * `connect()` rejects if the id is invalid (out of the server's accepted range)
+   * or if no open connection with that id exists for the session.
+   */
+  connectionId?: number;
 }
 
 /**

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -62,10 +62,13 @@ export interface ConnectOptions {
   /** Maximum number of SDP polling attempts before giving up. Default: 6. */
   maxAttempts?: number;
   /**
-   * When true, sends `resume_track` for every recvonly track immediately
-   * after the connection is established, causing the backend to begin
-   * streaming those tracks. When false (default), recvonly tracks start
-   * paused and must be resumed individually via `resumeTrack()`.
+   * When true (default), sends `resume_track` for every recvonly track
+   * immediately after the connection is established, causing the backend to
+   * begin streaming those tracks — this preserves the pre-multi-connection
+   * behaviour where output tracks flow automatically on connect. Set to false
+   * to keep recvonly tracks paused on connect and resume them individually via
+   * `resumeTrack()` (e.g. multi-connection apps that only subscribe to a
+   * subset of peers).
    */
   autoResumeTracks?: boolean;
   /**


### PR DESCRIPTION
Stacked on #185 (`douglaseel/multi-connection-support`).

## Why

Multi-connection support negotiates `recvonly` output tracks but leaves them **paused** on an explicit connection until a `resume_track` is sent. With `autoResumeTracks` defaulting to `false`, simply **upgrading the SDK** would silently stop output media from flowing for existing single-stream apps — black video, no error — because the pre-multi-connection behaviour was for outputs to start immediately on connect.

Defaulting `autoResumeTracks` to `true` restores that behaviour on upgrade. Apps that only want to subscribe to a subset of peers (e.g. the meeting demo) opt out with `autoResumeTracks: false` and resume per track via `resumeTrack()`.

```ts
// default: outputs flow on connect (pre-multi-connection behaviour)
await reactor.connect(jwt);

// opt out: keep recvonly tracks paused, resume selectively
await reactor.connect(jwt, { autoResumeTracks: false });
reactor.resumeTrack("video_2");
```

## Session lifecycle: why page-unload teardown is gated on ownership

On page unload the provider calls `disconnect(false)`, but the actual `DELETE /sessions` is gated inside `Reactor.disconnect()` on whether *this* client **created** the session (`createdSession`) versus merely **connected** to an existing one. The reason this gate matters is that the SDK now serves two very different topologies, and we want one piece of teardown logic that is correct for both.

**Single-player (the topology in our docs and examples).** The client mints its own session and connects to it — it *is* the creator. There is exactly one participant, so when that participant leaves (closes the tab, navigates away, calls `disconnect()`), tearing the session down is exactly what we want: the session is theirs, nobody else is attached, and prompt termination is clean and safe (no orphaned session lingering until a server-side timeout, no stray billing). This is the behaviour we ship today and the gate preserves it untouched — creator unloads, creator terminates.

**Decentralized / multi-player (one client among many).** Here the topology flips. A single browser tab is no longer the owner of the session — it is one of N peers sharing it. If each client minted its own session we would have N sessions, not one shared room; and if the *first* client to connect were treated as the creator, that client closing its tab would tear the whole session down for everyone still in the room. That is the failure mode the gate is designed to avoid.

The pattern we will prescribe for multi-player usage is therefore: **a backend mints the session** (server-side `POST /sessions`) and hands the `session_id` to every client. Each client then joins as a pure **connector** via `connect({ sessionId })` — so `createdSession` is `false` for *all* of them, and **no client is ever the creator**. As a result, any individual client disconnecting (unload or explicit) only tears down its own transport and leaves the shared session alive for the remaining participants. The session's lifecycle is owned by the backend that created it, which decides when the room is actually over. The first-client-tears-it-down-for-everyone problem simply never arises, because the gate has no creator to fire on.

This is why the gate is the right primitive: the same `disconnect(false)` call does the safe thing in both worlds — terminate when you own the session, leave it alone when you are a guest in someone else's.

## Adopting a pre-registered connection id

Symmetric to `sessionId` adoption, `connect()` accepts an optional `connectionId`. When omitted the transport mints its own id (`POST .../connections`, server-minted) as before; when provided it **skips registration** and sends its SDP offer straight to `.../connections/{id}/sdp_params`.

This completes the backend-orchestrated multi-player story above: a backend can mint **both** the session and a connection slot per client (each `POST .../connections` returns a `connection_id`), then hand each client its `{ sessionId, connectionId }` pair.

```ts
await reactor.connect(jwt, { sessionId, connectionId: 4321 });
```

Because the id must reference a connection the server already knows, `connect()` rejects clearly when it can't be used — the coordinator returns `404` for an unknown/closed id and `400` for an out-of-range one, surfaced as:

- `Connection <id> not found or already closed (404) …` — the id was never registered under this session, or it has been closed.
- `Connection <id> rejected (400) …` — the id is outside the server's accepted range.

The id is also range-checked client-side (`1000 < id <= 9999`, mirroring the coordinator) to fail fast before any network call.

## What changed

- `autoResumeTracks` now defaults to `true` (`Reactor.connect`), with the doc on `ConnectOptions` updated.
- **Page-unload teardown is gated on session ownership** (see narrative above). The provider's `beforeunload` calls `disconnect(false)` again; the creator-vs-connector gating lives in `Reactor.disconnect()` via the `createdSession` flag.
- **`ConnectOptions.connectionId`** lets a client adopt a pre-registered connection id instead of minting one; `WebRTCTransportClient.connect` gained an optional `connectionId` arg (the `TransportClient` interface widened to match) and surfaces the coordinator's 400/404 as actionable errors.
- Cleanup of artifacts on the multi-connection branch: removed a stray empty-template-literal statement inside the auto-resume loop, and demoted two debug `console.log`s (`trackReceived`, and the resume-while-disconnected warning) to `console.debug`.
- Sibling transport mocks gain `pauseTrack`/`resumeTrack` so they satisfy the `TransportClient` interface now that auto-resume fires by default; unit tests cover the new `autoResumeTracks` default (and explicit opt-out) and the provided-`connectionId` path (adopt + skip-registration, out-of-range rejection, 404 surfacing).

## Test plan

- [x] `pnpm test:unit` — 394 passing