### PR TITLE
fix(create-app): build CLI as ESM to fix ERR_REQUIRE_ESM

### DIFF
--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-reactor-app",
-  "version": "2.1.2",
+  "version": "2.1.3",
+  "type": "module",
   "description": "Scaffold a real-time AI video app with the Reactor SDK in seconds. Starter templates for Helios and other world models — run `npx create-reactor-app`.",
   "keywords": [
     "reactor",

--- a/packages/create-app/tsup.config.ts
+++ b/packages/create-app/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: "dist/bin",
   bundle: false,
   splitting: false,
-  format: ["cjs"],
+  format: ["esm"],
   sourcemap: false,
   clean: true,
   shims: false,


### PR DESCRIPTION
## Problem

Running the documented command fails on Node < 20.19 before the app scaffolds:

```
npx create-reactor-app my-sana-app --model=sana-streaming
```
```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../inquirer/dist/index.js ... not supported.
```

`create-reactor-app` was built as **CommonJS** (`tsup` `format: ["cjs"]`), so the compiled bin does `require("inquirer")` / `require("chalk")`. Both are ESM-only (`inquirer` 14.x, `chalk` 5.x), which throws `ERR_REQUIRE_ESM` on Node **< 20.19** — before the `require(esm)` interop was backported. The CLI crashes at module load, before doing anything. (This is why bumping Node "fixed" it for others — 20.19+ has the interop.)

## Fix

Build the CLI as **ESM** and mark the package `"type": "module"`:

- `tsup.config.ts`: `format: ["cjs"]` → `format: ["esm"]`
- `package.json`: add `"type": "module"`, bump `2.1.2` → `2.1.3`

No source changes needed — the file already uses `import` syntax, has no `__dirname`/`require`, and no extensionless relative imports. ESM output runs on **all** supported Node versions, so this is strictly more compatible than the previous CJS build.

## Verification

Baseline reproduced against published `2.1.1` (CJS) on **Node 20.18.3** — the exact reported version:

| Case | Result |
|------|--------|
| Baseline: `2.1.1` (CJS), Node 20.18.3 | ❌ `ERR_REQUIRE_ESM` at `require("inquirer")` — reproduces the report |

Fixed `2.1.3` (ESM), tested via `npm pack` → install tarball → run bin, across the Node matrix:

| Node | `--help` (module load) | no `--model` (chalk + fetch) | full scaffold (clone + install) |
|------|:-:|:-:|:-:|
| 20.18.3 | ✅ | ✅ (lists `sana-streaming`) | ✅ |
| 22.18.0 | ✅ | ✅ | ✅ |
| 24.x | ✅ | ✅ | ✅ |

Node 20.18.3 is the critical case: it lacks the `require(esm)` interop, so it crashed on the old CJS build and now works. Node 22/24 confirm no regression on versions that already had the interop.

## Not yet covered
- `--token` private-repo flow (needs a real GitHub token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)