### PR TITLE
[REA-1506] Notify users when network connection is unstable

### DIFF
--- a/packages/js-sdk/__tests__/unit/media-stats-client.test.ts
+++ b/packages/js-sdk/__tests__/unit/media-stats-client.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for {@link MediaStatsClient} in isolation, against a fake
+ * {@link MediaStatsClientHost}. Reactor-level integration is in
+ * `reactor-media-stats.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MediaStatsClient,
+  type MediaStatsClientHost,
+} from "../../src/core/MediaStatsClient";
+import type { ReactorStatus, RuntimeAlert } from "../../src/types";
+import {
+  DEFAULT_ALERT_BACKOFF_MS,
+  DEFAULT_DEGRADED_NETWORK_MESSAGE,
+  DEFAULT_MIN_AGGREGATE_QOS,
+  DEFAULT_SUSTAINED_DEGRADATION_MS,
+  RuntimeMediaStatsMessageType,
+} from "../../src/utils/mediaStats";
+
+interface FakeHostHandles {
+  host: MediaStatsClientHost;
+  emitRuntimeMessage: (msg: unknown) => void;
+  emitStatus: (status: ReactorStatus) => void;
+  getAlerts: () => Array<{ type: string; data: RuntimeAlert }>;
+  isRuntimeMessageUnsubscribed: () => boolean;
+}
+
+function buildMediaStats(aggregateQos: number): {
+  type: string;
+  data: { video: { aggregateQos: number } };
+} {
+  return {
+    type: RuntimeMediaStatsMessageType.MEDIA_STATS,
+    data: { video: { aggregateQos } },
+  };
+}
+
+function makeHost(): FakeHostHandles {
+  const runtimeListeners = new Set<(msg: unknown) => void>();
+  const statusListeners = new Set<(s: ReactorStatus) => void>();
+  let runtimeMessageUnsubCalled = false;
+  const alerts: Array<{ type: string; data: RuntimeAlert }> = [];
+
+  const host: MediaStatsClientHost = {
+    onRuntimeMessage(handler) {
+      runtimeListeners.add(handler);
+      return () => {
+        runtimeListeners.delete(handler);
+        runtimeMessageUnsubCalled = true;
+      };
+    },
+    onStatusChanged(handler) {
+      statusListeners.add(handler);
+      return () => statusListeners.delete(handler);
+    },
+    emitRuntimeMessage(message) {
+      alerts.push(message);
+    },
+  };
+
+  return {
+    host,
+    emitRuntimeMessage: (msg) =>
+      runtimeListeners.forEach((handler) => handler(msg)),
+    emitStatus: (s) => statusListeners.forEach((handler) => handler(s)),
+    getAlerts: () => alerts,
+    isRuntimeMessageUnsubscribed: () => runtimeMessageUnsubCalled,
+  };
+}
+
+describe("MediaStatsClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ignores non-mediaStats messages on the private channel", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage({ type: "ping", data: {} });
+    fake.emitRuntimeMessage({
+      type: RuntimeMediaStatsMessageType.ALERT,
+      data: {},
+    });
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("ignores malformed mediaStats payloads", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage({
+      type: RuntimeMediaStatsMessageType.MEDIA_STATS,
+      data: { video: {} },
+    });
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("does not alert when QoS is at or above threshold", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(DEFAULT_MIN_AGGREGATE_QOS));
+    fake.emitRuntimeMessage(buildMediaStats(DEFAULT_MIN_AGGREGATE_QOS + 1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("alerts after sustained low QoS", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()).toHaveLength(1);
+    expect(fake.getAlerts()[0]).toEqual({
+      type: RuntimeMediaStatsMessageType.ALERT,
+      data: {
+        level: "warn",
+        message: DEFAULT_DEGRADED_NETWORK_MESSAGE,
+      },
+    });
+    client.destroy();
+  });
+
+  it("resets degradation timer when QoS recovers before sustained duration", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS - 1_000);
+    fake.emitRuntimeMessage(buildMediaStats(DEFAULT_MIN_AGGREGATE_QOS));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("suppresses alert during backoff and re-arms degradation timer", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()).toHaveLength(1);
+
+    // Re-armed degradation timer fires while still in backoff — no second alert.
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()).toHaveLength(1);
+    client.destroy();
+  });
+
+  it("emits a second alert after backoff and another sustained degradation", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()).toHaveLength(1);
+
+    // Backoff expires, degradation re-arms, second alert after sustained period.
+    vi.advanceTimersByTime(
+      DEFAULT_ALERT_BACKOFF_MS + DEFAULT_SUSTAINED_DEGRADATION_MS
+    );
+    expect(fake.getAlerts()).toHaveLength(2);
+    client.destroy();
+  });
+
+  it("clears state on disconnect", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    fake.emitStatus("disconnected");
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("reports isEnabled() false when disabled", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host, { enabled: false });
+    expect(client.isEnabled()).toBe(false);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("does not process messages when disabled", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host, { enabled: false });
+    client.deliver(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+    client.destroy();
+  });
+
+  it("destroy() unsubscribes and clears timers", () => {
+    const fake = makeHost();
+    const client = new MediaStatsClient(fake.host);
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    client.destroy();
+    expect(fake.isRuntimeMessageUnsubscribed()).toBe(true);
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS + 1);
+    expect(fake.getAlerts()).toHaveLength(0);
+  });
+
+  it("uses a custom degraded message when configured", () => {
+    const fake = makeHost();
+    const custom = "Network is slow.";
+    const client = new MediaStatsClient(fake.host, {
+      degradedMessage: custom,
+    });
+    fake.emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+    expect(fake.getAlerts()[0]?.data.message).toBe(custom);
+    client.destroy();
+  });
+});

--- a/packages/js-sdk/__tests__/unit/reactor-media-stats.test.ts
+++ b/packages/js-sdk/__tests__/unit/reactor-media-stats.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Reactor } from "../../src/core/Reactor";
+import {
+  DEFAULT_SUSTAINED_DEGRADATION_MS,
+  RuntimeMediaStatsMessageType,
+} from "../../src/utils/mediaStats";
+
+const MOCK_SESSION_ID = "85ded560-014c-42df-8902-89dfbca8fa00";
+
+const MOCK_INITIAL_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "CREATED",
+};
+
+const MOCK_FULL_SESSION_RESPONSE = {
+  session_id: MOCK_SESSION_ID,
+  model: { name: "echo" },
+  state: "ACTIVE",
+  selected_transport: { protocol: "webrtc", version: "1.0" },
+  capabilities: {
+    protocol_version: "1.0",
+    tracks: [],
+  },
+};
+
+let transportHandlers: Record<string, (...args: any[]) => void> = {};
+
+vi.mock("../../src/core/CoordinatorClient", () => ({
+  CoordinatorClient: vi.fn(function (this: any) {
+    return {
+      createSession: vi.fn().mockResolvedValue(MOCK_INITIAL_RESPONSE),
+      pollSessionReady: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+      getSession: vi.fn().mockResolvedValue(MOCK_FULL_SESSION_RESPONSE),
+      terminateSession: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue(MOCK_SESSION_ID),
+    };
+  }),
+}));
+
+vi.mock("../../src/core/WebRTCTransportClient", () => ({
+  WebRTCTransportClient: vi.fn(function (this: any) {
+    transportHandlers = {};
+    return {
+      warmup: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn(),
+      publishTrack: vi.fn().mockResolvedValue(undefined),
+      unpublishTrack: vi.fn().mockResolvedValue(undefined),
+      pauseTrack: vi.fn(),
+      resumeTrack: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        transportHandlers[event] = handler;
+      }),
+      off: vi.fn(),
+      getStats: vi.fn().mockReturnValue(undefined),
+      getTransportTimings: vi.fn().mockReturnValue(undefined),
+      abort: vi.fn(),
+    };
+  }),
+}));
+
+async function newConnectedReactor(
+  options: ConstructorParameters<typeof Reactor>[0] = { modelName: "echo" }
+): Promise<Reactor> {
+  const r = new Reactor(options);
+  await r.connect("jwt-token");
+  transportHandlers["statusChanged"]?.("connected");
+  return r;
+}
+
+function emitRuntimeMessage(message: unknown): void {
+  transportHandlers["message"]?.(message, "runtime");
+}
+
+function buildMediaStats(aggregateQos: number): {
+  type: string;
+  data: { video: { aggregateQos: number } };
+} {
+  return {
+    type: RuntimeMediaStatsMessageType.MEDIA_STATS,
+    data: { video: { aggregateQos } },
+  };
+}
+
+describe("Reactor mediaStats interception", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    transportHandlers = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not forward mediaStats to runtimeMessage when monitor is enabled", async () => {
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    emitRuntimeMessage(buildMediaStats(2));
+
+    expect(handler).not.toHaveBeenCalled();
+    await r.disconnect();
+  });
+
+  it("forwards mediaStats to runtimeMessage when monitor is disabled", async () => {
+    const r = await newConnectedReactor({
+      modelName: "echo",
+      mediaStatsMonitor: { enabled: false },
+    });
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    const msg = buildMediaStats(2);
+    emitRuntimeMessage(msg);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(msg);
+    await r.disconnect();
+  });
+
+  it("synthesizes alert on runtimeMessage after sustained low QoS", async () => {
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    emitRuntimeMessage(buildMediaStats(1));
+    vi.advanceTimersByTime(DEFAULT_SUSTAINED_DEGRADATION_MS);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      type: RuntimeMediaStatsMessageType.ALERT,
+      data: {
+        level: "warn",
+        message: expect.any(String),
+      },
+    });
+    await r.disconnect();
+  });
+
+  it("does not affect other runtime message types", async () => {
+    const r = await newConnectedReactor();
+    const handler = vi.fn();
+    r.on("runtimeMessage", handler);
+
+    emitRuntimeMessage({ type: "ping", data: {} });
+    emitRuntimeMessage({
+      type: "moderation",
+      data: {
+        action: "warn",
+        input_kind: "text",
+        command: "set_prompt",
+        categories: ["harassment"],
+        message: "Flagged.",
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0][0].type).toBe("ping");
+    expect(handler.mock.calls[1][0].type).toBe("moderation");
+    await r.disconnect();
+  });
+});

--- a/packages/js-sdk/src/core/MediaStatsClient.ts
+++ b/packages/js-sdk/src/core/MediaStatsClient.ts
@@ -1,0 +1,227 @@
+/**
+ * Per-Reactor media stats client. Subscribes to inbound `mediaStats`
+ * runtime messages on a private delivery channel (not forwarded to
+ * apps), tracks sustained low `video.aggregateQos`, and synthesizes
+ * `{ type: "alert", data: RuntimeAlert }` onto the public
+ * `runtimeMessage` bus.
+ */
+
+import type { ReactorStatus, RuntimeAlert } from "../types";
+import {
+  DEFAULT_ALERT_BACKOFF_MS,
+  DEFAULT_DEGRADED_NETWORK_MESSAGE,
+  DEFAULT_MIN_AGGREGATE_QOS,
+  DEFAULT_SUSTAINED_DEGRADATION_MS,
+  MediaStatsPayloadSchema,
+  RuntimeMediaStatsMessageType,
+  type MediaStatsMonitorOptions,
+} from "../utils/mediaStats";
+
+/** Slim adapter the {@link MediaStatsClient} requires from its host. */
+export interface MediaStatsClientHost {
+  /**
+   * Subscribe to privately delivered runtime-scoped messages.
+   * Reactor delivers only `mediaStats` here — not the public bus.
+   */
+  onRuntimeMessage: (handler: (message: unknown) => void) => () => void;
+  /**
+   * Subscribe to status changes (so the client can clear state on
+   * disconnect). Returns an unsubscribe function.
+   */
+  onStatusChanged: (handler: (status: ReactorStatus) => void) => () => void;
+  /** Emit a synthesized message onto the public `runtimeMessage` bus. */
+  emitRuntimeMessage: (message: { type: string; data: RuntimeAlert }) => void;
+}
+
+export class MediaStatsClient {
+  private readonly minAggregateQos: number;
+  private readonly sustainedDegradationMs: number;
+  private readonly alertBackoffMs: number;
+  private readonly degradedMessage: string;
+  private readonly enabled: boolean;
+
+  private lastAggregateQos: number | null = null;
+  private degradationTimer: ReturnType<typeof setTimeout> | null = null;
+  private backoffTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastAlertAt: number | null = null;
+
+  private readonly unsubscribers: Array<() => void> = [];
+  private inboundHandler: ((message: unknown) => void) | undefined;
+
+  constructor(
+    private readonly host: MediaStatsClientHost,
+    options: MediaStatsMonitorOptions = {}
+  ) {
+    this.enabled = options.enabled !== false;
+    this.minAggregateQos = options.minAggregateQos ?? DEFAULT_MIN_AGGREGATE_QOS;
+    this.sustainedDegradationMs =
+      options.sustainedDegradationMs ?? DEFAULT_SUSTAINED_DEGRADATION_MS;
+    this.alertBackoffMs = options.alertBackoffMs ?? DEFAULT_ALERT_BACKOFF_MS;
+    this.degradedMessage =
+      options.degradedMessage ?? DEFAULT_DEGRADED_NETWORK_MESSAGE;
+
+    const handler = (message: unknown) => this.onRuntimeMessage(message);
+    this.inboundHandler = handler;
+    this.unsubscribers.push(this.host.onRuntimeMessage(handler));
+    this.unsubscribers.push(
+      this.host.onStatusChanged((status) => this.onStatusChanged(status))
+    );
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Called by Reactor to deliver intercepted `mediaStats` messages. */
+  deliver(message: unknown): void {
+    this.inboundHandler?.(message);
+  }
+
+  destroy(): void {
+    this.clearTimers();
+    while (this.unsubscribers.length > 0) {
+      const off = this.unsubscribers.pop();
+      try {
+        off?.();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    this.inboundHandler = undefined;
+  }
+
+  private onRuntimeMessage(message: unknown): void {
+    if (!this.enabled) return;
+    if (!message || typeof message !== "object") return;
+
+    const msg = message as { type?: unknown; data?: unknown };
+    if (msg.type !== RuntimeMediaStatsMessageType.MEDIA_STATS) return;
+
+    const parsed = MediaStatsPayloadSchema.safeParse(msg.data);
+    if (!parsed.success) return;
+
+    const aggregateQos = parsed.data.video?.aggregateQos;
+    if (typeof aggregateQos !== "number" || !Number.isFinite(aggregateQos)) {
+      return;
+    }
+
+    this.lastAggregateQos = aggregateQos;
+
+    if (aggregateQos >= this.minAggregateQos) {
+      this.clearDegradationState();
+      return;
+    }
+
+    if (this.degradationTimer === null && this.backoffTimer === null) {
+      this.armDegradationTimer();
+    }
+  }
+
+  private onStatusChanged(status: ReactorStatus): void {
+    if (status === "disconnected") {
+      this.clearDegradationState();
+      this.lastAlertAt = null;
+    }
+  }
+
+  private armDegradationTimer(): void {
+    this.clearDegradationTimer();
+    this.degradationTimer = setTimeout(() => {
+      this.degradationTimer = null;
+      this.onDegradationTimerFire();
+    }, this.sustainedDegradationMs);
+  }
+
+  private onDegradationTimerFire(): void {
+    if (!this.isBelowThreshold(this.lastAggregateQos)) {
+      this.clearDegradationState();
+      return;
+    }
+
+    if (this.isInBackoff()) {
+      this.scheduleBackoffRearm();
+      return;
+    }
+
+    this.emitAlert();
+    this.lastAlertAt = Date.now();
+    this.armDegradationTimer();
+  }
+
+  private scheduleBackoffRearm(): void {
+    if (this.lastAlertAt === null) return;
+
+    const remaining = this.alertBackoffMs - (Date.now() - this.lastAlertAt);
+    if (remaining <= 0) {
+      this.onBackoffTimerFire();
+      return;
+    }
+
+    this.clearBackoffTimer();
+    this.backoffTimer = setTimeout(() => {
+      this.backoffTimer = null;
+      this.onBackoffTimerFire();
+    }, remaining);
+  }
+
+  private onBackoffTimerFire(): void {
+    if (!this.isBelowThreshold(this.lastAggregateQos)) {
+      this.clearDegradationState();
+      return;
+    }
+
+    if (this.isInBackoff()) {
+      this.scheduleBackoffRearm();
+      return;
+    }
+
+    this.emitAlert();
+    this.lastAlertAt = Date.now();
+    this.armDegradationTimer();
+  }
+
+  private emitAlert(): void {
+    this.host.emitRuntimeMessage({
+      type: RuntimeMediaStatsMessageType.ALERT,
+      data: {
+        level: "warn",
+        message: this.degradedMessage,
+      },
+    });
+  }
+
+  private isBelowThreshold(qos: number | null): boolean {
+    return qos !== null && qos < this.minAggregateQos;
+  }
+
+  private isInBackoff(): boolean {
+    return (
+      this.lastAlertAt !== null &&
+      Date.now() - this.lastAlertAt < this.alertBackoffMs
+    );
+  }
+
+  private clearDegradationTimer(): void {
+    if (this.degradationTimer !== null) {
+      clearTimeout(this.degradationTimer);
+      this.degradationTimer = null;
+    }
+  }
+
+  private clearBackoffTimer(): void {
+    if (this.backoffTimer !== null) {
+      clearTimeout(this.backoffTimer);
+      this.backoffTimer = null;
+    }
+  }
+
+  private clearTimers(): void {
+    this.clearDegradationTimer();
+    this.clearBackoffTimer();
+  }
+
+  private clearDegradationState(): void {
+    this.clearTimers();
+    this.lastAggregateQos = null;
+  }
+}

--- a/packages/js-sdk/src/core/Reactor.ts
+++ b/packages/js-sdk/src/core/Reactor.ts
@@ -31,18 +31,39 @@ const TrackHintSchema = z.object({
   direction: z.enum(["recvonly", "sendonly"]),
 });
 
+const MediaStatsMonitorOptionsSchema = z.object({
+  minAggregateQos: z.number().min(0).max(10).default(DEFAULT_MIN_AGGREGATE_QOS),
+  sustainedDegradationMs: z
+    .number()
+    .min(0)
+    .default(DEFAULT_SUSTAINED_DEGRADATION_MS),
+  alertBackoffMs: z.number().min(0).default(DEFAULT_ALERT_BACKOFF_MS),
+  degradedMessage: z.string().default(DEFAULT_DEGRADED_NETWORK_MESSAGE),
+  enabled: z.boolean().optional().default(true),
+});
+
 const OptionsSchema = z.object({
   apiUrl: z.string().default(DEFAULT_BASE_URL),
   modelName: z.string(),
   local: z.boolean().default(false),
   modelTracks: z.array(TrackHintSchema).optional(),
+  mediaStatsMonitor: MediaStatsMonitorOptionsSchema.optional(),
 });
 export type Options = z.input<typeof OptionsSchema>;
 
 export { FileRef } from "./FileRef";
 import { FileRef } from "./FileRef";
 import { RecordingClient } from "./RecordingClient";
+import { MediaStatsClient } from "./MediaStatsClient";
 import type { Clip, DownloadClipOptions } from "../utils/recording";
+import {
+  DEFAULT_ALERT_BACKOFF_MS,
+  DEFAULT_DEGRADED_NETWORK_MESSAGE,
+  DEFAULT_MIN_AGGREGATE_QOS,
+  DEFAULT_SUSTAINED_DEGRADATION_MS,
+  RuntimeMediaStatsMessageType,
+  type MediaStatsMonitorOptions,
+} from "../utils/mediaStats";
 
 type EventHandler = (...args: any[]) => void;
 
@@ -82,6 +103,9 @@ export class Reactor {
   /** Per-Reactor recording client. See {@link RecordingClient}. */
   readonly recording: RecordingClient;
 
+  /** Per-Reactor media stats monitor. See {@link MediaStatsClient}. */
+  readonly mediaStats: MediaStatsClient;
+
   constructor(options: Options) {
     const validatedOptions = OptionsSchema.parse(options);
     this.coordinatorUrl = validatedOptions.apiUrl;
@@ -108,6 +132,20 @@ export class Reactor {
       getStatus: () => this.status,
       getCoordinatorBaseUrl: () => this.coordinatorUrl,
     });
+
+    this.mediaStats = new MediaStatsClient(
+      {
+        onRuntimeMessage: () => () => {},
+        onStatusChanged: (handler) => {
+          this.on("statusChanged", handler);
+          return () => this.off("statusChanged", handler);
+        },
+        emitRuntimeMessage: (message) => {
+          this.emit("runtimeMessage", message);
+        },
+      },
+      validatedOptions.mediaStatsMonitor as MediaStatsMonitorOptions | undefined
+    );
   }
 
   private eventListeners: Map<ReactorEvent, Set<EventHandler>> = new Map();
@@ -598,6 +636,15 @@ export class Reactor {
         ) {
           this.schema = message.data as ModelSchema;
           this.emit("schemaReceived", this.schema);
+        }
+        if (
+          message &&
+          typeof message === "object" &&
+          message.type === RuntimeMediaStatsMessageType.MEDIA_STATS &&
+          this.mediaStats.isEnabled()
+        ) {
+          this.mediaStats.deliver(message);
+          return;
         }
         this.emit("runtimeMessage", message);
       }

--- a/packages/js-sdk/src/core/WebRTCTransportClient.ts
+++ b/packages/js-sdk/src/core/WebRTCTransportClient.ts
@@ -897,7 +897,7 @@ export class WebRTCTransportClient implements TransportClient {
     } catch (e) {
       // Roll back a half-applied offer so the connection returns to "stable"
       // and the next queued direction change can proceed cleanly.
-      if (pc.signalingState === "have-local-offer") {
+      if ((pc.signalingState as RTCSignalingState) === "have-local-offer") {
         try {
           await pc.setLocalDescription({ type: "rollback" });
         } catch {

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -34,6 +34,20 @@ export {
   RecordingClient,
 } from "./core/RecordingClient";
 export type { RecordingClientHost } from "./core/RecordingClient";
+// Media stats monitor + stateless primitives.
+export {
+  DEFAULT_ALERT_BACKOFF_MS,
+  DEFAULT_DEGRADED_NETWORK_MESSAGE,
+  DEFAULT_MIN_AGGREGATE_QOS,
+  DEFAULT_SUSTAINED_DEGRADATION_MS,
+  RuntimeMediaStatsMessageType,
+} from "./utils/mediaStats";
+export type {
+  MediaStatsMonitorOptions,
+  MediaStatsPayload,
+} from "./utils/mediaStats";
+export { MediaStatsClient } from "./core/MediaStatsClient";
+export type { MediaStatsClientHost } from "./core/MediaStatsClient";
 export type { ReactorStore } from "./core/store";
 export type { JwtResolver, JwtSource } from "./core/auth";
 export { normalizeJwtSource } from "./core/auth";

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -192,3 +192,30 @@ export interface ModerationEvent {
   /** Short human-readable summary suitable for UI rendering. */
   message: string;
 }
+
+/**
+ * Severity tier of a client-synthesized alert delivered as the inner
+ * payload of a `runtimeMessage` with `type === "alert"`.
+ */
+export type RuntimeAlertLevel = "warn" | "error" | "fatal";
+
+/**
+ * Inner payload of a `runtimeMessage` with `type === "alert"`.
+ *
+ * Emitted by the SDK (e.g. when sustained low video QoS is detected).
+ * Apps receive it by subscribing to `runtimeMessage` and filtering on
+ * `type`, or via {@link useReactorInternalMessage}:
+ *
+ *     reactor.on("runtimeMessage", (m) => {
+ *       if (m?.type === "alert") {
+ *         const payload = m.data as RuntimeAlert;
+ *         // ...render banner, log, etc.
+ *       }
+ *     });
+ */
+export interface RuntimeAlert {
+  /** Severity tier. */
+  level: RuntimeAlertLevel;
+  /** Short human-readable summary suitable for UI rendering. */
+  message: string;
+}

--- a/packages/js-sdk/src/utils/mediaStats.ts
+++ b/packages/js-sdk/src/utils/mediaStats.ts
@@ -1,0 +1,76 @@
+/**
+ * Stateless primitives for the MediaStats QoS alert monitor.
+ *
+ * Wire contract mirrors `RuntimeMessageType.MEDIA_STATS` in
+ * `reactor_runtime/utils/messages.py`. Stateful monitoring lives in
+ * `core/MediaStatsClient.ts`.
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime message types (mirrors RuntimeMessageType in Python)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Names of runtime-scoped messages used by the media stats feature.
+ * Inbound `mediaStats` is consumed privately by {@link MediaStatsClient};
+ * outbound `alert` is synthesized onto the public `runtimeMessage` bus.
+ */
+export const RuntimeMediaStatsMessageType = {
+  MEDIA_STATS: "mediaStats",
+  ALERT: "alert",
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimum acceptable `video.aggregateQos` (0–10 scale). */
+export const DEFAULT_MIN_AGGREGATE_QOS = 3;
+
+/** How long QoS must stay below threshold before alerting (ms). */
+export const DEFAULT_SUSTAINED_DEGRADATION_MS = 15_000;
+
+/** Minimum time between repeated alerts while degraded (ms). */
+export const DEFAULT_ALERT_BACKOFF_MS = 60_000;
+
+export const DEFAULT_DEGRADED_NETWORK_MESSAGE =
+  "Your network connection quality is poor. You may experience degraded video quality.";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const MediaStatsPayloadSchema = z
+  .object({
+    video: z
+      .object({
+        aggregateQos: z.number().finite().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type MediaStatsPayload = z.infer<typeof MediaStatsPayloadSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MediaStatsMonitorOptions {
+  /** Minimum acceptable `video.aggregateQos` (0–10). Default: {@link DEFAULT_MIN_AGGREGATE_QOS}. */
+  minAggregateQos?: number;
+  /** Sustained degradation duration before alerting (ms). Default: {@link DEFAULT_SUSTAINED_DEGRADATION_MS}. */
+  sustainedDegradationMs?: number;
+  /** Minimum gap between repeated alerts (ms). Default: {@link DEFAULT_ALERT_BACKOFF_MS}. */
+  alertBackoffMs?: number;
+  /** Custom alert message text. Default: {@link DEFAULT_DEGRADED_NETWORK_MESSAGE}. */
+  degradedMessage?: string;
+  /**
+   * When `false`, the monitor is disabled and raw `mediaStats` messages
+   * pass through on `runtimeMessage`. Default: `true`.
+   */
+  enabled?: boolean;
+}


### PR DESCRIPTION
Add a network status notification in the JS SDK to inform users when their connection is unstable,
similar to online calling apps. This should help clarify that reduced stream quality may be caused
by network conditions and bandwidth estimation lowering bitrate rather than the streaming service itself.

* Create a handler client for new mediaStat runtime messages.

* Add logic in the new message handler that will generate an alert message when the video aggregate
QOS level is below a configured threshold. The alert trigger time and the time to wait to
notify again are also configurable.

* Create a runtime alert message class that allows a message to be emitted and then caught
in the onRunTimeMessage react hook. Use this to send the bad network warning.