### PR TITLE
feat(create-app): improve npm + agent discoverability of create-reactor-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install @reactor-team/js-sdk
 ## Quick Start
 
 ```bash
-npx create-reactor-app my-app
+npx create-reactor-app my-app --model=helios
 cd my-app
 npm run dev
 ```

--- a/examples/helios/README.md
+++ b/examples/helios/README.md
@@ -26,6 +26,8 @@ Connect, send a prompt, and watch the model produce a continuous video stream yo
 
 ## Quick start
 
+> **Start a standalone project:** `npx create-reactor-app my-app --model=helios` scaffolds this example into a fresh app — no clone needed. The steps below are for running it in-place from a monorepo checkout.
+
 You'll need a Reactor API key — grab one at [reactor.inc/account/api-keys](https://www.reactor.inc/account/api-keys). It starts with `rk_`.
 
 ```bash

--- a/examples/lingbot/README.md
+++ b/examples/lingbot/README.md
@@ -25,6 +25,8 @@ Pick a starting image, watch it come alive as a continuous video stream, and dri
 
 ## Quick start
 
+> **Start a standalone project:** `npx create-reactor-app my-app --model=lingbot` scaffolds this example into a fresh app — no clone needed. The steps below are for running it in-place from a monorepo checkout.
+
 You'll need a Reactor API key — grab one at [reactor.inc/account/api-keys](https://www.reactor.inc/account/api-keys). It starts with `rk_`.
 
 ```bash

--- a/examples/longlive-v2/README.md
+++ b/examples/longlive-v2/README.md
@@ -21,6 +21,8 @@ Direct a video like a storyboard: set an opening shot, then compose **shots** (s
 
 ## Quick start
 
+> **Start a standalone project:** `npx create-reactor-app my-app --model=longlive-v2` scaffolds this example into a fresh app — no clone needed. The steps below are for running it in-place from a monorepo checkout.
+
 ```bash
 cp .env.example .env        # then add your REACTOR_API_KEY
 pnpm install

--- a/examples/sana-streaming/README.md
+++ b/examples/sana-streaming/README.md
@@ -19,6 +19,8 @@ Where Reactor's other models generate video from a prompt, SANA-Streaming edits 
 
 ## Quick start
 
+> **Start a standalone project:** `npx create-reactor-app my-app --model=sana-streaming` scaffolds this example into a fresh app — no clone needed. The steps below are for running it in-place from a monorepo checkout.
+
 ```bash
 cp .env.example .env.local  # then add your REACTOR_API_KEY
 pnpm install

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,24 @@
 {
   "name": "create-reactor-app",
   "version": "2.1.1",
+  "description": "Scaffold a real-time AI video app with the Reactor SDK in seconds. Starter templates for Helios and other world models — run `npx create-reactor-app`.",
+  "keywords": [
+    "reactor",
+    "create-reactor-app",
+    "scaffold",
+    "starter",
+    "template",
+    "boilerplate",
+    "cli",
+    "npx",
+    "create-app",
+    "sdk",
+    "react",
+    "real-time",
+    "video",
+    "ai",
+    "world-models"
+  ],
   "bin": {
     "create-reactor-app": "dist/bin/create-reactor-app.js"
   },

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-reactor-app",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Scaffold a real-time AI video app with the Reactor SDK in seconds. Starter templates for Helios and other world models — run `npx create-reactor-app`.",
   "keywords": [
     "reactor",


### PR DESCRIPTION
## What & why

Improves how `create-reactor-app` is discovered by developers and by AI agents/search, and fixes a broken copy-paste command on the SDK front page.

### Changes

- **npm search metadata** — `packages/create-app/package.json` had no `description` and no `keywords`, so the package didn't surface in npm search. Added both (`scaffold`, `starter`, `template`, `npx`, `world-models`, etc.), modeled on the `@reactor-team/js-sdk` package.
- **Version bump `2.1.1` → `2.1.2`** — required for the change to actually ship: the publish workflow's guard only publishes when the version isn't already on npm, and `2.1.1` is already published.
- **Fixed broken quick start in root `README.md`** — `npx create-reactor-app my-app` → `... --model=helios`. The bare command exits with an error because `--model` is required (see `packages/create-app/bin/create-reactor-app.ts`).
- **Example READMEs** (helios, lingbot, longlive-v2, sana-streaming) — added a one-line standalone `npx create-reactor-app my-app --model=<name>` pointer at the top of each Quick start, reframing the existing clone-based steps as the monorepo-checkout path. Model flags map 1:1 to folder names (MODEL_MAP is empty by default).

### Reviewer notes

- Only the `package.json` change ships to npm; the README edits live on GitHub.
- After merge, this needs a **GitHub Release tagged `create-app/v2.1.2`** to trigger publish (per `.github/workflows/publish.yml`). Cutting that release is intentionally left as a human step.
- Out of scope (different repos): `llms.txt`, docs `/quickstart` page, and homepage mentions — these were part of a broader discoverability audit but live in the docs/marketing repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)