### PR TITLE
Bump @reactor-team/js-sdk to 2.11.2

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactor-team/js-sdk",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Reactor JavaScript frontend SDK — connect React and TypeScript apps to real-time AI video models on Reactor.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Patch bump to cut a release of the SDK from main. The published 2.11.1
predates `connect({ sessionId })` (PR #189), which lets a client attach
to a session created elsewhere (e.g. a backend/queue) instead of always
issuing its own `POST /sessions`. That attach path, plus the
`ModerationEvent` runtimeMessage types, already sit on main but have
never been published. This bump makes them releasable so downstream
consumers (e.g. the reactor-queue waiting-room library) can depend on a
real npm version rather than a local link.

No source changes — version-only bump. `connect()` with no `sessionId`
is unchanged, so the release is backward compatible with 2.11.1.

Signed-off-by: Dere-Wah <derexcontact@gmail.com>
Co-authored-by: Cursor <cursoragent@cursor.com>