### PR TITLE
[REA-1584] Tricle ICE: end-to-end testing

### DIFF
--- a/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
+++ b/packages/js-sdk/__tests__/integration/reactor-e2e.test.ts
@@ -178,6 +178,9 @@ describe.skipIf(!API_KEY)("Reactor E2E — echo model", () => {
 
     await reactor.connect(jwt);
     await waitForStatus(reactor, "ready", 60_000);
+    console.log(
+      `Transport connect time: ${reactor.getConnectionTimings()?.transportConnectingMs.toFixed(2)} ms`
+    );
     await reactor.disconnect();
 
     expect(statuses[0]).toBe("connecting");

--- a/packages/js-sdk/__tests__/unit/connection-timings.test.ts
+++ b/packages/js-sdk/__tests__/unit/connection-timings.test.ts
@@ -94,14 +94,25 @@ describe("Reactor connection timings", () => {
     const r = new Reactor({ modelName: "echo" });
     await connectAndReady(r);
 
-    const stats = r.getStats();
-    expect(stats).toBeDefined();
-    expect(stats!.connectionTimings).toBeDefined();
+    const t = r.getConnectionTimings();
+    expect(t).toBeDefined();
+    expect(t!.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t!.transportConnectingMs).toBeGreaterThanOrEqual(0);
+    expect(t!.totalMs).toBeGreaterThanOrEqual(0);
 
-    const t = stats!.connectionTimings!;
-    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
-    expect(t.transportConnectingMs).toBeGreaterThanOrEqual(0);
-    expect(t.totalMs).toBeGreaterThanOrEqual(0);
+    await r.disconnect();
+  });
+
+  it("getConnectionTimings() is available before transport stats are polled", async () => {
+    const r = new Reactor({ modelName: "echo" });
+    await r.connect("jwt");
+    mockTransportClient.getStats.mockReturnValue(undefined);
+    transportHandlers["statusChanged"]("connected");
+
+    expect(r.getStats()).toBeUndefined();
+    expect(
+      r.getConnectionTimings()?.transportConnectingMs
+    ).toBeGreaterThanOrEqual(0);
 
     await r.disconnect();
   });
@@ -126,14 +137,14 @@ describe("Reactor connection timings", () => {
     await r.disconnect();
   });
 
-  it("clears connectionTimings on disconnect (getStats)", async () => {
+  it("clears connectionTimings on disconnect", async () => {
     const r = new Reactor({ modelName: "echo" });
     await connectAndReady(r);
 
-    expect(r.getStats()!.connectionTimings).toBeDefined();
+    expect(r.getConnectionTimings()).toBeDefined();
 
     await r.disconnect();
-    expect(r.getStats()).toBeUndefined();
+    expect(r.getConnectionTimings()).toBeUndefined();
   });
 
   it("clears connectionTimings from statsUpdate events after disconnect", async () => {
@@ -153,12 +164,11 @@ describe("Reactor connection timings", () => {
     const r = new Reactor({ modelName: "echo" });
     await r.connect("jwt");
 
-    const stats = r.getStats();
-    expect(stats).toBeDefined();
-    const t = stats!.connectionTimings!;
-    expect(t.sessionCreationMs).toBeGreaterThanOrEqual(0);
-    expect(t.transportConnectingMs).toBeGreaterThanOrEqual(0);
-    expect(t.totalMs).toBe(0);
+    const t = r.getConnectionTimings();
+    expect(t).toBeDefined();
+    expect(t!.sessionCreationMs).toBeGreaterThanOrEqual(0);
+    expect(t!.transportConnectingMs).toBeGreaterThanOrEqual(0);
+    expect(t!.totalMs).toBe(0);
 
     await r.disconnect();
   });

--- a/packages/js-sdk/__tests__/unit/reactor.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor.test.ts
@@ -173,6 +173,10 @@ describe("Reactor", () => {
       expect(r.getStats()).toBeUndefined();
     });
 
+    it("getConnectionTimings() returns undefined when not connected", () => {
+      expect(r.getConnectionTimings()).toBeUndefined();
+    });
+
     it("getCapabilities() returns undefined initially", () => {
       expect(r.getCapabilities()).toBeUndefined();
     });

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -753,6 +753,11 @@ export class Reactor {
     return { ...stats, connectionTimings: this.connectionTimings };
   }
 
+  /** Timing breakdown from the most recent connect() handshake. */
+  getConnectionTimings(): ConnectionTimings | undefined {
+    return this.connectionTimings;
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // Private State Management
   // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Validate trickle ICE across the full system with end-to-end tests.
Measure time-to-first-frame improvement vs. vanilla ICE baseline.

- Added an accessor function to allow access to connectionTimings without
waiting for the first capture of WebRTC stats; getStats will return undefined
until the first WebRTC stats gathering operation.

- Print out transport connection time during reactor-e2e.test.ts in order
to capture and compare connection timing.