### PR TITLE
Harden npm publish: explicit provenance and per-package version guards

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,21 @@ jobs:
 
       - run: pnpm install
       - run: pnpm build
-      - run: npm publish --access public
+
+      # Both jobs run on every release, but a js-sdk tag (vX.Y.Z) and a
+      # create-app tag (create-app/vX.Y.Z) only ever bump one of the two
+      # packages. Publish solely when this package's version isn't on the
+      # registry yet, so the unrelated job no-ops instead of failing on a
+      # "cannot publish over previously published version" conflict.
+      - name: Publish if version is new
         working-directory: packages/js-sdk
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "@reactor-team/js-sdk@${version}" version >/dev/null 2>&1; then
+            echo "@reactor-team/js-sdk@${version} already published; skipping."
+          else
+            npm publish --access public --provenance
+          fi
 
   publish-create-app:
     runs-on: ubuntu-latest
@@ -42,5 +55,13 @@ jobs:
 
       - run: pnpm install
       - run: pnpm --filter create-reactor-app build
-      - run: npm publish --access public
+
+      - name: Publish if version is new
         working-directory: packages/create-app
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "create-reactor-app@${version}" version >/dev/null 2>&1; then
+            echo "create-reactor-app@${version} already published; skipping."
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
## Why

The release pipeline lives entirely in `.github/workflows/publish.yml` and fires on every published GitHub release. It runs two jobs unconditionally — `publish-sdk` (`packages/js-sdk`) and `publish-create-app` (`packages/create-app`) — but a release only ever bumps one of the two packages: `@reactor-team/js-sdk` ships under a `vX.Y.Z` tag, `create-reactor-app` under a `create-app/vX.Y.Z` tag. The package that wasn't bumped still runs its job, calls `npm publish` for a version that already exists, and dies with `npm error You cannot publish over the previously published versions`.

The practical result is that **every** release run shows up red even when the intended publish succeeded. The last `v2.12.0` run is the canonical example: `publish-sdk` succeeded and `@reactor-team/js-sdk@2.12.0` shipped with SLSA provenance, while `publish-create-app` failed purely because `create-reactor-app@2.1.1` was already on the registry. A perpetually-failing publish workflow trains everyone to ignore release failures, which is exactly when you don't want to be ignoring them.

Separately, provenance today is implicit: `@reactor-team/js-sdk` gets SLSA attestations because npm auto-detects the OIDC trusted-publisher path when `id-token: write` is set. That works, but the workflow gives no signal that provenance is intended, and a silent regression (e.g. trusted publishing getting misconfigured) would just quietly drop attestations rather than fail.

## What this changes

Both publish steps now resolve their own version from `package.json` and ask the registry whether it already exists before doing anything. If `npm view <pkg>@<version>` resolves, the job logs that it's skipping and exits clean; otherwise it publishes. This makes the shared release trigger safe in both directions — a js-sdk release no-ops the create-app job, and a create-app release no-ops the js-sdk job — so a release run is only red when a publish that was supposed to happen actually failed. The reasoning lives in a comment on the `publish-sdk` job since it explains the shared-trigger mechanism that both jobs rely on.

The publish call itself becomes `npm publish --access public --provenance`. For `@reactor-team/js-sdk` this codifies the behavior that's already happening; for `create-reactor-app` it's the on-ramp to provenance once its trusted publisher is configured (see below). Making the flag explicit also turns a provenance failure into a loud job failure instead of a silently unsigned package.

## Verification

- `prettier --check` passes on the edited workflow (the repo's `Format Check` CI job covers it).
- Logic is the standard `npm view … >/dev/null 2>&1` existence probe: exit 0 (version present) → skip; non-zero (404 / unpublished) → publish.
- End-to-end can only be confirmed on a real release tag; the next `vX.Y.Z` release should show `publish-create-app` skipping cleanly instead of failing.

## Out of band (not doable from this PR)

`create-reactor-app` still needs a **trusted publisher** configured on npmjs.com (Package → Settings → Trusted Publisher → GitHub Actions: `reactor-team/js-sdk`, workflow `publish.yml`). `@reactor-team/js-sdk` already has this. Until that's done, the `--provenance` publish for create-reactor-app will fail when its version is first bumped — which is the correct, loud failure mode rather than a silent unsigned publish.

Made with [Cursor](https://cursor.com)