### PR TITLE
Lift pause/resume track controls onto the React store surface

### DIFF
--- a/packages/js-sdk/__tests__/unit/store-tracks.test.ts
+++ b/packages/js-sdk/__tests__/unit/store-tracks.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Verifies that `pauseTrack` / `resumeTrack` are exposed as top-level
+ * actions on the React store and delegate to the underlying
+ * {@link Reactor} instance, so consumers don't have to reach through
+ * `state.internal.reactor` (as `publish` / `unpublish` already do).
+ *
+ * The wire-level behaviour of the underlying methods is covered by the
+ * reactor / transport suites; this file only checks the store-layer
+ * passthrough.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createReactorStore } from "../../src/core/store";
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn(function (this: unknown) {
+    return {};
+  }),
+}));
+vi.mock("../../src/core/LocalCoordinatorClient", () => ({
+  LocalCoordinatorClient: vi.fn(function (this: unknown) {
+    return {};
+  }),
+}));
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn(function (this: unknown) {
+    return { on: vi.fn(), off: vi.fn() };
+  }),
+}));
+
+function makeStore() {
+  return createReactorStore({ modelName: "echo", local: true });
+}
+
+describe("ReactorStore track actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes pauseTrack / resumeTrack on the public surface", () => {
+    const state = makeStore().getState();
+    expect(typeof state.pauseTrack).toBe("function");
+    expect(typeof state.resumeTrack).toBe("function");
+  });
+
+  it("pauseTrack delegates to internal.reactor.pauseTrack with the same name", () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    const spy = vi.spyOn(reactor, "pauseTrack").mockReturnValue(undefined);
+
+    store.getState().pauseTrack("main_video");
+
+    expect(spy).toHaveBeenCalledWith("main_video");
+  });
+
+  it("resumeTrack delegates to internal.reactor.resumeTrack with the same name", () => {
+    const store = makeStore();
+    const reactor = store.getState().internal.reactor;
+    const spy = vi.spyOn(reactor, "resumeTrack").mockReturnValue(undefined);
+
+    store.getState().resumeTrack("main_audio");
+
+    expect(spy).toHaveBeenCalledWith("main_audio");
+  });
+});

--- a/packages/js-sdk/src/core/store.ts
+++ b/packages/js-sdk/src/core/store.ts
@@ -48,6 +48,19 @@ export interface ReactorActions {
   disconnect(recoverable?: boolean): Promise<void>;
   publish(name: string, track: MediaStreamTrack): Promise<void>;
   unpublish(name: string): Promise<void>;
+  /**
+   * Ask the runtime to stop processing a recvonly track. Top-level
+   * alias for `internal.reactor.pauseTrack(…)` — lifted onto the store
+   * so consumers don't have to reach through `internal.reactor`. See
+   * {@link Reactor.pauseTrack}.
+   */
+  pauseTrack(name: string): void;
+  /**
+   * Ask the runtime to resume a previously paused recvonly track.
+   * Top-level alias for `internal.reactor.resumeTrack(…)`. See
+   * {@link Reactor.resumeTrack}.
+   */
+  resumeTrack(name: string): void;
   reconnect(options?: ConnectOptions): Promise<void>;
   uploadFile(file: File | Blob, options?: { name?: string }): Promise<FileRef>;
   /**
@@ -282,6 +295,8 @@ export const createReactorStore = (
           throw error;
         }
       },
+      pauseTrack: (name: string) => get().internal.reactor.pauseTrack(name),
+      resumeTrack: (name: string) => get().internal.reactor.resumeTrack(name),
       reconnect: async (options?: ConnectOptions) => {
         console.debug("[ReactorStore] Reconnecting");
         try {


### PR DESCRIPTION
## Why

Track control in the SDK is layered: `WebRTCTransportClient` implements the
primitives, the `TransportClient` interface declares them, the `Reactor` core
wraps them, and the zustand store (`ReactorActions`) is what React apps
actually consume through `useReactor(...)`. For publishing this chain is
complete — `publish` / `unpublish` are lifted onto the store, so components
call `s.publish(...)` and never touch internals.

Pause/resume are the odd ones out. The multi-connection work added
`pauseTrack` / `resumeTrack` down the `TransportClient` → `Reactor` stack (a
recvonly track is negotiated but left paused until the client resumes it), but
the corresponding store actions were never added. The only way for a React
consumer to drive per-track playback was to reach through the
documented-internal escape hatch:

```ts
const reactor = useReactor((s) => s.internal.reactor);
reactor.pauseTrack("main_video");
```

`s.internal` is meant for advanced/internal access, not for a first-class
capability like pausing a stream, so this is an inconsistency in the public
surface rather than an intended design.

## What this changes

`pauseTrack` / `resumeTrack` are now top-level actions on the store, sitting
next to `publish` / `unpublish` in `ReactorActions`. Each delegates straight to
the underlying `Reactor` (`get().internal.reactor.pauseTrack(name)`), mirroring
how the recording aliases (`requestClip`, `requestRecording`,
`downloadClipAsFile`) are surfaced. They stay **synchronous** to match the core
methods, which fire the control message over the data channel without awaiting
a reply — unlike `publish` / `unpublish`, which await an `replaceTrack` and so
return promises.

## API surface

```ts
interface ReactorActions {
  // …existing
  pauseTrack(name: string): void;
  resumeTrack(name: string): void;
}
```

Consumers can now drive playback straight off the store, with no `internal`
reach-through:

```tsx
function MuteButton({ track }: { track: string }) {
  const { pauseTrack, resumeTrack } = useReactor((s) => ({
    pauseTrack: s.pauseTrack,
    resumeTrack: s.resumeTrack,
  }));

  return (
    <>
      <button onClick={() => pauseTrack(track)}>Pause</button>
      <button onClick={() => resumeTrack(track)}>Resume</button>
    </>
  );
}
```

## Verification

`pnpm -F @reactor-team/js-sdk build` and the full unit/integration suite are
green. A new `store-tracks.test.ts` (modelled on `store-recording.test.ts`)
asserts both actions are present on the public surface and delegate to
`internal.reactor` with the track name unchanged.
